### PR TITLE
Mention vcpkg in README.md

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -459,8 +459,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC libcoro)
 
 ```
 
-##### Conan
-libcoro is available via the [Conan](https://conan.io/center/libcoro) package manager.
+##### Package managers
+libcoro is available via package managers [Conan](https://conan.io/center/libcoro) and [vcpkg](https://vcpkg.io/).
 
 #### Tests
 The tests will automatically be run by github actions on creating a pull request.  They can also be ran locally:

--- a/README.md
+++ b/README.md
@@ -1147,8 +1147,8 @@ target_link_libraries(${PROJECT_NAME} PUBLIC libcoro)
 
 ```
 
-##### Conan
-libcoro is available via the [Conan](https://conan.io/center/libcoro) package manager.
+##### Package managers
+libcoro is available via package managers [Conan](https://conan.io/center/libcoro) and [vcpkg](https://vcpkg.io/).
 
 #### Tests
 The tests will automatically be run by github actions on creating a pull request.  They can also be ran locally:


### PR DESCRIPTION
libcoro is [now available](https://github.com/microsoft/vcpkg/pull/30623) via vcpkg. This updates README.md correspondingly.