### PR TITLE
Switch pull_request to pull for ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
     build-ubuntu-20-04:


### PR DESCRIPTION
push is required to get the `main` branch to run on PR merge for the status badges