### PR TITLE
pkg-config fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,11 @@ endif()
 
 
 # generate pc file for pkg-config
-string(REGEX REPLACE "^lib" "" target1 ${PROJECT_NAME})
+if(MSVC)
+    set(target1 ${PROJECT_NAME})
+else()
+    string(REGEX REPLACE "^lib" "" target1 ${PROJECT_NAME})
+endif()
 configure_file(libcoro.pc.in libcoro.pc @ONLY)
 
 install(TARGETS libcoro)

--- a/libcoro.pc.in
+++ b/libcoro.pc.in
@@ -1,6 +1,6 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 libdir="${prefix}/lib"
-includedir="@CMAKE_INSTALL_INCLUDEDIR@"
+includedir="${prefix}/include"
 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@


### PR DESCRIPTION
This contributes two fixes for pkg-config that were originally found when porting the library for vcpkg: https://github.com/microsoft/vcpkg/pull/35814#issuecomment-1867449402

* `includedir` in the .pc file is incorrect when a different install suffix is set
* the linker option -l in the .pc file is incorrect on Windows because the library prefix "lib" must be included in the name