### PR TITLE
Minor fix for compatibility with OpenSSL < 1.1.0

### DIFF
--- a/examples/coro_http_200_ok_server.cpp
+++ b/examples/coro_http_200_ok_server.cpp
@@ -22,6 +22,8 @@ Connection: keep-alive
                 switch (rstatus)
                 {
                     case coro::net::recv_status::ok:
+                        // Make sure the client socket can be written to.
+                        co_await client.poll(coro::poll_op::write);
                         client.send(std::span<const char>{response});
                         break;
                     case coro::net::recv_status::would_block:

--- a/examples/coro_io_scheduler.cpp
+++ b/examples/coro_io_scheduler.cpp
@@ -129,10 +129,13 @@ int main()
         // Connect to the server.
         co_await client.connect();
 
+        // Make sure the client socket can be written to.
+        co_await client.poll(coro::poll_op::write);
+
         // Send the request data.
         client.send(std::string_view{"Hello from client."});
 
-        // Wait for the response an receive it.
+        // Wait for the response and receive it.
         co_await client.poll(coro::poll_op::read);
         std::string response(256, '\0');
         auto [recv_status, recv_bytes] = client.recv(response);

--- a/examples/coro_task_container.cpp
+++ b/examples/coro_task_container.cpp
@@ -26,6 +26,9 @@ int main()
                 request.resize(recv_bytes.size());
                 std::cout << "server: " << request << "\n";
 
+                // Make sure the client socket can be written to.
+                co_await client.poll(coro::poll_op::write);
+
                 auto response = "Hello from server " + std::to_string(requests);
                 client.send(response);
 
@@ -63,6 +66,9 @@ int main()
         // Send N requests on the same connection and wait for the server response to each one.
         for (size_t i = 1; i <= request_count; ++i)
         {
+            // Make sure the client socket can be written to.
+            co_await client.poll(coro::poll_op::write);
+
             // Send the request data.
             auto request = "Hello from client " + std::to_string(i);
             client.send(request);

--- a/examples/coro_tcp_echo_server.cpp
+++ b/examples/coro_tcp_echo_server.cpp
@@ -16,6 +16,8 @@ auto main() -> int
                 switch (rstatus)
                 {
                     case coro::net::recv_status::ok:
+                        // Make sure the client socket can be written to.
+                        co_await client.poll(coro::poll_op::write);
                         client.send(std::span<const char>{rspan});
                         break;
                     case coro::net::recv_status::would_block:


### PR DESCRIPTION
1、Minor fix for compatibility with OpenSSL < 1.1.0
2、Examples make sure the socket can be read/write before recv/send