### PR TITLE
Fix coro::when_all not compiling when passing the output of std::views

### DIFF
--- a/include/coro/when_all.hpp
+++ b/include/coro/when_all.hpp
@@ -482,7 +482,7 @@ template<
     }
 
     // Wrap each task into a when_all_task.
-    for (auto& a : awaitables)
+    for (auto&& a : awaitables)
     {
         output_tasks.emplace_back(detail::make_when_all_task(std::move(a)));
     }


### PR DESCRIPTION
Fixes a bug that prevents `coro::when_all` from compiling when passing the result of a std::ranges::views of awaitables. The for-each loop in `coro::when_all` defines an `auto& a` when looping through awaitables, when it should use `auto&& a` since it's moving them into a vector.

Here is a minimal example that should compile, but currently doesn't.
```cpp
#include <iostream>
#include <ranges>

#include <coro/coro.hpp>

static coro::task<void> foo(int i)
{
    std::cout << i << '\n';
    co_return;
}

int main(void)
{
    coro::sync_wait(coro::when_all(
        std::views::iota(0, 6)
        | std::views::transform(::foo)
    ));
    return 0;
}
```

Also there's a bug in your `.githooks` that changes all `&` in the code portions of your README to `${EXAMPLE_CORO_TASK_CPP}`. I haven't fixed that, but you I thought you should know.