### PR TITLE
Add macos 14

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -26,6 +26,7 @@ jobs:
             -   name: Release
                 run: |
                     brew --prefix llvm@17
+                    ls $(brew --prefix llvm@17)/bin
                     mkdir Release
                     cd Release
                     cmake \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ project(libcoro
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX TRUE)
-    # We need to build with clang >= 17, assuming its installed by
-    # brew. We also need to force linking to libc++.a
-    add_link_options(-L/usr/local/opt/llvm/lib)
     link_libraries(-lc++)
 endif()
 


### PR DESCRIPTION
The latest macos image appears to have changed the directory that llvm/clang are installed into. Change the directory appropriately.