### PR TITLE
coro::thread_pool high cpu usage when tasks < threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,10 +362,12 @@ int main()
     // Complete worker tasks faster on a thread pool, using the io_scheduler version so the worker
     // tasks can yield for a specific amount of time to mimic difficult work.  The pool is only
     // setup with a single thread to showcase yield_for().
-    coro::io_scheduler tp{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto tp = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     // This task will wait until the given latch setters have completed.
-    auto make_latch_task = [](coro::latch& l) -> coro::task<void> {
+    auto make_latch_task = [](coro::latch& l) -> coro::task<void>
+    {
         // It seems like the dependent worker tasks could be created here, but in that case it would
         // be superior to simply do: `co_await coro::when_all(tasks);`
         // It is also important to note that the last dependent task will resume the waiting latch
@@ -381,14 +383,15 @@ int main()
 
     // This task does 'work' and counts down on the latch when completed.  The final child task to
     // complete will end up resuming the latch task when the latch's count reaches zero.
-    auto make_worker_task = [](coro::io_scheduler& tp, coro::latch& l, int64_t i) -> coro::task<void> {
+    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler>& tp, coro::latch& l, int64_t i) -> coro::task<void>
+    {
         // Schedule the worker task onto the thread pool.
-        co_await tp.schedule();
+        co_await tp->schedule();
         std::cout << "worker task " << i << " is working...\n";
         // Do some expensive calculations, yield to mimic work...!  Its also important to never use
         // std::this_thread::sleep_for() within the context of coroutines, it will block the thread
         // and other tasks that are ready to execute will be blocked.
-        co_await tp.yield_for(std::chrono::milliseconds{i * 20});
+        co_await tp->yield_for(std::chrono::milliseconds{i * 20});
         std::cout << "worker task " << i << " is done, counting down on the latch\n";
         l.count_down();
         co_return;
@@ -846,7 +849,7 @@ The example provided here shows an i/o scheduler that spins up a basic `coro::ne
 
 int main()
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(coro::io_scheduler::options{
+    auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         // The scheduler will spawn a dedicated event processing thread.  This is the default, but
         // it is possible to use 'manual' and call 'process_events()' to drive the scheduler yourself.
         .thread_strategy = coro::io_scheduler::thread_strategy_t::spawn,
@@ -1017,7 +1020,7 @@ All tasks that are stored within a `coro::task_container` must have a `void` ret
 
 int main()
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_server_task = [&]() -> coro::task<void>

--- a/examples/coro_http_200_ok_server.cpp
+++ b/examples/coro_http_200_ok_server.cpp
@@ -67,7 +67,7 @@ Connection: keep-alive
     std::vector<coro::task<void>> workers{};
     for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i)
     {
-        auto scheduler = std::make_shared<coro::io_scheduler>(coro::io_scheduler::options{
+        auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
             .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
         workers.push_back(make_http_200_ok_server(scheduler));

--- a/examples/coro_io_scheduler.cpp
+++ b/examples/coro_io_scheduler.cpp
@@ -3,7 +3,7 @@
 
 int main()
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(coro::io_scheduler::options{
+    auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         // The scheduler will spawn a dedicated event processing thread.  This is the default, but
         // it is possible to use 'manual' and call 'process_events()' to drive the scheduler yourself.
         .thread_strategy = coro::io_scheduler::thread_strategy_t::spawn,

--- a/examples/coro_latch.cpp
+++ b/examples/coro_latch.cpp
@@ -6,10 +6,12 @@ int main()
     // Complete worker tasks faster on a thread pool, using the io_scheduler version so the worker
     // tasks can yield for a specific amount of time to mimic difficult work.  The pool is only
     // setup with a single thread to showcase yield_for().
-    coro::io_scheduler tp{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto tp = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     // This task will wait until the given latch setters have completed.
-    auto make_latch_task = [](coro::latch& l) -> coro::task<void> {
+    auto make_latch_task = [](coro::latch& l) -> coro::task<void>
+    {
         // It seems like the dependent worker tasks could be created here, but in that case it would
         // be superior to simply do: `co_await coro::when_all(tasks);`
         // It is also important to note that the last dependent task will resume the waiting latch
@@ -25,14 +27,15 @@ int main()
 
     // This task does 'work' and counts down on the latch when completed.  The final child task to
     // complete will end up resuming the latch task when the latch's count reaches zero.
-    auto make_worker_task = [](coro::io_scheduler& tp, coro::latch& l, int64_t i) -> coro::task<void> {
+    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler>& tp, coro::latch& l, int64_t i) -> coro::task<void>
+    {
         // Schedule the worker task onto the thread pool.
-        co_await tp.schedule();
+        co_await tp->schedule();
         std::cout << "worker task " << i << " is working...\n";
         // Do some expensive calculations, yield to mimic work...!  Its also important to never use
         // std::this_thread::sleep_for() within the context of coroutines, it will block the thread
         // and other tasks that are ready to execute will be blocked.
-        co_await tp.yield_for(std::chrono::milliseconds{i * 20});
+        co_await tp->yield_for(std::chrono::milliseconds{i * 20});
         std::cout << "worker task " << i << " is done, counting down on the latch\n";
         l.count_down();
         co_return;

--- a/examples/coro_task_container.cpp
+++ b/examples/coro_task_container.cpp
@@ -3,7 +3,7 @@
 
 int main()
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_server_task = [&]() -> coro::task<void>

--- a/examples/coro_tcp_echo_server.cpp
+++ b/examples/coro_tcp_echo_server.cpp
@@ -61,7 +61,7 @@ auto main() -> int
     std::vector<coro::task<void>> workers{};
     for (size_t i = 0; i < std::thread::hardware_concurrency(); ++i)
     {
-        auto scheduler = std::make_shared<coro::io_scheduler>(coro::io_scheduler::options{
+        auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
             .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
         workers.push_back(make_tcp_echo_server(scheduler));

--- a/include/coro/concepts/executor.hpp
+++ b/include/coro/concepts/executor.hpp
@@ -22,6 +22,9 @@ concept executor = requires(type t, std::coroutine_handle<> c)
     { t.schedule() } -> coro::concepts::awaiter;
     { t.yield() } -> coro::concepts::awaiter;
     { t.resume(c) } -> std::same_as<bool>;
+    { t.size() } -> std::same_as<std::size_t>;
+    { t.empty() } -> std::same_as<bool>;
+    { t.shutdown() } -> std::same_as<void>;
 };
 
 #ifdef LIBCORO_FEATURE_NETWORKING

--- a/include/coro/concepts/executor.hpp
+++ b/include/coro/concepts/executor.hpp
@@ -21,7 +21,7 @@ concept executor = requires(type t, std::coroutine_handle<> c)
 {
     { t.schedule() } -> coro::concepts::awaiter;
     { t.yield() } -> coro::concepts::awaiter;
-    { t.resume(c) } -> std::same_as<void>;
+    { t.resume(c) } -> std::same_as<bool>;
 };
 
 #ifdef LIBCORO_FEATURE_NETWORKING

--- a/include/coro/io_scheduler.hpp
+++ b/include/coro/io_scheduler.hpp
@@ -21,9 +21,14 @@
 
 namespace coro
 {
-class io_scheduler
+class io_scheduler : public std::enable_shared_from_this<io_scheduler>
 {
     using timed_events = detail::poll_info::timed_events;
+
+    struct private_constructor
+    {
+        private_constructor() = default;
+    };
 
 public:
     class schedule_operation;
@@ -69,7 +74,18 @@ public:
         const execution_strategy_t execution_strategy{execution_strategy_t::process_tasks_on_thread_pool};
     };
 
-    explicit io_scheduler(
+    /**
+     * @see io_scheduler::make_shared
+     */
+    explicit io_scheduler(options&& opts, private_constructor);
+
+    /**
+     * @brief Creates an io_scheduler.
+     *
+     * @param opts
+     * @return std::shared_ptr<io_scheduler>
+     */
+    static auto make_shared(
         options opts = options{
             .thread_strategy            = thread_strategy_t::spawn,
             .on_io_thread_start_functor = nullptr,
@@ -79,7 +95,7 @@ public:
                      ((std::thread::hardware_concurrency() > 1) ? (std::thread::hardware_concurrency() - 1) : 1),
                  .on_thread_start_functor = nullptr,
                  .on_thread_stop_functor  = nullptr},
-            .execution_strategy = execution_strategy_t::process_tasks_on_thread_pool});
+            .execution_strategy = execution_strategy_t::process_tasks_on_thread_pool}) -> std::shared_ptr<io_scheduler>;
 
     io_scheduler(const io_scheduler&)                    = delete;
     io_scheduler(io_scheduler&&)                         = delete;

--- a/include/coro/task_container.hpp
+++ b/include/coro/task_container.hpp
@@ -10,7 +10,6 @@
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <thread>
 #include <vector>
 
 namespace coro
@@ -37,8 +36,7 @@ public:
     task_container(
         std::shared_ptr<executor_type> e, const options opts = options{.reserve_size = 8, .growth_factor = 2})
         : m_growth_factor(opts.growth_factor),
-          m_executor(std::move(e)),
-          m_executor_ptr(m_executor.get())
+          m_executor(std::move(e))
     {
         if (m_executor == nullptr)
         {
@@ -148,7 +146,7 @@ public:
         while (!empty())
         {
             garbage_collect();
-            co_await m_executor_ptr->yield();
+            co_await m_executor->yield();
         }
     }
 
@@ -211,7 +209,7 @@ private:
     auto make_cleanup_task(task<void> user_task, std::size_t index) -> coro::task<void>
     {
         // Immediately move the task onto the executor.
-        co_await m_executor_ptr->schedule();
+        co_await m_executor->schedule();
 
         try
         {
@@ -260,20 +258,6 @@ private:
     double m_growth_factor{};
     /// The executor to schedule tasks that have just started.
     std::shared_ptr<executor_type> m_executor{nullptr};
-    /// This is used internally since io_scheduler cannot pass itself in as a shared_ptr.
-    executor_type* m_executor_ptr{nullptr};
-
-    /**
-     * Special constructor for internal types to create their embeded task containers.
-     */
-
-    friend io_scheduler;
-    task_container(executor_type& e, const options opts = options{.reserve_size = 8, .growth_factor = 2})
-        : m_growth_factor(opts.growth_factor),
-          m_executor_ptr(&e)
-    {
-        init(opts.reserve_size);
-    }
 
     auto init(std::size_t reserve_size) -> void
     {

--- a/test/net/test_dns_resolver.cpp
+++ b/test/net/test_dns_resolver.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("dns_resolver basic", "[dns]")
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
     coro::net::dns::resolver<coro::io_scheduler> dns_resolver{scheduler, std::chrono::milliseconds{5000}};
 

--- a/test/net/test_tcp_server.cpp
+++ b/test/net/test_tcp_server.cpp
@@ -11,7 +11,7 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
     const std::string client_msg{"Hello from client"};
     const std::string server_msg{"Reply from server!"};
 
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_client_task = [&]() -> coro::task<void>
@@ -91,7 +91,7 @@ TEST_CASE("tcp_server concurrent polling on the same socket", "[tcp_server]")
     // Issue 224: This test duplicates a client and issues two different poll operations per coroutine.
 
     using namespace std::chrono_literals;
-    auto scheduler = std::make_shared<coro::io_scheduler>(coro::io_scheduler::options{
+    auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
     auto make_read_task = [](coro::net::tcp::client client) -> coro::task<void>

--- a/test/net/test_tls_server.cpp
+++ b/test/net/test_tls_server.cpp
@@ -9,7 +9,7 @@
 
 TEST_CASE("tls_server hello world server", "[tls_server]")
 {
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     std::string client_msg = "Hello world from TLS client!";

--- a/test/net/test_udp_peers.cpp
+++ b/test/net/test_udp_peers.cpp
@@ -8,7 +8,7 @@ TEST_CASE("udp one way")
 {
     const std::string msg{"aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbcccccccccccccccccc"};
 
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_send_task = [&]() -> coro::task<void>
@@ -54,7 +54,7 @@ TEST_CASE("udp echo peers")
     const std::string peer1_msg{"Hello from peer1!"};
     const std::string peer2_msg{"Hello from peer2!!"};
 
-    auto scheduler = std::make_shared<coro::io_scheduler>(
+    auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_peer_task = [&scheduler](

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -18,20 +18,21 @@ using namespace std::chrono_literals;
 
 TEST_CASE("io_scheduler schedule single task", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_task = [&]() -> coro::task<uint64_t>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         co_return 42;
     };
 
     auto value = coro::sync_wait(make_task());
     REQUIRE(value == 42);
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler submit mutiple tasks", "[io_scheduler]")
@@ -40,11 +41,11 @@ TEST_CASE("io_scheduler submit mutiple tasks", "[io_scheduler]")
     std::atomic<uint64_t>         counter{0};
     std::vector<coro::task<void>> tasks{};
     tasks.reserve(n);
-    coro::io_scheduler s{};
+    auto s = coro::io_scheduler::make_shared();
 
     auto make_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         counter++;
         co_return;
     };
@@ -57,16 +58,17 @@ TEST_CASE("io_scheduler submit mutiple tasks", "[io_scheduler]")
 
     REQUIRE(counter == n);
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
 {
     std::atomic<uint64_t> counter{0};
-    coro::io_scheduler    s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto                  s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     coro::event e1;
     coro::event e2;
@@ -74,7 +76,7 @@ TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
 
     auto make_wait_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         co_await e1;
         counter++;
         co_await e2;
@@ -86,7 +88,7 @@ TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
 
     auto make_set_task = [&](coro::event& e) -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         e.set();
     };
 
@@ -94,28 +96,29 @@ TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
 
     REQUIRE(counter == 3);
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler task with read poll", "[io_scheduler]")
 {
-    auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    auto s          = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_poll_read_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
-        auto status = co_await s.poll(trigger_fd, coro::poll_op::read);
+        co_await s->schedule();
+        auto status = co_await s->poll(trigger_fd, coro::poll_op::read);
         REQUIRE(status == coro::poll_status::event);
         co_return;
     };
 
     auto make_poll_write_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         uint64_t value{42};
         auto     unused = write(trigger_fd, &value, sizeof(value));
         (void)unused;
@@ -124,30 +127,31 @@ TEST_CASE("io_scheduler task with read poll", "[io_scheduler]")
 
     coro::sync_wait(coro::when_all(make_poll_read_task(), make_poll_write_task()));
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
     close(trigger_fd);
 }
 
 TEST_CASE("io_scheduler task with read poll with timeout", "[io_scheduler]")
 {
-    auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    auto s          = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_poll_read_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         // Poll with a timeout but don't timeout.
-        auto status = co_await s.poll(trigger_fd, coro::poll_op::read, 50ms);
+        auto status = co_await s->poll(trigger_fd, coro::poll_op::read, 50ms);
         REQUIRE(status == coro::poll_status::event);
         co_return;
     };
 
     auto make_poll_write_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         uint64_t value{42};
         auto     unused = write(trigger_fd, &value, sizeof(value));
         (void)unused;
@@ -156,73 +160,49 @@ TEST_CASE("io_scheduler task with read poll with timeout", "[io_scheduler]")
 
     coro::sync_wait(coro::when_all(make_poll_read_task(), make_poll_write_task()));
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
     close(trigger_fd);
 }
 
 TEST_CASE("io_scheduler task with read poll timeout", "[io_scheduler]")
 {
-    auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    auto s          = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         // Poll with a timeout and timeout.
-        auto status = co_await s.poll(trigger_fd, coro::poll_op::read, 10ms);
+        auto status = co_await s->poll(trigger_fd, coro::poll_op::read, 10ms);
         REQUIRE(status == coro::poll_status::timeout);
         co_return;
     };
 
     coro::sync_wait(make_task());
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
     close(trigger_fd);
 }
 
-// TODO: This probably requires a TCP socket?
-// TEST_CASE("io_scheduler task with read poll closed socket", "[io_scheduler]")
-// {
-//     auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-//     coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options { .thread_count = 1 }}};
-
-//     auto make_poll_task = [&]() -> coro::task<void> {
-//         co_await s.schedule();
-//         auto status = co_await s.poll(trigger_fd, coro::poll_op::read, 1000ms);
-//         REQUIRE(status == coro::poll_status::closed);
-//         co_return;
-//     };
-
-//     auto make_close_task = [&]() -> coro::task<void> {
-//         co_await s.schedule();
-//         std::this_thread::sleep_for(100ms);
-//         // shutdown(trigger_fd, SHUT_RDWR);
-//         close(trigger_fd);
-//         co_return;
-//     };
-
-//     coro::sync_wait(coro::when_all(make_poll_task(), make_close_task()));
-
-//     s.shutdown();
-//     REQUIRE(s.empty());
-// }
-
 TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
 {
-    coro::io_scheduler s1{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
-    coro::io_scheduler s2{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s1 = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
+    auto s2 = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     coro::event e{};
 
     auto make_s1_task = [&]() -> coro::task<void>
     {
-        co_await s1.schedule();
+        co_await s1->schedule();
         auto tid = std::this_thread::get_id();
         co_await e;
 
@@ -234,7 +214,7 @@ TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
 
     auto make_s2_task = [&]() -> coro::task<void>
     {
-        co_await s2.schedule();
+        co_await s2->schedule();
         // Wait a bit to be sure the wait on 'e' in the other scheduler is done first.
         std::this_thread::sleep_for(10ms);
         e.set();
@@ -243,19 +223,20 @@ TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
 
     coro::sync_wait(coro::when_all(make_s1_task(), make_s2_task()));
 
-    s1.shutdown();
-    REQUIRE(s1.empty());
-    s2.shutdown();
-    REQUIRE(s2.empty());
+    s1->shutdown();
+    REQUIRE(s1->empty());
+    s2->shutdown();
+    REQUIRE(s2->empty());
 }
 
 TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         coro::event e{};
 
         auto tid = std::this_thread::get_id();
@@ -269,7 +250,7 @@ TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]"
             {
                 // mimic some expensive computation
                 // Resume the coroutine back onto the scheduler, not this background thread.
-                e.set(s);
+                e.set(*s);
             });
         third_party_thread.detach();
 
@@ -280,14 +261,15 @@ TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]"
 
     coro::sync_wait(make_task());
 
-    s.shutdown();
-    REQUIRE(s.empty());
+    s->shutdown();
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
 {
     constexpr uint64_t expected_value{1337};
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto               s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     coro::event           start_service{};
     coro::event           service_done{};
@@ -302,7 +284,7 @@ TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
             }
 
             output = expected_value;
-            service_done.set(s);
+            service_done.set(*s);
         }};
 
     auto third_party_service = [&](int multiplier) -> coro::task<uint64_t>
@@ -314,7 +296,7 @@ TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
 
     auto make_task = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
 
         int      multiplier{5};
         uint64_t value = co_await third_party_service(multiplier);
@@ -324,26 +306,27 @@ TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
     coro::sync_wait(make_task());
 
     service.join();
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler with basic task", "[io_scheduler]")
 {
     constexpr std::size_t expected_value{5};
-    coro::io_scheduler    s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto                  s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto add_data = [&](uint64_t val) -> coro::task<int>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         co_return val;
     };
 
     auto func = [&]() -> coro::task<int>
     {
-        co_await s.schedule();
+        co_await s->schedule();
 
         auto output_tasks = co_await coro::when_all(add_data(1), add_data(1), add_data(1), add_data(1), add_data(1));
 
@@ -357,10 +340,10 @@ TEST_CASE("io_scheduler with basic task", "[io_scheduler]")
 
     REQUIRE(counter == expected_value);
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler scheduler_after", "[io_scheduler]")
@@ -379,38 +362,38 @@ TEST_CASE("io_scheduler scheduler_after", "[io_scheduler]")
     };
 
     {
-        coro::io_scheduler s{coro::io_scheduler::options{
-            .pool = coro::thread_pool::options{
-                .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}}};
-        auto               start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(s, 0ms));
+        auto s     = coro::io_scheduler::make_shared(coro::io_scheduler::options{
+                .pool = coro::thread_pool::options{
+                    .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
+        auto start = std::chrono::steady_clock::now();
+        coro::sync_wait(func(*s, 0ms));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
         REQUIRE(counter == 1);
         REQUIRE(duration < wait_for);
-        std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-        s.shutdown();
-        std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-        REQUIRE(s.empty());
+        std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+        s->shutdown();
+        std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+        REQUIRE(s->empty());
     }
 
     {
-        coro::io_scheduler s{coro::io_scheduler::options{
+        auto s = coro::io_scheduler::make_shared(coro::io_scheduler::options{
             .pool = coro::thread_pool::options{
-                .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}}};
+                .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(s, wait_for));
+        coro::sync_wait(func(*s, wait_for));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
         REQUIRE(counter == 2);
         REQUIRE(duration >= wait_for);
-        std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-        s.shutdown();
-        std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-        REQUIRE(s.empty());
+        std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+        s->shutdown();
+        std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+        REQUIRE(s->empty());
     }
 }
 
@@ -422,13 +405,13 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
     std::atomic<uint64_t>               counter{0};
     std::thread::id                     tid;
 
-    coro::io_scheduler s{coro::io_scheduler::options{
+    auto s = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .pool = coro::thread_pool::options{
-            .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}}};
+            .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
     auto func = [&](std::chrono::steady_clock::time_point time) -> coro::task<void>
     {
-        co_await s.schedule_at(time);
+        co_await s->schedule_at(time);
         ++counter;
         REQUIRE(tid == std::this_thread::get_id());
         co_return;
@@ -467,55 +450,57 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
 
 TEST_CASE("io_scheduler yield", "[io_scheduler]")
 {
-    std::thread::id    tid;
-    coro::io_scheduler s{coro::io_scheduler::options{
-        .pool = coro::thread_pool::options{
-            .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}}};
+    std::thread::id tid;
+    auto            s = coro::io_scheduler::make_shared(coro::io_scheduler::options{
+                   .pool = coro::thread_pool::options{
+                       .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
     auto func = [&]() -> coro::task<void>
     {
         REQUIRE(tid != std::this_thread::get_id());
-        co_await s.schedule();
+        co_await s->schedule();
         REQUIRE(tid == std::this_thread::get_id());
-        co_await s.yield(); // this is really a thread pool function but /shrug
+        co_await s->yield(); // this is really a thread pool function but /shrug
         REQUIRE(tid == std::this_thread::get_id());
         co_return;
     };
 
     coro::sync_wait(func());
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler yield_for", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     const std::chrono::milliseconds wait_for{50};
 
     auto make_task = [&]() -> coro::task<std::chrono::milliseconds>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         auto start = std::chrono::steady_clock::now();
-        co_await s.yield_for(wait_for);
+        co_await s->yield_for(wait_for);
         co_return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     };
 
     auto duration = coro::sync_wait(make_task());
     REQUIRE(duration >= wait_for);
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler yield_until", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     // Because yield_until() takes its own time internally the wait_for might be off by a bit.
     const std::chrono::milliseconds epsilon{3};
@@ -523,26 +508,26 @@ TEST_CASE("io_scheduler yield_until", "[io_scheduler]")
 
     auto make_task = [&]() -> coro::task<std::chrono::milliseconds>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         auto start = std::chrono::steady_clock::now();
-        co_await s.yield_until(start + wait_for);
+        co_await s->yield_until(start + wait_for);
         co_return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     };
 
     auto duration = coro::sync_wait(make_task());
     REQUIRE(duration >= (wait_for - epsilon));
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
 {
     const constexpr std::size_t total{10};
     coro::event                 e{};
-    coro::io_scheduler          s{};
+    auto                        s = coro::io_scheduler::make_shared();
 
     auto func = [&]() -> coro::task<uint64_t>
     {
@@ -552,7 +537,7 @@ TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
 
     auto spawn = [&]() -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         std::vector<coro::task<uint64_t>> tasks;
         for (size_t i = 0; i < total; ++i)
         {
@@ -571,30 +556,31 @@ TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
 
     auto release = [&]() -> coro::task<void>
     {
-        co_await s.schedule_after(10ms);
-        e.set(s);
+        co_await s->schedule_after(10ms);
+        e.set(*s);
     };
 
     coro::sync_wait(coro::when_all(spawn(), release()));
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler self generating coroutine (stack overflow check)", "[io_scheduler]")
 {
     const constexpr std::size_t total{1'000'000};
     uint64_t                    counter{0};
-    coro::io_scheduler          s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto                        s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     std::vector<coro::task<void>> tasks;
     tasks.reserve(total);
 
     auto func = [&](auto f) -> coro::task<void>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         ++counter;
 
         if (counter % total == 0)
@@ -619,44 +605,44 @@ TEST_CASE("io_scheduler self generating coroutine (stack overflow check)", "[io_
 
     REQUIRE(tasks.size() == total - 1);
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
 }
 
 TEST_CASE("io_scheduler manual process events thread pool", "[io_scheduler]")
 {
-    auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    coro::io_scheduler s{coro::io_scheduler::options{
-        .thread_strategy = coro::io_scheduler::thread_strategy_t::manual,
-        .pool            = coro::thread_pool::options{
-                       .thread_count = 1,
-        }}};
+    auto trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    auto s          = coro::io_scheduler::make_shared(coro::io_scheduler::options{
+                 .thread_strategy = coro::io_scheduler::thread_strategy_t::manual,
+                 .pool            = coro::thread_pool::options{
+                                .thread_count = 1,
+        }});
 
     std::atomic<bool> polling{false};
 
     auto make_poll_read_task = [&]() -> coro::task<void>
     {
-        std::cerr << "poll task start s.size() == " << s.size() << "\n";
-        co_await s.schedule();
+        std::cerr << "poll task start s.size() == " << s->size() << "\n";
+        co_await s->schedule();
         polling = true;
-        std::cerr << "poll task polling s.size() == " << s.size() << "\n";
-        auto status = co_await s.poll(trigger_fd, coro::poll_op::read);
+        std::cerr << "poll task polling s.size() == " << s->size() << "\n";
+        auto status = co_await s->poll(trigger_fd, coro::poll_op::read);
         REQUIRE(status == coro::poll_status::event);
-        std::cerr << "poll task exiting s.size() == " << s.size() << "\n";
+        std::cerr << "poll task exiting s.size() == " << s->size() << "\n";
         co_return;
     };
 
     auto make_poll_write_task = [&]() -> coro::task<void>
     {
-        std::cerr << "write task start s.size() == " << s.size() << "\n";
-        co_await s.schedule();
+        std::cerr << "write task start s.size() == " << s->size() << "\n";
+        co_await s->schedule();
         uint64_t value{42};
-        std::cerr << "write task writing s.size() == " << s.size() << "\n";
+        std::cerr << "write task writing s.size() == " << s->size() << "\n";
         auto unused = write(trigger_fd, &value, sizeof(value));
         (void)unused;
-        std::cerr << "write task exiting s.size() == " << s.size() << "\n";
+        std::cerr << "write task exiting s.size() == " << s->size() << "\n";
         co_return;
     };
 
@@ -671,43 +657,43 @@ TEST_CASE("io_scheduler manual process events thread pool", "[io_scheduler]")
 
     write_task.resume();
 
-    while (s.process_events(100ms) > 0)
+    while (s->process_events(100ms) > 0)
         ;
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
     close(trigger_fd);
 }
 
 TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
 {
-    auto               trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-    coro::io_scheduler s{coro::io_scheduler::options{
-        .thread_strategy    = coro::io_scheduler::thread_strategy_t::manual,
-        .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline}};
+    auto trigger_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    auto s          = coro::io_scheduler::make_shared(coro::io_scheduler::options{
+                 .thread_strategy    = coro::io_scheduler::thread_strategy_t::manual,
+                 .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
     auto make_poll_read_task = [&]() -> coro::task<void>
     {
-        std::cerr << "poll task start s.size() == " << s.size() << "\n";
-        co_await s.schedule();
-        std::cerr << "poll task polling s.size() == " << s.size() << "\n";
-        auto status = co_await s.poll(trigger_fd, coro::poll_op::read);
+        std::cerr << "poll task start s.size() == " << s->size() << "\n";
+        co_await s->schedule();
+        std::cerr << "poll task polling s.size() == " << s->size() << "\n";
+        auto status = co_await s->poll(trigger_fd, coro::poll_op::read);
         REQUIRE(status == coro::poll_status::event);
-        std::cerr << "poll task exiting s.size() == " << s.size() << "\n";
+        std::cerr << "poll task exiting s.size() == " << s->size() << "\n";
         co_return;
     };
 
     auto make_poll_write_task = [&]() -> coro::task<void>
     {
-        std::cerr << "write task start s.size() == " << s.size() << "\n";
-        co_await s.schedule();
+        std::cerr << "write task start s.size() == " << s->size() << "\n";
+        co_await s->schedule();
         uint64_t value{42};
-        std::cerr << "write task writing s.size() == " << s.size() << "\n";
+        std::cerr << "write task writing s.size() == " << s->size() << "\n";
         auto unused = write(trigger_fd, &value, sizeof(value));
         (void)unused;
-        std::cerr << "write task exiting s.size() == " << s.size() << "\n";
+        std::cerr << "write task exiting s.size() == " << s->size() << "\n";
         co_return;
     };
 
@@ -721,7 +707,7 @@ TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
     // Now process them to completion.
     while (true)
     {
-        auto remaining = s.process_events(100ms);
+        auto remaining = s->process_events(100ms);
         std::cerr << "remaining " << remaining << "\n";
         if (remaining == 0)
         {
@@ -729,20 +715,21 @@ TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
         }
     };
 
-    std::cerr << "io_scheduler.size() before shutdown = " << s.size() << "\n";
-    s.shutdown();
-    std::cerr << "io_scheduler.size() after shutdown = " << s.size() << "\n";
-    REQUIRE(s.empty());
+    std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
+    s->shutdown();
+    std::cerr << "io_scheduler.size() after shutdown = " << s->size() << "\n";
+    REQUIRE(s->empty());
     close(trigger_fd);
 }
 
 TEST_CASE("io_scheduler task throws", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto func = [&]() -> coro::task<uint64_t>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         throw std::runtime_error{"I always throw."};
         co_return 42;
     };
@@ -752,13 +739,14 @@ TEST_CASE("io_scheduler task throws", "[io_scheduler]")
 
 TEST_CASE("io_scheduler task throws after resume", "[io_scheduler]")
 {
-    coro::io_scheduler s{coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}}};
+    auto s = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
     auto make_thrower = [&]() -> coro::task<bool>
     {
-        co_await s.schedule();
+        co_await s->schedule();
         std::cerr << "Throwing task is doing some work...\n";
-        co_await s.yield();
+        co_await s->yield();
         throw std::runtime_error{"I always throw."};
         co_return true;
     };

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -83,7 +83,7 @@ TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
 #ifdef LIBCORO_FEATURE_NETWORKING
 TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]")
 {
-    auto tp = std::make_shared<coro::io_scheduler>(
+    auto tp = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 8}});
     coro::shared_mutex<coro::io_scheduler> m{tp};
 


### PR DESCRIPTION
The check for m_size > 0 was keeping threads awake in a spin state until all tasks completed. This correctl now uses m_queue.size() behind the lock to correctly only wake up threads on the condition variable when tasks are waiting to be processed.

Closes #262