### PR TITLE
New task_completion_source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ set(LIBCORO_SOURCE_FILES
     inc/coro/coro.hpp
     inc/coro/generator.hpp
     inc/coro/task.hpp
+    inc/coro/task_completion_source.hpp
     inc/coro/when_all.hpp
 )
 

--- a/inc/coro/coro.hpp
+++ b/inc/coro/coro.hpp
@@ -38,4 +38,5 @@
 
 #include "coro/generator.hpp"
 #include "coro/task.hpp"
+#include "coro/task_completion_source.hpp"
 #include "coro/when_all.hpp"

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -21,13 +21,14 @@ private:
         std::shared_ptr<T>                   value;
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
     };
-    struct awaitable
+    struct awaiter
     {
-        explicit awaitable(std::shared_ptr<state_type>& _state) : state(_state) {}
-        awaitable(const awaitable&)           = default;
-        awaitable(awaitable&& other) noexcept = default;
-        auto                        operator=(const awaitable&) -> awaitable& = default;
-        auto                        operator=(awaitable&& other) noexcept -> awaitable& = default;
+        explicit awaiter() {}
+        explicit awaiter(std::shared_ptr<state_type>& _state) : state(_state) {}
+        awaiter(const awaiter&)           = default;
+        awaiter(awaiter&& other) noexcept = default;
+        auto                        operator=(const awaiter&) -> awaiter& = default;
+        auto                        operator=(awaiter&& other) noexcept -> awaiter& = default;
         std::shared_ptr<state_type> state;
 
         bool await_ready() const noexcept { return state->ready.exchange(true); }
@@ -64,7 +65,7 @@ public:
         for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
     }
     auto               handle() const { return state->coroutine.load(); }
-    [[nodiscard]] auto token() { return awaitable(state); }
+    [[nodiscard]] auto token() { return awaiter(state); }
 };
 
 template<>
@@ -82,13 +83,13 @@ private:
         std::atomic<bool>                    ready{false};
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
     };
-    struct awaitable
+    struct awaiter
     {
-        explicit awaitable(std::shared_ptr<state_type>& _state) : state(_state) {}
-        awaitable(const awaitable&)           = default;
-        awaitable(awaitable&& other) noexcept = default;
-        auto                        operator=(const awaitable&) -> awaitable& = default;
-        auto                        operator=(awaitable&& other) noexcept -> awaitable& = default;
+        explicit awaiter(std::shared_ptr<state_type>& _state) : state(_state) {}
+        awaiter(const awaiter&)           = default;
+        awaiter(awaiter&& other) noexcept = default;
+        auto                        operator=(const awaiter&) -> awaiter& = default;
+        auto                        operator=(awaiter&& other) noexcept -> awaiter& = default;
         std::shared_ptr<state_type> state;
 
         bool await_ready() const noexcept { return state->ready.exchange(true); }
@@ -116,7 +117,7 @@ public:
         for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
     }
     auto               handle() const { return state->coroutine.load(); }
-    [[nodiscard]] auto token() { return awaitable(state); }
+    [[nodiscard]] auto token() { return awaiter(state); }
 };
 
 } // namespace coro

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "coro/task.hpp"
 #include <atomic>
 #include <memory>
 
@@ -10,114 +9,121 @@ template<typename T = void>
 struct task_completion_source
 {
 private:
-    struct suspendable
+    struct state_type
     {
-        explicit suspendable() {}
-        suspendable(const suspendable&)              = delete;
-        suspendable(suspendable&& other) noexcept    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable& = delete;
-        auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
+        explicit state_type() {}
+        state_type(const state_type&)                = delete;
+        state_type(state_type&& other) noexcept      = delete;
+        auto                                 operator=(const state_type&) -> state_type& = delete;
+        auto                                 operator=(state_type&& other) noexcept -> state_type& = delete;
         std::atomic<bool>                    is_set{false};
-        T                                    value;
         std::atomic<bool>                    ready{false};
+        std::shared_ptr<T>                   value;
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
+    };
+    struct awaitable
+    {
+        explicit awaitable(std::shared_ptr<state_type>& _state) : state(_state) {}
+        awaitable(const awaitable&)           = default;
+        awaitable(awaitable&& other) noexcept = default;
+        auto                        operator=(const awaitable&) -> awaitable& = default;
+        auto                        operator=(awaitable&& other) noexcept -> awaitable& = default;
+        std::shared_ptr<state_type> state;
 
-        bool await_ready() noexcept { return ready.exchange(true); }
-        void await_suspend(std::coroutine_handle<> handle) noexcept
+        bool await_ready() const noexcept { return state->ready.exchange(true); }
+        void await_suspend(std::coroutine_handle<> handle) const noexcept
         {
-            coroutine.store(handle);
-            ready.store(false);
+            state->coroutine.store(handle);
+            state->ready.store(false);
         }
-        T await_resume() const noexcept { return std::move(value); }
+        T await_resume() const noexcept { return *state->value; }
     };
 
-    std::shared_ptr<suspendable> suspender{std::make_shared<suspendable>()};
+    std::shared_ptr<state_type> state{std::make_shared<state_type>()};
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)           = delete;
+    task_completion_source(const task_completion_source&)           = default;
     task_completion_source(task_completion_source&& other) noexcept = default;
