### PR TITLE
Add test to verify dup'ed sockets can poll on read/write

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -44,11 +44,11 @@ jobs:
                         -DLIBCORO_FEATURE_TLS=ON \
                         -DLIBCORO_CODE_COVERAGE=ON \
                         ..
-                    ninja
+                    cmake --build . --config Debug
             -   name: Coverage
                 run: |
                     cd Debug
-                    ctest -VV
+                    ctest --build-config Debug -VV
                     gcov -o ./test/CMakeFiles/libcoro_test.dir/main.cpp.o ./test/libcoro_test
                     lcov --include "*/include/coro/*" --include "*/src/*" --exclude "test/*" -o libcoro_tests.lcov -c -d .
             -   name: Coveralls GitHub Action

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -44,7 +44,7 @@ jobs:
                         -GNinja \
                         -DCMAKE_BUILD_TYPE=Release \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd emsdk

--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -9,8 +9,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                fedora_version: [32, 33, 34, 35, 36, 37]
-                libcoro_feature_networking: [ {enabled: ON, tls: ON}]
+                fedora_version: [32, 33, 34, 35, 36, 37, 38, 39, 40]
+                libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
                 libcoro_feature_platform: [ON]
         container:
             image: fedora:${{ matrix.fedora_version }}
@@ -41,8 +41,8 @@ jobs:
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_FEATURE_PLATFORM=${{ matrix.libcoro_feature_platform }} \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
+                    ctest --build-config Release -VV

--- a/.github/workflows/ci-opensuse.yml
+++ b/.github/workflows/ci-opensuse.yml
@@ -42,9 +42,9 @@ jobs:
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_FEATURE_PLATFORM=${{ matrix.libcoro_feature_platform }} \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
+                    ctest --build-config Release -VV
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -146,8 +146,8 @@ jobs:
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_FEATURE_PLATFORM=${{ matrix.libcoro_feature_platform }} \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
+                    ctest --build-config Release -VV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.2.0")
-        message(FATAL_ERROR "gcc version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 10.2.0")
+        message(FATAL_ERROR "g++ version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 10.2.0")
     endif()
 
     target_compile_options(${PROJECT_NAME} PUBLIC
@@ -160,7 +160,8 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
         $<$<COMPILE_LANGUAGE:CXX>:-Wall>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-        $<$<COMPILE_LANGUAGE:CXX>:-pipe>)
+        $<$<COMPILE_LANGUAGE:CXX>:-pipe>
+    )
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
         message(FATAL_ERROR "Clang version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 16.0.0")
@@ -171,9 +172,12 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
         $<$<COMPILE_LANGUAGE:CXX>:-Wall>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-        $<$<COMPILE_LANGUAGE:CXX>:-pipe>)
+        $<$<COMPILE_LANGUAGE:CXX>:-pipe>
+    )
 elseif(MSVC)
-    target_compile_options(${PROJECT_NAME} PUBLIC /W4)
+    target_compile_options(${PROJECT_NAME} PUBLIC 
+        /W4
+    )
 endif()
 
 if(LIBCORO_BUILD_TESTS)

--- a/include/coro/io_scheduler.hpp
+++ b/include/coro/io_scheduler.hpp
@@ -162,11 +162,7 @@ public:
      * @param task The task to execute on this io_scheduler.  It's lifetime ownership will be transferred
      *             to this io_scheduler.
      */
-    auto schedule(coro::task<void>&& task) -> void
-    {
-        auto* ptr = static_cast<coro::task_container<coro::io_scheduler>*>(m_owned_tasks);
-        ptr->start(std::move(task));
-    }
+    auto schedule(coro::task<void>&& task) -> void;
 
     /**
      * Schedules the current task to run after the given amount of time has elapsed.
@@ -290,11 +286,7 @@ public:
      * new tasks but this allows the user to cleanup resources manually.  One usage might be making sure fds
      * are cleaned up as soon as possible.
      */
