### PR TITLE
Fix: Define macros for __attribute__.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(LIBCORO_SOURCE_FILES
 
     include/coro/detail/void_value.hpp
 
+    include/coro/attribute.hpp
     include/coro/coro.hpp
     include/coro/generator.hpp
     include/coro/task.hpp

--- a/include/coro/attribute.hpp
+++ b/include/coro/attribute.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+// This is a GCC extension; define it only for GCC and compilers that emulate GCC.
+#ifdef __GNUC__
+    #define __ATTRIBUTE__(attr) __attribute__((attr))
+#else
+    #define __ATTRIBUTE__(attr)
+#endif

--- a/include/coro/sync_wait.hpp
+++ b/include/coro/sync_wait.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "coro/attribute.hpp"
 #include "coro/concepts/awaitable.hpp"
 
 #include <condition_variable>
@@ -188,7 +189,7 @@ private:
 template<
     concepts::awaitable awaitable_type,
     typename return_type = concepts::awaitable_traits<awaitable_type>::awaiter_return_type>
-static auto make_sync_wait_task(awaitable_type&& a) -> sync_wait_task<return_type> __attribute__((used));
+static auto make_sync_wait_task(awaitable_type&& a) -> sync_wait_task<return_type> __ATTRIBUTE__(used);
 
 template<concepts::awaitable awaitable_type, typename return_type>
 static auto make_sync_wait_task(awaitable_type&& a) -> sync_wait_task<return_type>

--- a/include/coro/task_container.hpp
+++ b/include/coro/task_container.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "coro/attribute.hpp"
 #include "coro/concepts/executor.hpp"
 #include "coro/task.hpp"
 
@@ -107,7 +108,7 @@ public:
      * the task container for newly stored tasks.
      * @return The number of tasks that were deleted.
      */
-    auto garbage_collect() -> std::size_t __attribute__((used))
+    auto garbage_collect() -> std::size_t __ATTRIBUTE__(used)
     {
         std::scoped_lock lk{m_mutex};
         return gc_internal();

--- a/include/coro/when_all.hpp
+++ b/include/coro/when_all.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "coro/attribute.hpp"
 #include "coro/concepts/awaitable.hpp"
 #include "coro/detail/void_value.hpp"
 
@@ -439,7 +440,7 @@ private:
 template<
     concepts::awaitable awaitable,
     typename return_type = typename concepts::awaitable_traits<awaitable&&>::awaiter_return_type>
-static auto make_when_all_task(awaitable a) -> when_all_task<return_type> __attribute__((used));
+static auto make_when_all_task(awaitable a) -> when_all_task<return_type> __ATTRIBUTE__(used);
 
 template<concepts::awaitable awaitable, typename return_type>
 static auto make_when_all_task(awaitable a) -> when_all_task<return_type>


### PR DESCRIPTION
Since `__attribute__` is GCC-only, provide a way to omit on other compilers. See also the discussion in #166.