### PR TITLE
Use std::expected when __cpp_lib_expected is defined

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -1,4 +1,4 @@
-# libcoro C++20 linux coroutine library
+# libcoro C++20 coroutine library
 
 [![CI](https://github.com/jbaldwin/libcoro/workflows/build/badge.svg)](https://github.com/jbaldwin/libcoro/workflows/build/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/jbaldwin/libcoro/badge.svg?branch=issue-1/ci)](https://coveralls.io/github/jbaldwin/libcoro?branch=issue-1/ci)
@@ -386,6 +386,10 @@ Transfer/sec:     18.33MB
         g++13
         clang++16
         clang++17
+        MSVC Windows 2022 CL
+            No io_scheduler support
+            No networking support
+            No SSL support
     CMake
     make or ninja
     pthreads
@@ -409,7 +413,7 @@ This project depends on the following git sub-modules:
  * [libc-ares](https://github.com/c-ares/c-ares) For async DNS resolver, this is a git submodule.
  * [catch2](https://github.com/catchorg/Catch2) For testing, this is embedded in the `test/` directory.
  * [expected](https://github.com/TartanLlama/expected) For results on operations that can fail, this is a git submodule in the `vendor/` directory.
-   * `-std=c++23` will use `std::expected` instead, g++ however with this flag isn't setting a high enough `__cplusplus` value to properly trigger on yet.
+   * `-std=c++23` if it supports `__cpp_lib_expected` will use `std::expected` instead.
 
 #### Building
     mkdir Release && cd Release
@@ -418,15 +422,15 @@ This project depends on the following git sub-modules:
 
 CMake Options:
 
-| Name                          | Default | Description                                                                    |
-|:------------------------------|:--------|:-------------------------------------------------------------------------------|
-| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.  |
-| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                     |
-| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                 |
-| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                  |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. |
-| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                   |
-| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                       |
+| Name                          | Default | Description                                                                                        |
+|:------------------------------|:--------|:---------------------------------------------------------------------------------------------------|
+| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.                      |
+| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                                         |
+| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                                     |
+| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                                      |
+| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. MSVC not supported. |
+| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features. MSVC not supported.                                                   |
+| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled. MSVC not supported.                       |
 
 #### Adding to your project
 
@@ -479,7 +483,7 @@ The tests will automatically be run by github actions on creating a pull request
 
 File bug reports, feature requests and questions using [GitHub libcoro Issues](https://github.com/jbaldwin/libcoro/issues)
 
-Copyright © 2020-2022 Josh Baldwin
+Copyright © 2020-2023 Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B20-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -409,6 +409,7 @@ This project depends on the following git sub-modules:
  * [libc-ares](https://github.com/c-ares/c-ares) For async DNS resolver, this is a git submodule.
  * [catch2](https://github.com/catchorg/Catch2) For testing, this is embedded in the `test/` directory.
  * [expected](https://github.com/TartanLlama/expected) For results on operations that can fail, this is a git submodule in the `vendor/` directory.
+   * `-std=c++23` will use `std::expected` instead, g++ however with this flag isn't setting a high enough `__cplusplus` value to properly trigger on yet.
 
 #### Building
     mkdir Release && cd Release
@@ -417,15 +418,15 @@ This project depends on the following git sub-modules:
 
 CMake Options:
 
-| Name                          | Default | Description                                                                   |
-|:------------------------------|:--------|:------------------------------------------------------------------------------|
-| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries. |
-| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                    |
-| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                |
-| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                 |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib.                                                  |
-| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                  |
-| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                                                  |
+| Name                          | Default | Description                                                                    |
+|:------------------------------|:--------|:-------------------------------------------------------------------------------|
+| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.  |
+| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                     |
+| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                 |
+| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                  |
+| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. |
+| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                   |
+| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                       |
 
 #### Adding to your project
 

--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,7 @@ This project depends on the following git sub-modules:
  * [libc-ares](https://github.com/c-ares/c-ares) For async DNS resolver, this is a git submodule.
  * [catch2](https://github.com/catchorg/Catch2) For testing, this is embedded in the `test/` directory.
  * [expected](https://github.com/TartanLlama/expected) For results on operations that can fail, this is a git submodule in the `vendor/` directory.
+   * `-std=c++23` will use `std::expected` instead, g++ however with this flag isn't setting a high enough `__cplusplus` value to properly trigger on yet.
 
 #### Building
     mkdir Release && cd Release
@@ -1117,15 +1118,15 @@ This project depends on the following git sub-modules:
 
 CMake Options:
 
-| Name                          | Default | Description                                                                   |
-|:------------------------------|:--------|:------------------------------------------------------------------------------|
-| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries. |
-| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                    |
-| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                |
-| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                 |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib.                                                  |
-| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                  |
-| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                                                  |
+| Name                          | Default | Description                                                                    |
+|:------------------------------|:--------|:-------------------------------------------------------------------------------|
+| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.  |
+| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                     |
+| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                 |
+| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                  |
+| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. |
+| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                   |
+| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                       |
 
 #### Adding to your project
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# libcoro C++20 linux coroutine library
+# libcoro C++20 coroutine library
 
 [![CI](https://github.com/jbaldwin/libcoro/workflows/build/badge.svg)](https://github.com/jbaldwin/libcoro/workflows/build/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/jbaldwin/libcoro/badge.svg?branch=issue-1/ci)](https://coveralls.io/github/jbaldwin/libcoro?branch=issue-1/ci)
@@ -1086,6 +1086,10 @@ Transfer/sec:     18.33MB
         g++13
         clang++16
         clang++17
+        MSVC Windows 2022 CL
+            No io_scheduler support
+            No networking support
+            No SSL support
     CMake
     make or ninja
     pthreads
@@ -1109,7 +1113,7 @@ This project depends on the following git sub-modules:
  * [libc-ares](https://github.com/c-ares/c-ares) For async DNS resolver, this is a git submodule.
  * [catch2](https://github.com/catchorg/Catch2) For testing, this is embedded in the `test/` directory.
  * [expected](https://github.com/TartanLlama/expected) For results on operations that can fail, this is a git submodule in the `vendor/` directory.
-   * `-std=c++23` will use `std::expected` instead, g++ however with this flag isn't setting a high enough `__cplusplus` value to properly trigger on yet.
+   * `-std=c++23` if it supports `__cpp_lib_expected` will use `std::expected` instead.
 
 #### Building
     mkdir Release && cd Release
@@ -1118,15 +1122,15 @@ This project depends on the following git sub-modules:
 
 CMake Options:
 
-| Name                          | Default | Description                                                                    |
-|:------------------------------|:--------|:-------------------------------------------------------------------------------|
-| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.  |
-| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                     |
-| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                 |
-| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                  |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. |
-| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features.                                                   |
-| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled.                       |
+| Name                          | Default | Description                                                                                        |
+|:------------------------------|:--------|:---------------------------------------------------------------------------------------------------|
+| LIBCORO_EXTERNAL_DEPENDENCIES | OFF     | Use CMake find_package to resolve dependencies instead of embedded libraries.                      |
+| LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                                         |
+| LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                                     |
+| LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                                      |
+| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. MSVC not supported. |
+| LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features. MSVC not supported.                                                   |
+| LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled. MSVC not supported.                       |
 
 #### Adding to your project
 
@@ -1179,7 +1183,7 @@ The tests will automatically be run by github actions on creating a pull request
 
 File bug reports, feature requests and questions using [GitHub libcoro Issues](https://github.com/jbaldwin/libcoro/issues)
 
-Copyright © 2020-2022 Josh Baldwin
+Copyright © 2020-2023 Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B20-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,59 +1,46 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 project(libcoro_examples)
 
 add_executable(coro_task coro_task.cpp)
-target_compile_features(coro_task PUBLIC cxx_std_20)
 target_link_libraries(coro_task PUBLIC libcoro)
 
 add_executable(coro_generator coro_generator.cpp)
-target_compile_features(coro_generator PUBLIC cxx_std_20)
 target_link_libraries(coro_generator PUBLIC libcoro)
 
 add_executable(coro_event coro_event.cpp)
-target_compile_features(coro_event PUBLIC cxx_std_20)
 target_link_libraries(coro_event PUBLIC libcoro)
 
 if(LIBCORO_FEATURE_THREADING)
     add_executable(coro_latch coro_latch.cpp)
-    target_compile_features(coro_latch PUBLIC cxx_std_20)
     target_link_libraries(coro_latch PUBLIC libcoro)
 endif()
 
 add_executable(coro_mutex coro_mutex.cpp)
-target_compile_features(coro_mutex PUBLIC cxx_std_20)
 target_link_libraries(coro_mutex PUBLIC libcoro)
 
 add_executable(coro_thread_pool coro_thread_pool.cpp)
-target_compile_features(coro_thread_pool PUBLIC cxx_std_20)
 target_link_libraries(coro_thread_pool PUBLIC libcoro)
 
 add_executable(coro_semaphore coro_semaphore.cpp)
-target_compile_features(coro_semaphore PUBLIC cxx_std_20)
 target_link_libraries(coro_semaphore PUBLIC libcoro)
 
 add_executable(coro_ring_buffer coro_ring_buffer.cpp)
-target_compile_features(coro_ring_buffer PUBLIC cxx_std_20)
 target_link_libraries(coro_ring_buffer PUBLIC libcoro)
 
 add_executable(coro_shared_mutex coro_shared_mutex.cpp)
-target_compile_features(coro_shared_mutex PUBLIC cxx_std_20)
 target_link_libraries(coro_shared_mutex PUBLIC libcoro)
 
 if(LIBCORO_FEATURE_NETWORKING)
     add_executable(coro_task_container coro_task_container.cpp)
-    target_compile_features(coro_task_container PUBLIC cxx_std_20)
     target_link_libraries(coro_task_container PUBLIC libcoro)
 
     add_executable(coro_io_scheduler coro_io_scheduler.cpp)
-    target_compile_features(coro_io_scheduler PUBLIC cxx_std_20)
     target_link_libraries(coro_io_scheduler PUBLIC libcoro)
 
     add_executable(coro_tcp_echo_server coro_tcp_echo_server.cpp)
-    target_compile_features(coro_tcp_echo_server PUBLIC cxx_std_20)
     target_link_libraries(coro_tcp_echo_server PUBLIC libcoro)
 
     add_executable(coro_http_200_ok_server coro_http_200_ok_server.cpp)
-    target_compile_features(coro_http_200_ok_server PUBLIC cxx_std_20)
     target_link_libraries(coro_http_200_ok_server PUBLIC libcoro)
 endif()
 

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#if __cplusplus < 202002L
-    #error "libcoro requires C++20 or greater"
-#endif
-
 #include "coro/concepts/awaitable.hpp"
 #include "coro/concepts/buffer.hpp"
 #include "coro/concepts/executor.hpp"

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
+#if __cplusplus < 202002L
+    #error "libcoro requires C++20 or greater"
+#endif
+
 #include "coro/concepts/awaitable.hpp"
 #include "coro/concepts/buffer.hpp"
 #include "coro/concepts/executor.hpp"
 #include "coro/concepts/promise.hpp"
 #include "coro/concepts/range_of.hpp"
+
+#include "coro/expected.hpp"
 
 #ifdef LIBCORO_FEATURE_THREADING
     #include "coro/io_scheduler.hpp"

--- a/include/coro/expected.hpp
+++ b/include/coro/expected.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if (__cplusplus > 202002L)
+#if (__cpp_lib_expected)
     #include <expected>
 namespace coro
 {

--- a/include/coro/expected.hpp
+++ b/include/coro/expected.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#if (__cplusplus > 202002L)
+    #include <expected>
+namespace coro
+{
+template<typename T, typename E>
+using expected = std::expected<T, E>;
+
+template<typename E>
+using unexpected = std::unexpected<E>;
+} // namespace coro
+#else
+    #include <tl/expected.hpp>
+namespace coro
+{
+template<typename T, typename E>
+using expected = tl::expected<T, E>;
+
+template<typename E>
+using unexpected = tl::unexpected<E>;
+} // namespace coro
+#endif

--- a/include/coro/ring_buffer.hpp
+++ b/include/coro/ring_buffer.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <tl/expected.hpp>
+#include <coro/expected.hpp>
 
 #include <array>
 #include <atomic>
@@ -140,11 +140,11 @@ public:
         /**
          * @return The consumed element or std::nullopt if the consume has failed.
          */
-        auto await_resume() -> tl::expected<element, consume_result>
+        auto await_resume() -> expected<element, consume_result>
         {
             if (m_stopped)
             {
-                return tl::make_unexpected(consume_result::ring_buffer_stopped);
+                return unexpected<consume_result>(consume_result::ring_buffer_stopped);
             }
 
             return std::move(m_e);

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,7 +1,3 @@
-#if __cplusplus < 202002L
-    #error libcoro requires C++20 or greater
-#endif
-
 #include "coro/event.hpp"
 #include "coro/thread_pool.hpp"
 

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,3 +1,7 @@
+#if __cplusplus < 202002L
+    #error libcoro requires C++20 or greater
+#endif
+
 #include "coro/event.hpp"
 #include "coro/thread_pool.hpp"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ if(LIBCORO_FEATURE_THREADING)
 endif()
 
 add_executable(${PROJECT_NAME} main.cpp ${LIBCORO_TEST_SOURCE_FILES})
-# target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(${PROJECT_NAME} PUBLIC libcoro)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 project(libcoro_test)
 
 set(LIBCORO_TEST_SOURCE_FILES
@@ -34,7 +34,7 @@ if(LIBCORO_FEATURE_THREADING)
 endif()
 
 add_executable(${PROJECT_NAME} main.cpp ${LIBCORO_TEST_SOURCE_FILES})
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+# target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(${PROJECT_NAME} PUBLIC libcoro)
 


### PR DESCRIPTION
This doesn't appear to actually be working yet due to g++-12 and g++-13 not setting any values higher than __cplusplus 202002L even when passing in -std=c++23.  The code works when manually enabled though. Hopefully a new version of g++ will set this properly and it will just work.

Closes #145