### PR TITLE
Extended tasks so they can return references and not just values.

### DIFF
--- a/inc/coro/task.hpp
+++ b/inc/coro/task.hpp
@@ -92,7 +92,7 @@ struct promise final : public promise_base
 
         if constexpr (return_type_is_reference)
         {
-            return *m_return_value;
+            return m_return_value.value();
         }
         else
         {


### PR DESCRIPTION
I needed the ability to return a reference to an object from a task, rather than copying the object. So I extended tasks to do that and added two tests for it.

There seems to be some reformatting spam in task.h from clang-format being run.