### PR TITLE
io_scheduler inline schedule_fd eventfd bug fix

### DIFF
--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -309,7 +309,7 @@ auto io_scheduler::process_scheduled_execute_inline() -> void
 
         // Clear the schedule eventfd if this is a scheduled task.
         eventfd_t value{0};
-        eventfd_read(m_shutdown_fd, &value);
+        eventfd_read(m_schedule_fd, &value);
 
         // Clear the in memory flag to reduce eventfd_* calls on scheduling.
         m_schedule_fd_triggered.exchange(false, std::memory_order::release);


### PR DESCRIPTION
The eventfd shutdown_fd was being reset instead of the schedule_fd,
this was causing a 100% cpu churn on scheduling the first task when
in inline mode.  This fixes it, and confirmed the throughput on the
inline scheduler has jumped quite a bit consistently.