-    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
+    auto operator=(const task_completion_source&) -> task_completion_source& = default;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
-    void set_value(const T& v)
+    void set_value(const T& v) const
     {
-        for (bool expect{false}; !suspender->is_set.compare_exchange_strong(expect, true);)
+        for (bool expect{false}; !state->is_set.compare_exchange_strong(expect, true);)
             return;
-        suspender->value = v;
+        state->value = std::make_shared<T>(v);
         std::atomic_thread_fence(std::memory_order_release);
-        for (bool expect{false}; !suspender->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = suspender->coroutine.load();
+        for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
+        auto coroutine = state->coroutine.load();
         if (coroutine)
             coroutine.resume();
     }
-    void set_value(T&& v)
+    void set_value(T&& v) const
     {
-        for (bool expect{false}; !suspender->is_set.compare_exchange_strong(expect, true);)
+        for (bool expect{false}; !state->is_set.compare_exchange_strong(expect, true);)
             return;
-        suspender->value = std::move(v);
+        state->value = std::make_shared<T>(std::move(v));
         std::atomic_thread_fence(std::memory_order_release);
-        for (bool expect{false}; !suspender->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = suspender->coroutine.load();
+        for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
+        auto coroutine = state->coroutine.load();
         if (coroutine)
             coroutine.resume();
     }
-    [[nodiscard]] coro::task<T> token() const
-    {
-        auto  suspender_ptr = suspender;
-        auto& suspend       = *suspender_ptr;
-        co_return co_await suspend;
-    }
+    [[nodiscard]] auto token() { return awaitable(state); }
 };
 
 template<>
 struct task_completion_source<void>
 {
 private:
-    struct suspendable
+    struct state_type
     {
-        explicit suspendable() {}
-        suspendable(const suspendable&)              = delete;
-        suspendable(suspendable&& other) noexcept    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable& = delete;
-        auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
+        explicit state_type() {}
+        state_type(const state_type&)                = delete;
+        state_type(state_type&& other) noexcept      = delete;
+        auto                                 operator=(const state_type&) -> state_type& = delete;
+        auto                                 operator=(state_type&& other) noexcept -> state_type& = delete;
+        std::atomic<bool>                    is_set{false};
         std::atomic<bool>                    ready{false};
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
+    };
+    struct awaitable
+    {
+        explicit awaitable(std::shared_ptr<state_type>& _state) : state(_state) {}
+        awaitable(const awaitable&)           = default;
+        awaitable(awaitable&& other) noexcept = default;
+        auto                        operator=(const awaitable&) -> awaitable& = default;
+        auto                        operator=(awaitable&& other) noexcept -> awaitable& = default;
+        std::shared_ptr<state_type> state;
 
-        bool await_ready() noexcept { return ready.exchange(true); }
-        void await_suspend(std::coroutine_handle<> handle) noexcept
+        bool await_ready() const noexcept { return state->ready.exchange(true); }
+        void await_suspend(std::coroutine_handle<> handle) const noexcept
         {
-            coroutine.store(handle);
-            ready.store(false);
+            state->coroutine.store(handle);
+            state->ready.store(false);
         }
         constexpr void await_resume() const noexcept {}
     };
 
-    std::shared_ptr<suspendable> suspender{std::make_shared<suspendable>()};
-
-    std::atomic<bool> is_set{false};
+    std::shared_ptr<state_type> state{std::make_shared<state_type>()};
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)           = delete;
+    task_completion_source(const task_completion_source&)           = default;
     task_completion_source(task_completion_source&& other) noexcept = default;
-    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
+    auto operator=(const task_completion_source&) -> task_completion_source& = default;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
-    void set_value()
+    void set_value() const
     {
-        for (bool expect{false}; !is_set.compare_exchange_strong(expect, true);)
+        for (bool expect{false}; !state->is_set.compare_exchange_strong(expect, true);)
             return;
         std::atomic_thread_fence(std::memory_order_release);
-        for (bool expect{false}; !suspender->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = suspender->coroutine.load();
+        for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
+        auto coroutine = state->coroutine.load();
         if (coroutine)
             coroutine.resume();
     }
-    [[nodiscard]] coro::task<> token() const
-    {
-        auto  suspender_ptr = suspender;
-        auto& suspend       = *suspender_ptr;
-        co_await suspend;
-    }
+    [[nodiscard]] auto token() { return awaitable(state); }
 };
 
 } // namespace coro

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -54,9 +54,6 @@ public:
         state->value = std::make_shared<T>(v);
         std::atomic_thread_fence(std::memory_order_release);
         for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = state->coroutine.load();
