### PR TITLE
Rename THREADING feature to PLATFORM

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -428,7 +428,7 @@ CMake Options:
 | LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                                         |
 | LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                                     |
 | LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                                      |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. MSVC not supported. |
+| LIBCORO_FEATURE_PLATFORM      | ON      | Include the features depending on the linux platform. MSVC not supported.                          |
 | LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features. MSVC not supported.                                                   |
 | LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled. MSVC not supported.                       |
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(LIBCORO_EXTERNAL_DEPENDENCIES "Use Cmake find_package to resolve dependen
 option(LIBCORO_BUILD_TESTS           "Build the tests, Default=ON." ON)
 option(LIBCORO_CODE_COVERAGE         "Enable code coverage, tests must also be enabled, Default=OFF" OFF)
 option(LIBCORO_BUILD_EXAMPLES        "Build the examples, Default=ON." ON)
-cmake_dependent_option(LIBCORO_FEATURE_THREADING "Include multithreading features, Default=ON." ON "NOT MSVC" OFF)
+cmake_dependent_option(LIBCORO_FEATURE_PLATFORM "Include linux platform features, Default=ON." ON "NOT MSVC" OFF)
 cmake_dependent_option(LIBCORO_FEATURE_NETWORKING "Include networking features, Default=ON." ON "NOT MSVC" OFF)
 cmake_dependent_option(LIBCORO_FEATURE_SSL "Include SSL encryption features, Default=ON." ON "NOT MSVC" OFF)
 
@@ -31,7 +31,7 @@ message("${PROJECT_NAME} LIBCORO_EXTERNAL_DEPENDENCIES = ${LIBCORO_EXTERNAL_DEPE
 message("${PROJECT_NAME} LIBCORO_BUILD_TESTS           = ${LIBCORO_BUILD_TESTS}")
 message("${PROJECT_NAME} LIBCORO_CODE_COVERAGE         = ${LIBCORO_CODE_COVERAGE}")
 message("${PROJECT_NAME} LIBCORO_BUILD_EXAMPLES        = ${LIBCORO_BUILD_EXAMPLES}")
-message("${PROJECT_NAME} LIBCORO_FEATURE_THREADING     = ${LIBCORO_FEATURE_THREADING}")
+message("${PROJECT_NAME} LIBCORO_FEATURE_PLATFORM      = ${LIBCORO_FEATURE_PLATFORM}")
 message("${PROJECT_NAME} LIBCORO_FEATURE_NETWORKING    = ${LIBCORO_FEATURE_NETWORKING}")
 message("${PROJECT_NAME} LIBCORO_FEATURE_SSL           = ${LIBCORO_FEATURE_SSL}")
 
@@ -79,7 +79,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/when_all.hpp
 )
 
-if(LIBCORO_FEATURE_THREADING)
+if(LIBCORO_FEATURE_PLATFORM)
     list(APPEND LIBCORO_SOURCE_FILES
         include/coro/detail/poll_info.hpp
 
@@ -119,9 +119,9 @@ if(MSVC)
     # Not sure why this is only needed on Windows.
     target_include_directories(${PROJECT_NAME} PUBLIC vendor/tartanllama/expected/include)
 endif()
-if(LIBCORO_FEATURE_THREADING)
+if(LIBCORO_FEATURE_PLATFORM)
     target_link_libraries(${PROJECT_NAME} PUBLIC pthread tl::expected)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC LIBCORO_FEATURE_THREADING)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC LIBCORO_FEATURE_PLATFORM)
 endif()
 if(LIBCORO_FEATURE_NETWORKING)
     target_link_libraries(${PROJECT_NAME} PUBLIC c-ares::cares)

--- a/README.md
+++ b/README.md
@@ -1128,7 +1128,7 @@ CMake Options:
 | LIBCORO_BUILD_TESTS           | ON      | Should the tests be built?                                                                         |
 | LIBCORO_CODE_COVERAGE         | OFF     | Should code coverage be enabled? Requires tests to be enabled.                                     |
 | LIBCORO_BUILD_EXAMPLES        | ON      | Should the examples be built?                                                                      |
-| LIBCORO_FEATURE_THREADING     | ON      | Include the features depending on multi-threading support by the standard lib. MSVC not supported. |
+| LIBCORO_FEATURE_PLATFORM      | ON      | Include the features depending on the linux platform. MSVC not supported.                          |
 | LIBCORO_FEATURE_NETWORKING    | ON      | Include networking features. MSVC not supported.                                                   |
 | LIBCORO_FEATURE_SSL           | ON      | Include SSL features. Requires networking to be enabled. MSVC not supported.                       |
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(coro_generator PUBLIC libcoro)
 add_executable(coro_event coro_event.cpp)
 target_link_libraries(coro_event PUBLIC libcoro)
 
-if(LIBCORO_FEATURE_THREADING)
+if(LIBCORO_FEATURE_PLATFORM)
     add_executable(coro_latch coro_latch.cpp)
     target_link_libraries(coro_latch PUBLIC libcoro)
 endif()

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -8,7 +8,7 @@
 
 #include "coro/expected.hpp"
 
-#ifdef LIBCORO_FEATURE_THREADING
+#ifdef LIBCORO_FEATURE_PLATFORM
     #include "coro/io_scheduler.hpp"
     #include "coro/poll.hpp"
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ if(LIBCORO_FEATURE_NETWORKING)
     )
 endif()
 
-if(LIBCORO_FEATURE_THREADING)
+if(LIBCORO_FEATURE_PLATFORM)
     list(APPEND LIBCORO_TEST_SOURCE_FILES
         bench.cpp
         test_io_scheduler.cpp

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -80,7 +80,7 @@ TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
     m.unlock();
 }
 
-#ifdef LIBCORO_FEATURE_THREADING
+#ifdef LIBCORO_FEATURE_PLATFORM
 TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]")
 {
     auto tp = std::make_shared<coro::io_scheduler>(


### PR DESCRIPTION
This feature is gating linux platform features (epoll specifically) and not really threading, I think renaming it is more appropriate than keeping it the same name.

Closes #183