### PR TITLE
Re-work tls client to match openssl requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if(LIBCORO_FEATURE_PLATFORM)
 
         include/coro/fd.hpp
         include/coro/io_scheduler.hpp src/io_scheduler.cpp
-        include/coro/poll.hpp
+        include/coro/poll.hpp src/poll.cpp
     )
 endif()
 

--- a/include/coro/net/tls/recv_status.hpp
+++ b/include/coro/net/tls/recv_status.hpp
@@ -15,6 +15,7 @@ enum class recv_status : int64_t
     ok = SSL_ERROR_NONE,
     // The user provided an 0 length buffer.
     buffer_is_empty = -3,
+    timeout         = -4,
     /// The peer closed the socket.
     closed           = SSL_ERROR_ZERO_RETURN,
     error            = SSL_ERROR_SSL,

--- a/include/coro/net/tls/send_status.hpp
+++ b/include/coro/net/tls/send_status.hpp
@@ -15,6 +15,8 @@ enum class send_status : int64_t
     ok = SSL_ERROR_NONE,
     // The user provided an 0 length buffer.
     buffer_is_empty = -3,
+    // The operation timed out.
+    timeout = -4,
     /// The peer closed the socket.
     closed           = SSL_ERROR_ZERO_RETURN,
     error            = SSL_ERROR_SSL,

--- a/include/coro/poll.hpp
+++ b/include/coro/poll.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <sys/epoll.h>
 
 namespace coro
@@ -24,6 +25,8 @@ inline auto poll_op_writeable(poll_op op) -> bool
     return (static_cast<uint64_t>(op) & EPOLLOUT);
 }
 
+auto to_string(poll_op op) -> const std::string&;
+
 enum class poll_status
 {
     /// The poll operation was was successful.
@@ -35,5 +38,7 @@ enum class poll_status
     /// The file descriptor has been closed by the remote or an internal error/close.
     closed
 };
+
+auto to_string(poll_status status) -> const std::string&;
 
 } // namespace coro

--- a/src/net/tls/client.cpp
+++ b/src/net/tls/client.cpp
@@ -214,6 +214,7 @@ auto client::tls_shutdown_and_free(
 {
     while (true)
     {
+        ERR_clear_error();
         auto r = SSL_shutdown(tls_ptr.get());
         if (r == 1) // shutdown complete
         {

--- a/src/net/tls/recv_status.cpp
+++ b/src/net/tls/recv_status.cpp
@@ -5,6 +5,7 @@ namespace coro::net::tls
 
 static std::string recv_status_ok{"ok"};
 static std::string recv_status_buffer_is_empty{"buffer_is_empty"};
+static std::string recv_status_timeout{"timeout"};
 static std::string recv_status_closed{"closed"};
 static std::string recv_status_error{"error"};
 static std::string recv_status_want_read{"want_read"};
@@ -23,6 +24,8 @@ auto to_string(recv_status status) -> const std::string&
             return recv_status_ok;
         case recv_status::buffer_is_empty:
             return recv_status_buffer_is_empty;
+        case recv_status::timeout:
+            return recv_status_timeout;
         case recv_status::closed:
             return recv_status_closed;
         case recv_status::error:

--- a/src/net/tls/send_status.cpp
+++ b/src/net/tls/send_status.cpp
@@ -5,6 +5,7 @@ namespace coro::net::tls
 
 static std::string send_status_ok{"ok"};
 static std::string send_status_buffer_is_empty{"buffer_is_empty"};
+static std::string send_status_timeout{"timeout"};
 static std::string send_status_closed{"closed"};
 static std::string send_status_error{"error"};
 static std::string send_status_want_read{"want_read"};
@@ -23,6 +24,8 @@ auto to_string(send_status status) -> const std::string&
             return send_status_ok;
         case send_status::buffer_is_empty:
             return send_status_buffer_is_empty;
+        case send_status::timeout:
+            return send_status_timeout;
         case send_status::closed:
             return send_status_closed;
         case send_status::error:

--- a/src/poll.cpp
+++ b/src/poll.cpp
@@ -1,0 +1,49 @@
+#include <coro/poll.hpp>
+
+namespace coro
+{
+
+static const std::string poll_unknown{"unknown"};
+
+static const std::string poll_op_read{"read"};
+static const std::string poll_op_write{"write"};
+static const std::string poll_op_read_write{"read_write"};
+
+auto to_string(poll_op op) -> const std::string&
+{
+    switch (op)
+    {
+        case poll_op::read:
+            return poll_op_read;
+        case poll_op::write:
+            return poll_op_write;
+        case poll_op::read_write:
+            return poll_op_read_write;
+        default:
+            return poll_unknown;
+    }
+}
+
+static const std::string poll_status_event{"event"};
+static const std::string poll_status_timeout{"timeout"};
+static const std::string poll_status_error{"error"};
+static const std::string poll_status_closed{"closed"};
+
+auto to_string(poll_status status) -> const std::string&
+{
+    switch (status)
+    {
+        case poll_status::event:
+            return poll_status_event;
+        case poll_status::timeout:
+            return poll_status_timeout;
+        case poll_status::error:
+            return poll_status_error;
+        case poll_status::closed:
+            return poll_status_closed;
+        default:
+            return poll_unknown;
+    }
+}
+
+} // namespace coro


### PR DESCRIPTION
SSL_read_ex and SSL_write_ex need to be recalled with the same paramters if they return SSL_ERROR_WANT_READ|WRITE.  This was left up to the user before.. which is cumbersome and not very intuitive. Now the send() and recv() functions on the net::tls::client are coro:task's so they can properly call SSL_read|write_ex as many times as required. They now also support a timeout since these calls could take longer than a traditional net::tcp::client send()/recv() call.

Closes #100