### PR TITLE
Fix wrong library naming in pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ endif()
 
 
 # generate pc file for pkg-config
-set(target1 ${PROJECT_NAME})
+string(REGEX REPLACE "^lib" "" target1 ${PROJECT_NAME})
 configure_file(libcoro.pc.in libcoro.pc @ONLY)
 
 install(TARGETS libcoro)


### PR DESCRIPTION
The CMake configuration for generating the `.pc` file for `pkg-config` was mistakenly prepending a `lib` prefix:
```
Libs: -L${libdir} -llibcoro
```

As a result, consumers of the `pkg-config` file would try to link to `liblibcoro` instead of the correct `libcoro`:
```
/usr/bin/ld: cannot find -llibcoro: No such file or directory
/usr/bin/ld: note to link with /usr/lib/gcc/x86_64-linux-gnu/13/../../../../lib/libcoro.a use -l:libcoro.a or rename it to liblibcoro.a
collect2: error: ld returned 1 exit status
```

This PR adjusts the `CMakeLists.txt` to strip the `lib` prefix from the `${PROJECT_NAME}` before passing it to the template for `.pc` file generation. This ensures that the resulting `.pc` file references the library correctly as `-lcoro`, aligning with the actual name of the library:
```
Libs: -L${libdir} -lcoro
```