### PR TITLE
Remove "lib" prefix for CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ set(LIBCORO_SOURCE_FILES
 )
 
 add_library(${PROJECT_NAME} STATIC ${LIBCORO_SOURCE_FILES})
-set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX PREFIX "")
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 target_include_directories(${PROJECT_NAME} PUBLIC inc)
 target_link_libraries(${PROJECT_NAME} PUBLIC pthread c-ares::cares tl::expected OpenSSL::SSL OpenSSL::Crypto)


### PR DESCRIPTION
CMake prepends library targets with "lib", resulting in a file named "liblibcoro.a". The suggested change sets the prefix to an empty string so that the file is named "libcoro.a".