### PR TITLE
Optimize coro::task

### DIFF
--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -107,13 +107,9 @@ struct promise final : public promise_base
             return_type ref = static_cast<Value&&>(value);
             new (m_storage) stored_type(std::addressof(ref));
         }
-        else if constexpr (std::is_constructible_v<stored_type, Value&&>)
-        {
-            new (m_storage) stored_type(static_cast<Value&&>(value));
-        }
         else
         {
-            new (m_storage) stored_type(static_cast<const std::remove_reference_t<Value>&>(value));
+            new (m_storage) stored_type(static_cast<Value&&>(value));
         }
         m_state = task_state::value;
     }

--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -327,3 +327,101 @@ TEST_CASE("task supports instantiation with rvalue reference", "[task]")
     int  ret       = coro::sync_wait(make_task());
     REQUIRE(ret == 42);
 }
+
+struct move_construct_only
+{
+    static int move_count;
+    move_construct_only(int& i) : i(i) {}
+    move_construct_only(move_construct_only&& x) noexcept : i(x.i) { ++move_count; }
+    move_construct_only(const move_construct_only&)            = delete;
+    move_construct_only& operator=(move_construct_only&&)      = delete;
+    move_construct_only& operator=(const move_construct_only&) = delete;
+    ~move_construct_only()                                     = default;
+    int& i;
+};
+
+int move_construct_only::move_count = 0;
+
+struct copy_construct_only
+{
+    static int copy_count;
+    copy_construct_only(int i) : i(i) {}
+    copy_construct_only(copy_construct_only&&) = delete;
+    copy_construct_only(const copy_construct_only& x) noexcept : i(x.i) { ++copy_count; }
+    copy_construct_only& operator=(copy_construct_only&&)      = delete;
+    copy_construct_only& operator=(const copy_construct_only&) = delete;
+    ~copy_construct_only()                                     = default;
+    int i;
+};
+
+int copy_construct_only::copy_count = 0;
+
+struct move_copy_construct_only
+{
+    static int move_count;
+    static int copy_count;
+    move_copy_construct_only(int i) : i(i) {}
+    move_copy_construct_only(move_copy_construct_only&& x) noexcept : i(x.i) { ++move_count; }
+    move_copy_construct_only(const move_copy_construct_only& x) noexcept : i(x.i) { ++copy_count; }
+    move_copy_construct_only& operator=(move_copy_construct_only&&)      = delete;
+    move_copy_construct_only& operator=(const move_copy_construct_only&) = delete;
+    ~move_copy_construct_only()                                          = default;
+    int i;
+};
+
+int move_copy_construct_only::move_count = 0;
+int move_copy_construct_only::copy_count = 0;
+
+TEST_CASE("task supports instantiation with non assignable type", "[task]")
+{
+    // https://github.com/jbaldwin/libcoro/issues/193
+    // Reported issue that the return type cannot be non assignable type.
+    // This test explicitly creates an coroutine that returns a task
+    // instantiated with non assignable types to verify that non assignable
+    // types are supported.
+
+    int i                           = 42;
+    move_construct_only::move_count = 0;
+    auto move_task                  = [&i]() -> coro::task<move_construct_only> { co_return move_construct_only(i); };
+    auto move_ret                   = coro::sync_wait(move_task());
+    REQUIRE(std::addressof(move_ret.i) == std::addressof(i));
+    REQUIRE(move_construct_only::move_count == 2);
+
+    auto move_task2 = [&i]() -> coro::task<move_construct_only> { co_return i; };
+    auto move_ret2  = coro::sync_wait(move_task2());
+    REQUIRE(std::addressof(move_ret2.i) == std::addressof(i));
+    REQUIRE(move_construct_only::move_count == 3);
+
+    copy_construct_only::copy_count = 0;
+    auto copy_task                  = [&i]() -> coro::task<copy_construct_only> { co_return copy_construct_only(i); };
+    auto copy_ret                   = coro::sync_wait(copy_task());
+    REQUIRE(copy_ret.i == 42);
+    REQUIRE(copy_construct_only::copy_count == 2);
+
+    auto copy_task2 = [&i]() -> coro::task<copy_construct_only> { co_return i; };
+    auto copy_ret2  = coro::sync_wait(copy_task2());
+    REQUIRE(copy_ret2.i == 42);
+    REQUIRE(copy_construct_only::copy_count == 3);
+
+    move_copy_construct_only::move_count = 0;
+    move_copy_construct_only::copy_count = 0;
+    auto move_copy_task = [&i]() -> coro::task<move_copy_construct_only> { co_return move_copy_construct_only(i); };
+    auto task           = move_copy_task();
+    auto move_copy_ret1 = coro::sync_wait(task);
+    auto move_copy_ret2 = coro::sync_wait(std::move(task));
+    REQUIRE(move_copy_ret1.i == 42);
+    REQUIRE(move_copy_ret2.i == 42);
+    REQUIRE(move_copy_construct_only::move_count == 2);
+    REQUIRE(move_copy_construct_only::copy_count == 1);
+
+    auto make_tuple_task = [&i]() -> coro::task<std::tuple<int, int>> {
+        co_return {i, i};
+    };
+    auto tuple_ret = coro::sync_wait(make_tuple_task());
+    REQUIRE(std::get<0>(tuple_ret) == 42);
+    REQUIRE(std::get<1>(tuple_ret) == 42);
+
+    auto  make_ref_task = [&i]() -> coro::task<int&> { co_return std::ref(i); };
+    auto& ref_ret       = coro::sync_wait(make_ref_task());
+    REQUIRE(std::addressof(ref_ret) == std::addressof(i));
+}


### PR DESCRIPTION
Please refer to issue #193 .

This pull request does lots of optimization including
1. sharing storage between value and exception ptr.
2. allowing inplace construction inside the promise to reduce 1 move/copy
3. disabling all move/copy ctor/assign functions
4. adding test to make sure that non assignable types can be used to initialize the  `coro::task`