### PR TITLE
Make coro::net::socket copyable

### DIFF
--- a/include/coro/net/socket.hpp
+++ b/include/coro/net/socket.hpp
@@ -47,9 +47,9 @@ public:
     socket() = default;
     explicit socket(int fd) : m_fd(fd) {}
 
-    socket(const socket&) = delete;
+    socket(const socket& other) : m_fd(dup(other.m_fd)) {}
     socket(socket&& other) : m_fd(std::exchange(other.m_fd, -1)) {}
-    auto operator=(const socket&) -> socket& = delete;
+    auto operator=(const socket& other) noexcept -> socket&;
     auto operator=(socket&& other) noexcept -> socket&;
 
     ~socket() { close(); }

--- a/src/net/socket.cpp
+++ b/src/net/socket.cpp
@@ -15,6 +15,13 @@ auto socket::type_to_os(type_t type) -> int
     }
 }
 
+auto socket::operator=(const socket& other) noexcept -> socket&
+{
+    this->close(); // Make sure we are not leaking.
+    this->m_fd = dup(other.m_fd);
+    return *this;
+}
+
 auto socket::operator=(socket&& other) noexcept -> socket&
 {
     if (std::addressof(other) != this)


### PR DESCRIPTION
This leverages the dup() function