### PR TITLE
Use std::shared_ptr for coro::net::ssl_context

### DIFF
--- a/include/coro/net/tcp_client.hpp
+++ b/include/coro/net/tcp_client.hpp
@@ -33,7 +33,7 @@ public:
         uint16_t port{8080};
 #ifdef LIBCORO_FEATURE_SSL
         /// Should this tcp_client connect using a secure connection SSL/TLS?
-        ssl_context* ssl_ctx{nullptr};
+        std::shared_ptr<ssl_context> ssl_ctx{nullptr};
 #endif
     };
 

--- a/include/coro/net/tcp_server.hpp
+++ b/include/coro/net/tcp_server.hpp
@@ -33,7 +33,7 @@ public:
 #ifdef LIBCORO_FEATURE_SSL
         /// Should this tcp server use TLS/SSL?  If provided all accepted connections will use the
         /// given SSL certificate and private key to secure the connections.
-        ssl_context* ssl_ctx{nullptr};
+        std::shared_ptr<ssl_context> ssl_ctx{nullptr};
 #endif
     };
 

--- a/test/net/test_tcp_server.cpp
+++ b/test/net/test_tcp_server.cpp
@@ -89,11 +89,6 @@ TEST_CASE("tcp_server with ssl", "[tcp_server]")
     auto scheduler = std::make_shared<coro::io_scheduler>(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    coro::net::ssl_context client_ssl_context{};
-
-    coro::net::ssl_context server_ssl_context{
-        "cert.pem", coro::net::ssl_file_type::pem, "key.pem", coro::net::ssl_file_type::pem};
-
     std::string client_msg = "Hello world from SSL client!";
     std::string server_msg = "Hello world from SSL server!!";
 
@@ -101,7 +96,8 @@ TEST_CASE("tcp_server with ssl", "[tcp_server]")
     {
         co_await scheduler->schedule();
 
-        coro::net::tcp_client client{scheduler, coro::net::tcp_client::options{.ssl_ctx = &client_ssl_context}};
+        coro::net::tcp_client client{
+            scheduler, coro::net::tcp_client::options{.ssl_ctx = std::make_shared<coro::net::ssl_context>()}};
 
         std::cerr << "client.connect()\n";
         auto cstatus = co_await client.connect();
@@ -158,7 +154,11 @@ TEST_CASE("tcp_server with ssl", "[tcp_server]")
     {
         co_await scheduler->schedule();
 
-        coro::net::tcp_server server{scheduler, coro::net::tcp_server::options{.ssl_ctx = &server_ssl_context}};
+        coro::net::tcp_server server{
+            scheduler,
+            coro::net::tcp_server::options{
+                .ssl_ctx = std::make_shared<coro::net::ssl_context>(
+                    "cert.pem", coro::net::ssl_file_type::pem, "key.pem", coro::net::ssl_file_type::pem)}};
 
         std::cerr << "server.poll()\n";
         auto pstatus = co_await server.poll();


### PR DESCRIPTION
Previously this was a raw pointer to allow for the user to pass in a global ssl context across various tcp_clients... this is pretty unsafe and I previously moved away from this model for the coro::io_scheduler handle that gets passed into the coro::net::tcp_client.  To be consistent and safe this pointer is being moved to an std::shared_ptr.

Closes #204