### PR TITLE
Disable mac ci builds

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,45 +1,45 @@
-name: ci-macos
+# name: ci-macos
 
-on: [pull_request, workflow_dispatch]
+# on: [pull_request, workflow_dispatch]
 
-jobs:
-    macos:
-        name: macos-12
-        runs-on: macos-12
-        strategy:
-            fail-fast: false
-            matrix:
-                clang_version: [17]
-                cxx_standard: [20, 23]
-                libcoro_feature_networking: [ {enabled: OFF, tls: OFF} ]
-                libcoro_build_shared_libs: [OFF, ON]
-        steps:
-            -   name: Install Dependencies
-                run: |
-                    brew update
-                    brew install llvm@${{ matrix.clang_version }}
-                    brew install ninja
-            -   name: Checkout
-                uses: actions/checkout@v4
-                with:
-                    submodules: recursive
-            -   name: Release
-                run: |
-                    brew --prefix llvm@17
-                    mkdir Release
-                    cd Release
-                    cmake \
-                        -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
-                        -DCMAKE_C_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
-                        -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
-                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
-                        -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
-                        -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
-                        -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
-                        ..
-                    cmake --build . --config Release
-            -   name: Test
-                run: |
-                    cd Release
-                    ctest --build-config Release -VV
+# jobs:
+#     macos:
+#         name: macos-12
+#         runs-on: macos-12
+#         strategy:
+#             fail-fast: false
+#             matrix:
+#                 clang_version: [17]
+#                 cxx_standard: [20, 23]
+#                 libcoro_feature_networking: [ {enabled: OFF, tls: OFF} ]
+#                 libcoro_build_shared_libs: [OFF, ON]
+#         steps:
+#             -   name: Install Dependencies
+#                 run: |
+#                     brew update
+#                     brew install llvm@${{ matrix.clang_version }}
+#                     brew install ninja
+#             -   name: Checkout
+#                 uses: actions/checkout@v4
+#                 with:
+#                     submodules: recursive
+#             -   name: Release
+#                 run: |
+#                     brew --prefix llvm@17
+#                     mkdir Release
+#                     cd Release
+#                     cmake \
+#                         -GNinja \
+#                         -DCMAKE_BUILD_TYPE=Release \
+#                         -DCMAKE_C_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
+#                         -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
+#                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+#                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
+#                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+#                         -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
+#                         ..
+#                     cmake --build . --config Release
+#             -   name: Test
+#                 run: |
+#                     cd Release
+#                     ctest --build-config Release -VV


### PR DESCRIPTION
I don't have a mac to test on and I've been unable to get the CI jobs to work.. debugging the github actions isn't straightforward. These jobs will be disabled until someone can provide a working CI job script.

Closes #289