### PR TITLE
Use std::thread for coro::thread_pool

### DIFF
--- a/include/coro/thread_pool.hpp
+++ b/include/coro/thread_pool.hpp
@@ -201,7 +201,6 @@ public:
      */
     auto queue_size() const noexcept -> std::size_t
     {
-        // Might not be totally perfect but good enough, avoids acquiring the lock for now.
         std::atomic_thread_fence(std::memory_order::acquire);
         return m_queue.size();
     }
@@ -215,7 +214,7 @@ private:
     /// The configuration options.
     options m_opts;
     /// The background executor threads.
-    std::vector<std::jthread> m_threads;
+    std::vector<std::thread> m_threads;
 
     /// Mutex for executor threads to sleep on the condition variable.
     std::mutex m_wait_mutex;
@@ -225,10 +224,9 @@ private:
     std::deque<std::coroutine_handle<>> m_queue;
     /**
      * Each background thread runs from this function.
-     * @param stop_token Token which signals when shutdown() has been called.
      * @param idx The executor's idx for internal data structure accesses.
      */
-    auto executor(std::stop_token stop_token, std::size_t idx) -> void;
+    auto executor(std::size_t idx) -> void;
 
     /**
      * @param handle Schedules the given coroutine to be executed upon the first available thread.

--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -183,13 +183,11 @@ auto io_scheduler::poll(fd_t fd, coro::poll_op op, std::chrono::milliseconds tim
 auto io_scheduler::shutdown() noexcept -> void
 {
     // Only allow shutdown to occur once.
-    if (m_shutdown_requested.exchange(true, std::memory_order::seq_cst) == false)
+    if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
     {
-        // std::cerr << "io_scheduler.m_shutdown_requested = " << m_shutdown_requested << "\n";
         if (m_thread_pool != nullptr)
         {
             m_thread_pool->shutdown();
-            // std::cerr << "io_scheduler.m_thread_pool->shutdown() complete\n";
         }
 
         // Signal the event loop to stop asap, triggering the event fd is safe.

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -24,7 +24,7 @@ thread_pool::thread_pool(options opts) : m_opts(std::move(opts))
 
     for (uint32_t i = 0; i < m_opts.thread_count; ++i)
     {
-        m_threads.emplace_back([this, i](std::stop_token st) { executor(std::move(st), i); });
+        m_threads.emplace_back([this, i]() { executor(i); });
     }
 }
 
@@ -35,7 +35,7 @@ thread_pool::~thread_pool()
 
 auto thread_pool::schedule() -> operation
 {
-    if (!m_shutdown_requested.load(std::memory_order::relaxed))
+    if (!m_shutdown_requested.load(std::memory_order::acquire))
     {
         m_size.fetch_add(1, std::memory_order::release);
         return operation{*this};
@@ -60,9 +60,11 @@ auto thread_pool::shutdown() noexcept -> void
     // Only allow shutdown to occur once.
     if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
     {
-        for (auto& thread : m_threads)
         {
-            thread.request_stop();
+            // There is a race condition if we are not holding the lock with the executors
+            // to always receive this.  std::jthread stop token works without this properly.
+            std::unique_lock<std::mutex> lk{m_wait_mutex};
+            m_wait_cv.notify_all();
         }
 
         for (auto& thread : m_threads)
@@ -75,34 +77,51 @@ auto thread_pool::shutdown() noexcept -> void
     }
 }
 
-auto thread_pool::executor(std::stop_token stop_token, std::size_t idx) -> void
+auto thread_pool::executor(std::size_t idx) -> void
 {
     if (m_opts.on_thread_start_functor != nullptr)
     {
         m_opts.on_thread_start_functor(idx);
     }
 
-    while (!stop_token.stop_requested())
+    auto drain_queue = [this](std::unique_lock<std::mutex>& lk) -> void
     {
-        // Wait until the queue has operations to execute or shutdown has been requested.
-        while (true)
+        // Process this batch until the queue is empty.
+        while (!m_queue.empty())
         {
-            std::unique_lock<std::mutex> lk{m_wait_mutex};
-            m_wait_cv.wait(lk, stop_token, [this] { return !m_queue.empty(); });
-            if (m_queue.empty())
-            {
-                lk.unlock(); // would happen on scope destruction, but being explicit/faster(?)
-                break;
-            }
-
             auto handle = m_queue.front();
             m_queue.pop_front();
 
-            lk.unlock(); // Not needed for processing the coroutine.
-
+            // Release the lock while executing the coroutine.
+            lk.unlock();
             handle.resume();
             m_size.fetch_sub(1, std::memory_order::release);
+            lk.lock();
         }
+    };
+
+    // Process until shutdown is requested and the total number of tasks reaches zero.
+    while (!m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        std::unique_lock<std::mutex> lk{m_wait_mutex};
+        m_wait_cv.wait(
+            lk,
+            [&] {
+                return m_size.load(std::memory_order::acquire) > 0 ||
+                       m_shutdown_requested.load(std::memory_order::acquire);
+            });
+
+        drain_queue(lk);
+    }
+
+    // Shutdown has been requested, we need to drain until no more tasks remain.
+    while (m_size.load(std::memory_order::acquire) > 0)
+    {
+        std::unique_lock<std::mutex> lk{m_wait_mutex};
+        m_wait_cv.wait_for(
+            lk, std::chrono::milliseconds{10}, [&] { return m_size.load(std::memory_order::acquire) > 0; });
+
+        drain_queue(lk);
     }
 
     if (m_opts.on_thread_stop_functor != nullptr)


### PR DESCRIPTION
* This change switches from std::jthread to std::thread for the coro::thread_pool
* This change is in support of emscripten support

Closes #220