-    auto garbage_collect() noexcept -> void
-    {
-        auto* ptr = static_cast<coro::task_container<coro::io_scheduler>*>(m_owned_tasks);
-        ptr->garbage_collect();
-    }
+    auto garbage_collect() noexcept -> void;
 
 private:
     /// The configuration options.

--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -84,6 +84,12 @@ auto io_scheduler::process_events(std::chrono::milliseconds timeout) -> std::siz
     return size();
 }
 
+auto io_scheduler::schedule(coro::task<void>&& task) -> void
+{
+    auto* ptr = static_cast<coro::task_container<coro::io_scheduler>*>(m_owned_tasks);
+    ptr->start(std::move(task));
+}
+
 auto io_scheduler::schedule_after(std::chrono::milliseconds amount) -> coro::task<void>
 {
     return yield_for(amount);
@@ -200,6 +206,12 @@ auto io_scheduler::shutdown() noexcept -> void
             m_io_thread.join();
         }
     }
+}
+
+auto io_scheduler::garbage_collect() noexcept -> void
+{
+    auto* ptr = static_cast<coro::task_container<coro::io_scheduler>*>(m_owned_tasks);
+    ptr->garbage_collect();
 }
 
 auto io_scheduler::process_events_manual(std::chrono::milliseconds timeout) -> void

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,33 +35,43 @@ endif()
 
 if(LIBCORO_FEATURE_PLATFORM)
     list(APPEND LIBCORO_TEST_SOURCE_FILES
-        bench.cpp # networking is ifdef'ed internally
+        bench.cpp # internally ifdef's LIBCORO_FEATURE_NETWORKING|TLS
         test_io_scheduler.cpp
     )
 endif()
 
 add_executable(${PROJECT_NAME} main.cpp ${LIBCORO_TEST_SOURCE_FILES})
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(LIBCORO_TEST_LINK_LIBRARIES libcoro)
+target_link_libraries(${PROJECT_NAME} PRIVATE libcoro)
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    set(LIBCORO_TEST_COMPILE_OPTIONS -fcoroutines -Wall -Wextra -pipe)
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
+        $<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>
+        $<$<COMPILE_LANGUAGE:CXX>:-fconcepts>
+        $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-pipe>
+    )
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    set(LIBCORO_TEST_COMPILE_OPTIONS -Wall -Wextra -pipe)
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
+        $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-pipe>
+    )
 elseif(MSVC)
-    set(LIBCORO_TEST_COMPILE_OPTIONS /W4)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W4)
 else()
     message(FATAL_ERROR "Unsupported compiler.")
 endif()
 
 if(LIBCORO_CODE_COVERAGE)
-    list(APPEND LIBCORO_TEST_LINK_LIBRARIES gcov)
-    list(APPEND LIBCORO_TEST_COMPILE_OPTIONS --coverage)
+    target_link_libraries(${PROJECT_NAME} PRIVATE gcov)
+    target_compile_options(${PROJECT_NAME} PRIVATE --coverage)
 endif()
-
-target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBCORO_TEST_LINK_LIBRARIES})
-target_compile_options(${PROJECT_NAME} PUBLIC ${LIBCORO_TEST_COMPILE_OPTIONS})
 
 add_test(NAME libcoro_tests COMMAND ${PROJECT_NAME})

--- a/test/net/test_tls_server.cpp
+++ b/test/net/test_tls_server.cpp
@@ -7,7 +7,7 @@
 
         #include <iostream>
 
-TEST_CASE("tls_server hello world server", "[tcp_server]")
+TEST_CASE("tls_server hello world server", "[tls_server]")
 {
     auto scheduler = std::make_shared<coro::io_scheduler>(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});


### PR DESCRIPTION
This change adds a test to prove that duplicating a tcp::client allows you to read in one coroutine while writing in another. This does not allow you to read in two coroutines, the epoll_ctl_mod will still fail.

Closes #224