### PR TITLE
Clean: Remove a few warnings.

### DIFF
--- a/include/coro/mutex.hpp
+++ b/include/coro/mutex.hpp
@@ -105,7 +105,7 @@ public:
     auto unlock() -> void;
 
 private:
-    friend class lock_operation;
+    friend struct lock_operation;
 
     /// unlocked -> state == unlocked_value()
     /// locked but empty waiter list == nullptr

--- a/include/coro/shared_mutex.hpp
+++ b/include/coro/shared_mutex.hpp
@@ -250,7 +250,7 @@ public:
     }
 
 private:
-    friend class lock_operation;
+    friend struct lock_operation;
 
     enum class state
     {

--- a/include/coro/thread_pool.hpp
+++ b/include/coro/thread_pool.hpp
@@ -98,7 +98,7 @@ public:
     /**
      * @return The number of executor threads for processing tasks.
      */
-    auto thread_count() const noexcept -> uint32_t { return m_threads.size(); }
+    auto thread_count() const noexcept -> size_t { return m_threads.size(); }
 
     /**
      * Schedules the currently executing coroutine to be run on this thread pool.  This must be


### PR DESCRIPTION
`lock_operation` is declared as a struct, not a class.