### PR TITLE
Fix unintended shallow copying when used with std::views::take (issue 261)

### DIFF
--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -118,7 +118,7 @@ private:
 } // namespace detail
 
 template<typename T>
-class generator
+class generator : public std::ranges::view_base
 {
 public:
     using promise_type = detail::generator_promise<T>;
@@ -131,7 +131,7 @@ public:
     generator(generator&& other) noexcept : m_coroutine(other.m_coroutine) { other.m_coroutine = nullptr; }
 
     auto operator=(const generator&) = delete;
-    auto operator=(generator&& other) noexcept -> generator&
+    auto operator                    =(generator&& other) noexcept -> generator&
     {
         m_coroutine       = other.m_coroutine;
         other.m_coroutine = nullptr;

--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -131,7 +131,7 @@ public:
     generator(generator&& other) noexcept : m_coroutine(other.m_coroutine) { other.m_coroutine = nullptr; }
 
     auto operator=(const generator&) = delete;
-    auto operator                    =(generator&& other) noexcept -> generator&
+    auto operator=(generator&& other) noexcept -> generator&
     {
         m_coroutine       = other.m_coroutine;
         other.m_coroutine = nullptr;

--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -127,10 +127,10 @@ public:
 
     generator() noexcept : m_coroutine(nullptr) {}
 
-    generator(const generator&) = delete;
+    generator(const generator&) { static_assert(false, "copying is not supported"); }
     generator(generator&& other) noexcept : m_coroutine(other.m_coroutine) { other.m_coroutine = nullptr; }
 
-    auto operator=(const generator&) = delete;
+    auto operator=(const generator&) { static_assert(false, "copying is not supported"); }
     auto operator=(generator&& other) noexcept -> generator&
     {
         m_coroutine       = other.m_coroutine;

--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -127,10 +127,10 @@ public:
 
     generator() noexcept : m_coroutine(nullptr) {}
 
-    generator(const generator&) { static_assert(false, "copying is not supported"); }
+    generator(const generator&) = delete;
     generator(generator&& other) noexcept : m_coroutine(other.m_coroutine) { other.m_coroutine = nullptr; }
 
-    auto operator=(const generator&) { static_assert(false, "copying is not supported"); }
+    auto operator=(const generator&) = delete;
     auto operator=(generator&& other) noexcept -> generator&
     {
         m_coroutine       = other.m_coroutine;

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -17,8 +17,7 @@ TEST_CASE("generator infinite incrementing integer yield", "[generator]")
 {
     constexpr const int64_t max = 1024;
 
-    auto func = []() -> coro::generator<int64_t>
-    {
+    auto func = []() -> coro::generator<int64_t> {
         int64_t i{0};
         while (true)
         {
@@ -37,5 +36,39 @@ TEST_CASE("generator infinite incrementing integer yield", "[generator]")
         {
             break;
         }
+    }
+}
+
+TEST_CASE("generator satisfies view concept for compatibility with std::views::take")
+{
+    auto counter = size_t{0};
+    auto natural = [n = counter]() mutable -> coro::generator<size_t> {
+        while (true)
+            co_yield ++n;
+    };
+    auto nat = natural();
+    static_assert(std::ranges::view<decltype(nat)>, "does not satisfy view concept");
+    SECTION("Count the items")
+    {
+        for (auto&& n : natural() | std::views::take(5))
+        {
+            ++counter;
+            REQUIRE(n == counter);
+        }
+        REQUIRE(counter == 5);
+    }
+    SECTION("Not supported when std::ranges::view is satisfied, see issue 261")
+    {
+        /// the following may fail to compile to prevent loss of items in the std::views:take:
+        /*
+        for (auto&& n : nat | std::views::take(3)) {
+            ++counter;
+            REQUIRE(n == counter); // expect 1, 2, 3
+        }
+        for (auto&& n : nat | std::views::take(3)) {
+            ++counter;
+            REQUIRE(n == counter); // expect 4, 5, 6 (4 may get lost if view is not enabled)
+        }
+        */
     }
 }

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -17,7 +17,8 @@ TEST_CASE("generator infinite incrementing integer yield", "[generator]")
 {
     constexpr const int64_t max = 1024;
 
-    auto func = []() -> coro::generator<int64_t> {
+    auto func = []() -> coro::generator<int64_t>
+    {
         int64_t i{0};
         while (true)
         {


### PR DESCRIPTION
Enables `view` concept on `generator` so that lvalue references cannot be accepted by `std::views:take`, which in turn would lead to erroneous behavior described in [issue 261](https://github.com/jbaldwin/libcoro/issues/261).