### PR TITLE
CI explicitly run CMAKE_CXX_STANDARD=20|23

### DIFF
--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -9,8 +9,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                fedora_version: [32, 33, 34, 35, 36, 37, 38, 39, 40]
+                fedora_version: [37, 38, 39, 40]
+                cxx_standard: [20, 23]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
+                libcoro_build_shared_libs: [OFF]
         container:
             image: fedora:${{ matrix.fedora_version }}
         steps:
@@ -36,8 +38,10 @@ jobs:
                         -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc \
                         -DCMAKE_CXX_COMPILER=g++ \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+                        -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
                         ..
                     cmake --build . --config Release
             -   name: Test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -8,11 +8,16 @@ jobs:
         runs-on: macos-latest
         strategy:
             fail-fast: false
+            matrix:
+                clang_version: [17]
+                cxx_standard: [20, 23]
+                libcoro_feature_networking: [ {enabled: OFF, tls: OFF} ]
+                libcoro_build_shared_libs: [OFF, ON]
         steps:
             -   name: Install Dependencies
                 run: |
                     brew update
-                    brew install llvm@17
+                    brew install llvm@${{ matrix.clang_version }}
                     brew install ninja
             -   name: Checkout
                 uses: actions/checkout@v4
@@ -25,10 +30,12 @@ jobs:
                     cmake \
                         -GNinja \
                         -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin//clang-17 \
-                        -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin//clang-17 \
-                        -DLIBCORO_FEATURE_NETWORKING=OFF \
-                        -DLIBCORO_FEATURE_TLS=ON \
+                        -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin//clang-${{ matrix.clang_version }} \
+                        -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin//clang-${{ matrix.clang_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+                        -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
+                        -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+                        -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
                         ..
                     cmake --build . --config Release
             -   name: Test

--- a/.github/workflows/ci-opensuse.yml
+++ b/.github/workflows/ci-opensuse.yml
@@ -9,6 +9,7 @@ jobs:
         strategy:
             matrix:
                 gplusplus_version: [10]
+                cxx_standard: [20]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
         container:
             image: opensuse/leap:15.2
@@ -37,6 +38,7 @@ jobs:
                         -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         ..

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -9,6 +9,7 @@ jobs:
         strategy:
             matrix:
                 gplusplus_version: [10]
+                cxx_standard: [20]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON}, {enabled: ON, tls: OFF}, {enabled: OFF, tls: OFF} ]
                 libcoro_build_shared_libs: [OFF, ON]
         container:
@@ -42,6 +43,7 @@ jobs:
                         -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
@@ -57,6 +59,7 @@ jobs:
         strategy:
             matrix:
                 gplusplus_version: [11, 12, 13]
+                cxx_standard: [20, 23]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON}]
         container:
             image: ubuntu:22.04
@@ -89,6 +92,7 @@ jobs:
                         -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         ..
@@ -103,6 +107,7 @@ jobs:
         strategy:
             matrix:
                 clang_version: [16, 17]
+                cxx_standard: [20, 23]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON}]
         container:
             image: ubuntu:22.04
@@ -139,6 +144,7 @@ jobs:
                         -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         ..

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -8,6 +8,7 @@ jobs:
         runs-on: windows-latest
         strategy:
             matrix:
+                cxx_standard: [20, 23]
                 libcoro_build_shared_libs: [OFF, ON]
         steps:
             -   name: Checkout
@@ -18,7 +19,7 @@ jobs:
                 run: |
                     mkdir Release
                     cd Release
-                    cmake .. -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }}
+                    cmake -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} ..
                     cmake --build . --config Release
             -   name: Test
                 run: |


### PR DESCRIPTION
CI Added explicit 20/23 standards for:
* ci-fedora
* ci-macos
* ci-ubuntu
* ci-windows

Did not add 23 builds for
* ci-opensuse
* ci_emscripten

Closes #256