### PR TITLE
Removing pull_request trigger broke external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, workflow_dispatch]
+on: [pull_request, push, workflow_dispatch]
 
 jobs:
     build-ubuntu-20-04:


### PR DESCRIPTION
Re-adding it since its required for contributors to get the PR CI runs to exceute now... oops.