-        if (coroutine)
-            coroutine.resume();
     }
     void set_value(T&& v) const
     {
@@ -65,10 +62,8 @@ public:
         state->value = std::make_shared<T>(std::move(v));
         std::atomic_thread_fence(std::memory_order_release);
         for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = state->coroutine.load();
-        if (coroutine)
-            coroutine.resume();
     }
+    auto               handle() const { return state->coroutine.load(); }
     [[nodiscard]] auto token() { return awaitable(state); }
 };
 
@@ -119,10 +114,8 @@ public:
             return;
         std::atomic_thread_fence(std::memory_order_release);
         for (bool expect{false}; !state->ready.compare_exchange_weak(expect, true); expect = false) {}
-        auto coroutine = state->coroutine.load();
-        if (coroutine)
-            coroutine.resume();
     }
+    auto               handle() const { return state->coroutine.load(); }
     [[nodiscard]] auto token() { return awaitable(state); }
 };
 

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "coro/task.hpp"
+
+namespace coro
+{
+template<typename T>
+struct task_completion_source
+{
+private:
+    coro::task<> suspend() { co_await std::suspend_always(); }
+    coro::task<> suspended{suspend()};
+    T            value;
+
+public:
+    task_completion_source() {}
+    task_completion_source(const task_completion_source&)           = delete;
+    task_completion_source(task_completion_source&& other) noexcept = default;
+    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
+    auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
+    void set_value(const T& v)
+    {
+        value = v;
+        std::atomic_thread_fence(std::memory_order_release);
+        suspended.resume();
+    }
+    void set_value(T&& v)
+    {
+        value = std::move(v);
+        std::atomic_thread_fence(std::memory_order_release);
+        suspended.resume();
+    }
+    coro::task<T> task()
+    {
+        co_await suspended;
+        co_return std::move(value);
+    }
+};
+
+} // namespace coro

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -13,9 +13,9 @@ private:
     struct suspendable
     {
         explicit suspendable() {}
-        suspendable(const suspendable&)              = delete;
-        suspendable(suspendable&& other) noexcept    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable& = delete;
+        suspendable(const suspendable&)                                                              = delete;
+        suspendable(suspendable&& other) noexcept                                                    = delete;
+        auto                                 operator=(const suspendable&) -> suspendable&           = delete;
         auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
         std::atomic<bool>                    is_set{false};
         T                                    value;
@@ -35,9 +35,9 @@ private:
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)           = delete;
-    task_completion_source(task_completion_source&& other) noexcept = default;
-    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
+    task_completion_source(const task_completion_source&)                              = delete;
+    task_completion_source(task_completion_source&& other) noexcept                    = default;
+    auto operator=(const task_completion_source&) -> task_completion_source&           = delete;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
     void set_value(const T& v)
     {
@@ -54,7 +54,7 @@ public:
     {
         for (bool expect{false}; !suspender->is_set.compare_exchange_strong(expect, true);)
             return;
-        suspender->value = v;
+        suspender->value = std::move(v);
         std::atomic_thread_fence(std::memory_order_release);
         for (bool expect{false}; !suspender->ready.compare_exchange_weak(expect, true); expect = false) {}
         auto coroutine = suspender->coroutine.load();
@@ -77,9 +77,9 @@ private:
     struct suspendable
     {
         explicit suspendable() {}
-        suspendable(const suspendable&)              = delete;
-        suspendable(suspendable&& other) noexcept    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable& = delete;
+        suspendable(const suspendable&)                                                              = delete;
+        suspendable(suspendable&& other) noexcept                                                    = delete;
+        auto                                 operator=(const suspendable&) -> suspendable&           = delete;
         auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
         std::atomic<bool>                    ready{false};
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
@@ -99,9 +99,9 @@ private:
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)           = delete;
-    task_completion_source(task_completion_source&& other) noexcept = default;
-    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
+    task_completion_source(const task_completion_source&)                              = delete;
+    task_completion_source(task_completion_source&& other) noexcept                    = default;
+    auto operator=(const task_completion_source&) -> task_completion_source&           = delete;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
     void set_value()
     {

--- a/inc/coro/task_completion_source.hpp
+++ b/inc/coro/task_completion_source.hpp
@@ -13,9 +13,9 @@ private:
     struct suspendable
     {
         explicit suspendable() {}
-        suspendable(const suspendable&)                                                              = delete;
-        suspendable(suspendable&& other) noexcept                                                    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable&           = delete;
+        suspendable(const suspendable&)              = delete;
+        suspendable(suspendable&& other) noexcept    = delete;
+        auto                                 operator=(const suspendable&) -> suspendable& = delete;
         auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
         std::atomic<bool>                    is_set{false};
         T                                    value;
@@ -28,16 +28,16 @@ private:
             coroutine.store(handle);
             ready.store(false);
         }
-        constexpr void await_resume() const noexcept {}
+        T await_resume() const noexcept { return std::move(value); }
     };
 
     std::shared_ptr<suspendable> suspender{std::make_shared<suspendable>()};
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)                              = delete;
-    task_completion_source(task_completion_source&& other) noexcept                    = default;
-    auto operator=(const task_completion_source&) -> task_completion_source&           = delete;
+    task_completion_source(const task_completion_source&)           = delete;
+    task_completion_source(task_completion_source&& other) noexcept = default;
+    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
     void set_value(const T& v)
     {
@@ -65,8 +65,7 @@ public:
     {
         auto  suspender_ptr = suspender;
         auto& suspend       = *suspender_ptr;
-        co_await suspend;
-        co_return std::move(suspend.value);
+        co_return co_await suspend;
     }
 };
 
@@ -77,9 +76,9 @@ private:
     struct suspendable
     {
         explicit suspendable() {}
-        suspendable(const suspendable&)                                                              = delete;
-        suspendable(suspendable&& other) noexcept                                                    = delete;
-        auto                                 operator=(const suspendable&) -> suspendable&           = delete;
+        suspendable(const suspendable&)              = delete;
+        suspendable(suspendable&& other) noexcept    = delete;
+        auto                                 operator=(const suspendable&) -> suspendable& = delete;
         auto                                 operator=(suspendable&& other) noexcept -> suspendable& = delete;
         std::atomic<bool>                    ready{false};
         std::atomic<std::coroutine_handle<>> coroutine{nullptr};
@@ -99,9 +98,9 @@ private:
 
 public:
     task_completion_source() {}
-    task_completion_source(const task_completion_source&)                              = delete;
-    task_completion_source(task_completion_source&& other) noexcept                    = default;
-    auto operator=(const task_completion_source&) -> task_completion_source&           = delete;
+    task_completion_source(const task_completion_source&)           = delete;
+    task_completion_source(task_completion_source&& other) noexcept = default;
+    auto operator=(const task_completion_source&) -> task_completion_source& = delete;
     auto operator=(task_completion_source&& other) noexcept -> task_completion_source& = default;
     void set_value()
     {
@@ -118,7 +117,6 @@ public:
         auto  suspender_ptr = suspender;
         auto& suspend       = *suspender_ptr;
         co_await suspend;
-        co_return;
     }
 };
 


### PR DESCRIPTION
I am proposing this for inclusion. It's made from the existing building blocks, viz. std::suspend_always. It is actually independant of coro::task etc. but should be fully interoperable. It is useful for implementing async queues, driver event patterns, anything that needs to resume (and pass data to) async functions waiting for some event. This may overlap with the schedulers that libcoro provides, but these are complete solutions and rely on broader OS support for epoll and mutexes etc, whereas this implementation is lock-free.

Using it goes like this:
```
auto eventAsync()
{
  coro::task_completion_source<int> tcs; // give tcs to some context or scheduler, even non-async
  // ...
  return tcs.token(); // co_await'ing tcs.token() continues or suspends depending on when tcs.set_value(42) is called
}
void someOtherContext()
{
  // ...
  // if co_wait tcs.token() has already suspended before tcs.set_value() gets called, it needs to be
  // resumed from another context or scheduler. use tcs.handle() to obtain the coroutine_handle<> for this.
  if (auto handle = tcs.handle(); handle && !handle.done()) {
    handle.resume();
  }
  // ...
}
```