### PR TITLE
[hotfix] cmake_dependent_option requires CMake 3.25

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -19,13 +19,14 @@ jobs:
                     apt install -y build-essential software-properties-common
                     add-apt-repository ppa:ubuntu-toolchain-r/test
                     apt-get install -y \
-                        cmake \
                         curl \
                         git \
                         ninja-build \
                         g++ \
                         libssl-dev \
                         lcov
+            -   name: Get latest CMake
+                uses: lukka/get-cmake@latest
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -19,9 +19,10 @@ jobs:
                     apt install -y build-essential software-properties-common
                     add-apt-repository ppa:ubuntu-toolchain-r/test
                     apt-get install -y \
-                        cmake \
                         git \
                         ninja-build
+            -   name: Get latest CMake
+                uses: lukka/get-cmake@latest
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:

--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -14,10 +14,11 @@ jobs:
         container:
             image: fedora:${{ matrix.fedora_version }}
         steps:
+            -   name: Get latest CMake
+                uses: lukka/get-cmake@latest
             -   name: Install Dependencies
                 run: |
                     sudo dnf install -y \
-                        cmake \
                         git \
                         ninja-build \
                         gcc-c++ \

--- a/.github/workflows/ci-opensuse.yml
+++ b/.github/workflows/ci-opensuse.yml
@@ -16,13 +16,14 @@ jobs:
             -   name: zypper
                 run: |
                     zypper install -y \
-                        cmake \
                         git \
                         ninja \
                         gcc${{ matrix.gplusplus_version }} \
                         gcc${{ matrix.gplusplus_version }}-c++ \
                         openssl \
                         openssl-devel
+            -   name: Get latest CMake
+                uses: lukka/get-cmake@latest
             # Cannot run higher version of checkout, node isn't backwards compatible
             -   name: Checkout
                 uses: actions/checkout@v2
@@ -45,4 +46,3 @@ jobs:
                 run: |
                     cd Release
                     ctest --build-config Release -VV
-

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -117,10 +117,11 @@ jobs:
                     apt install -y build-essential software-properties-common
                     apt-get install -y \
                         wget \
-                        cmake \
                         git \
                         ninja-build \
                         libssl-dev
+            -   name: Get latest CMake
+                uses: lukka/get-cmake@latest
             -   name: install-clang
                 run: |
                     wget https://apt.llvm.org/llvm.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.15)
 include(CMakeDependentOption)
 project(libcoro
     VERSION 0.11.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25)
 include(CMakeDependentOption)
 project(libcoro
     VERSION 0.11.0


### PR DESCRIPTION
Hello!

We are packaging the version 0.11 in Conan and we found an error related to `cmake_dependent_option` when building on Linux. It's possible to reproduce it locally, but basically, does not matter what option value you pass when running CMake <3.25, it will always use the forced negative value. For instance:

```
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.7 LTS"

$ cmake --version
cmake version 3.24.3

$ cmake --preset debug-shared
Preset CMake variables:

  CMAKE_BUILD_TYPE="Debug"
  CMAKE_TOOLCHAIN_FILE="/home/conan/project/build/conan/conan_toolchain.cmake"
  CMAKE_VERBOSE_MAKEFILE="ON"
  LIBCORO_BUILD_EXAMPLES="ON"
  LIBCORO_BUILD_SHARED_LIBS="ON"
  LIBCORO_BUILD_TESTS="ON"
  LIBCORO_EXTERNAL_DEPENDENCIES="ON"
  LIBCORO_FEATURE_NETWORKING="ON"
  LIBCORO_FEATURE_TLS="ON"

-- Using Conan toolchain: /home/conan/project/build/conan/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The CXX compiler identification is GNU 11.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
libcoro LIBCORO_EXTERNAL_DEPENDENCIES = ON
libcoro LIBCORO_BUILD_TESTS           = ON
libcoro LIBCORO_CODE_COVERAGE         = OFF
libcoro LIBCORO_BUILD_EXAMPLES        = ON
libcoro LIBCORO_FEATURE_NETWORKING    = OFF
libcoro LIBCORO_FEATURE_TLS           = OFF
libcoro LIBCORO_RUN_GITCONFIG         = OFF
libcoro LIBCORO_BUILD_SHARED_LIBS     = ON
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The C compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build/debug-shared
```

As you can see, `LIBCORO_FEATURE_TLS` is configured to be `ON`, but results in `OFF`. The code is clear about the condition:

`cmake_dependent_option(LIBCORO_FEATURE_TLS "Include TLS encryption features, Default=ON." ON "NOT EMSCRIPTEN; LINUX" OFF)`

If Not Emscripten AND Is Linux ... That's my current scenario. Still, does not work.


Now using CMake 3.25:

```
$ cmake --version
cmake version 3.25.0

$ cmake --preset debug-shared
Preset CMake variables:

  CMAKE_BUILD_TYPE="Debug"
  CMAKE_TOOLCHAIN_FILE="/home/conan/project/build/conan/conan_toolchain.cmake"
  CMAKE_VERBOSE_MAKEFILE="ON"
  LIBCORO_BUILD_EXAMPLES="ON"
  LIBCORO_BUILD_SHARED_LIBS="ON"
  LIBCORO_BUILD_TESTS="ON"
  LIBCORO_EXTERNAL_DEPENDENCIES="ON"
  LIBCORO_FEATURE_NETWORKING="ON"
  LIBCORO_FEATURE_TLS="ON"

-- Using Conan toolchain: /home/conan/project/build/conan/conan_toolchain.cmake
-- Conan toolchain: C++ Standard 20 with extensions OFF
-- The CXX compiler identification is GNU 11.1.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
libcoro LIBCORO_EXTERNAL_DEPENDENCIES = ON
libcoro LIBCORO_BUILD_TESTS           = ON
libcoro LIBCORO_CODE_COVERAGE         = OFF
libcoro LIBCORO_BUILD_EXAMPLES        = ON
libcoro LIBCORO_FEATURE_NETWORKING    = ON
libcoro LIBCORO_FEATURE_TLS           = ON
libcoro LIBCORO_RUN_GITCONFIG         = OFF
libcoro LIBCORO_BUILD_SHARED_LIBS     = ON
-- Conan: Component target declared 'c-ares::cares'
-- Conan: Component target declared 'OpenSSL::Crypto'
-- Conan: Component target declared 'OpenSSL::SSL'
-- Conan: Target declared 'openssl::openssl'
-- Conan: Target declared 'ZLIB::ZLIB'
-- Conan: Including build module from '/home/conan/.conan2/p/b/opens8c4125cc29df4/p/lib/cmake/conan-official-openssl-variables.cmake'
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The C compiler identification is GNU 11.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/conan/project/build/debug-shared
```

Now it works when running CMake 2.25. I changed nothing related to the project, only the CMake version.

My guess is some CMP changed in 3.25 which affects `cmake_dependent_option`.