### PR TITLE
Fix rvalue reference instantiation of coro::task

### DIFF
--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -313,3 +313,17 @@ TEST_CASE("task doesn't require default constructor", "[task]")
 
     REQUIRE(coro::sync_wait(make_task()).m_value == 42);
 }
+
+TEST_CASE("task supports instantiation with rvalue reference", "[task]")
+{
+    // https://github.com/jbaldwin/libcoro/issues/180
+    // Reported issue that the return type cannot be rvalue reference.
+    // This test explicitly creates an coroutine that returns a task
+    // instantiated with rvalue reference to verify that rvalue
+    // reference is supported.
+
+    int  i         = 42;
+    auto make_task = [&i]() -> coro::task<int&&> { co_return std::move(i); };
+    int  ret       = coro::sync_wait(make_task());
+    REQUIRE(ret == 42);
+}


### PR DESCRIPTION
This pull request fixes the problem that `coro::task<int&&>` cannot be constructed.

When `return_type` is reference_type, the `promise::result()` always returns `return_type`
When `return_type` is not reference_type, the `promise::result()` either returns `const return_type&` by `decltype(m_return_value.value())` or returns `return_type&&` by `decltype(std::move(m_return_value.value())`

The pull request also reduces the size of `promise` when `return_type` is reference type. The underlying held type for reference return type is changed from `std::optional<std::reference_wrapper<std::remove_reference<return_type>>>` to `std::remove_reference<return_type>*`. The typical size of `std::optional<std::reference_wrapper<int>>` is 16 and the size of pointer is typically 8.