### PR TITLE
Upgrade supported opensuse/leap:15.6

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -433,7 +433,7 @@ Transfer/sec:     18.33MB
 
  * ubuntu:20.04, 22.04
  * fedora:32-40
- * openSUSE/leap:15.2
+ * openSUSE/leap:15.6
  * Windows 2022
  * Emscripten 3.1.45
  * MacOS 12

--- a/.github/workflows/ci-opensuse.yml
+++ b/.github/workflows/ci-opensuse.yml
@@ -12,7 +12,7 @@ jobs:
                 cxx_standard: [20]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
         container:
-            image: opensuse/leap:15.2
+            image: opensuse/leap:15.6
         steps:
             -   name: zypper
                 run: |

--- a/README.md
+++ b/README.md
@@ -1222,7 +1222,7 @@ Transfer/sec:     18.33MB
 
  * ubuntu:20.04, 22.04
  * fedora:32-40
- * openSUSE/leap:15.2
+ * openSUSE/leap:15.6
  * Windows 2022
  * Emscripten 3.1.45
  * MacOS 12


### PR DESCRIPTION
15.2 is having issues with nodejs and glibc

/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node

Closes #274