### PR TITLE
Upgrade emscripten build

### DIFF
--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -21,7 +21,8 @@ jobs:
                     apt-get install -y \
                         cmake \
                         git \
-                        ninja-build
+                        ninja-build \
+                        nodejs
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:
@@ -50,4 +51,4 @@ jobs:
                     cd emsdk
                     . ./emsdk_env.sh
                     cd ../Release
-                    node --experimental-wasm-eh ./test/libcoro_test.js
+                    node --experimental-wasm-threads --experimental-wasm-bulk-memory ./test/libcoro_test.js


### PR DESCRIPTION
Currently failing due to nodejs dependencies:

Setting up EMSDK environment (suppress these messages with EMSDK_QUIET=1) Adding directories to PATH:
PATH += /__w/libcoro/libcoro/emsdk
PATH += /__w/libcoro/libcoro/emsdk/upstream/emscripten PATH += /__w/libcoro/libcoro/emsdk/node/20.18.0_64bit/bin

Setting environment variables:
PATH = /__w/libcoro/libcoro/emsdk:/__w/libcoro/libcoro/emsdk/upstream/emscripten:/__w/libcoro/libcoro/emsdk/node/20.18.0_64bit/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin EMSDK = /__w/libcoro/libcoro/emsdk
EMSDK_NODE = /__w/libcoro/libcoro/emsdk/node/20.18.0_64bit/bin/node node: bad option: --experimental-wasm-eh