### PR TITLE
Fix for Clang

### DIFF
--- a/inc/coro/when_all.hpp
+++ b/inc/coro/when_all.hpp
@@ -84,7 +84,7 @@ class when_all_ready_awaitable<std::tuple<task_types...>>
 {
 public:
     explicit when_all_ready_awaitable(task_types&&... tasks) noexcept(
-        std::conjunction_v<std::is_nothrow_move_constructible_v<task_types>...>)
+        std::conjunction<std::is_nothrow_move_constructible<task_types>...>::value)
         : m_latch(sizeof...(task_types)),
           m_tasks(std::move(tasks)...)
     {


### PR DESCRIPTION
g++ has no issues with the modified line; however, clang will issue an error.

If you use clangd in vs code, you will get a viral red squiggle for all files that include when_all.hpp.