### PR TITLE
Fix #154 that broke task.hpp by using optional without adding #include

### DIFF
--- a/inc/coro/task.hpp
+++ b/inc/coro/task.hpp
@@ -4,6 +4,7 @@
 
 #include <coroutine>
 #include <exception>
+#include <optional>
 #include <utility>
 
 namespace coro


### PR DESCRIPTION
@jbaldwin Please check that the README get regenerated, it didn't last time, and I have disabled that commit hook because it's not working here with my setup yet.