### PR TITLE
Added missing header '<atomic>' when compiling with clang and c++23

### DIFF
--- a/include/coro/sync_wait.hpp
+++ b/include/coro/sync_wait.hpp
@@ -3,6 +3,7 @@
 #include "coro/attribute.hpp"
 #include "coro/concepts/awaitable.hpp"
 
+#include <atomic>
 #include <condition_variable>
 #include <exception>
 #include <mutex>


### PR DESCRIPTION
When compiling with clang and c++23 on macos and linux, the header `atomic` was missing from `sync_wait.hpp`. This PR fixes that.