### PR TITLE
task doesn't require default ctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,9 @@ CMake Options:
 | LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                    |
 | LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                |
 | LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                 |
+| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib.                                                  |
 | LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                  |
+| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                                                  |
 
 #### Adding to your project
 

--- a/inc/coro/task.hpp
+++ b/inc/coro/task.hpp
@@ -5,6 +5,7 @@
 #include <coroutine>
 #include <exception>
 #include <optional>
+#include <stdexcept>
 #include <utility>
 
 namespace coro


### PR DESCRIPTION
Reported issue that a task's return type would fail to compile if it didn't have a default constructor. This behavior shouldn't be required and this fix addresses that by adding a test which should fail compilation if task incorrectly requires a default ctor.

Closes #163