### PR TITLE
Remove lambda captures

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -56,6 +56,7 @@ Its important to note with coroutines that _any_ `co_await` has the potential to
 
 The recommendation is to not use lambda captures and instead pass any data into the coroutine via its function arguments to guarantee the argument lifetimes. Lambda captures will be destroyed at the coroutines first suspension point so if they are used past that point it will result in a use after free bug.
 
+
 ### sync_wait
 The `sync_wait` construct is meant to be used outside of a coroutine context to block the calling thread until the coroutine has completed. The coroutine can be executed on the calling thread or scheduled on one of libcoro's schedulers.
 

--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -40,7 +40,7 @@
     - coro::net::tls::client (OpenSSL)
     - coro::net::tls::server (OpenSSL)
     - coro::net::udp::peer
-* 
+*
 * [Requirements](#requirements)
 * [Build Instructions](#build-instructions)
 * [Contributing](#contributing)
@@ -51,6 +51,12 @@
 ### A note on co_await and threads
 Its important to note with coroutines that _any_ `co_await` has the potential to switch the underyling thread that is executing the currently executing coroutine if the scheduler used has more than 1 thread. In general this shouldn't affect the way any user of the library would write code except for `thread_local`. Usage of `thread_local` should be extremely careful and _never_ used across any `co_await` boundary do to thread switching and work stealing on libcoro's schedulers. The only way this is safe is by using a `coro::thread_pool` with 1 thread or an inline `io_scheduler` which also only has 1 thread.
 
+### A note on lambda captures (do not use them!)
+[C++ Core Guidelines - CP.51: Do no use capturing lambdas that are coroutines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rcoro-capture)
+
+The recommendation is to not use lambda captures and instead pass any data into the coroutine via its function arguments to guarantee the argument lifetimes. Lambda captures will be destroyed at the coroutines first suspension point so if they are used past that point it will result in a use after free bug.
+
+
 ### sync_wait
 The `sync_wait` construct is meant to be used outside of a coroutine context to block the calling thread until the coroutine has completed. The coroutine can be executed on the calling thread or scheduled on one of libcoro's schedulers.
 
@@ -60,7 +66,7 @@ ${EXAMPLE_CORO_SYNC_WAIT}
 
 Expected output:
 ```bash
-$ ./examples/coro_sync_wait 
+$ ./examples/coro_sync_wait
 Inline Result = 10
 Offload Result = 20
 ```
@@ -74,7 +80,7 @@ ${EXAMPLE_CORO_WHEN_ALL}
 
 Expected output:
 ```bash
-$ ./examples/coro_when_all 
+$ ./examples/coro_when_all
 2
 4
 6
@@ -520,7 +526,7 @@ If you open a PR for a bugfix or new feature please include tests to verify that
 
 File bug reports, feature requests and questions using [GitHub libcoro Issues](https://github.com/jbaldwin/libcoro/issues)
 
-Copyright © 2020-2024 Josh Baldwin
+Copyright © 2020-2025 Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B20-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -56,7 +56,6 @@ Its important to note with coroutines that _any_ `co_await` has the potential to
 
 The recommendation is to not use lambda captures and instead pass any data into the coroutine via its function arguments to guarantee the argument lifetimes. Lambda captures will be destroyed at the coroutines first suspension point so if they are used past that point it will result in a use after free bug.
 
-
 ### sync_wait
 The `sync_wait` construct is meant to be used outside of a coroutine context to block the calling thread until the coroutine has completed. The coroutine can be executed on the calling thread or scheduled on one of libcoro's schedulers.
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ int main()
     coro::event e;
 
     // These tasks will wait until the given event has been set before advancing.
-    auto make_wait_task = [](const coro::event& e, uint64_t i) -> coro::task<void> {
+    auto make_wait_task = [](const coro::event& e, uint64_t i) -> coro::task<void>
+    {
         std::cout << "task " << i << " is waiting on the event...\n";
         co_await e;
         std::cout << "task " << i << " event triggered, now resuming.\n";
@@ -332,7 +333,8 @@ int main()
     };
 
     // This task will trigger the event allowing all waiting tasks to proceed.
-    auto make_set_task = [](coro::event& e) -> coro::task<void> {
+    auto make_set_task = [](coro::event& e) -> coro::task<void>
+    {
         std::cout << "set task is triggering the event\n";
         e.set();
         co_return;
@@ -453,7 +455,9 @@ int main()
     std::vector<uint64_t> output{};
     coro::mutex           mutex;
 
-    auto make_critical_section_task = [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void> {
+    auto make_critical_section_task =
+        [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void>
+    {
         co_await tp.schedule();
         // To acquire a mutex lock co_await its lock() function.  Upon acquiring the lock the
         // lock() function returns a coro::scoped_lock that holds the mutex and automatically
@@ -510,10 +514,13 @@ int main()
     // to also show the interleaving of coroutines acquiring the shared lock in shared and
     // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
-    auto               tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
     coro::shared_mutex<coro::thread_pool> mutex{tp};
 
-    auto make_shared_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex, uint64_t i) -> coro::task<void> {
+    auto make_shared_task = [](std::shared_ptr<coro::thread_pool>     tp,
+                               coro::shared_mutex<coro::thread_pool>& mutex,
+                               uint64_t                               i) -> coro::task<void>
+    {
         co_await tp->schedule();
         {
             std::cerr << "shared task " << i << " lock_shared()\n";
@@ -527,7 +534,9 @@ int main()
         co_return;
     };
 
-    auto make_exclusive_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void> {
+    auto make_exclusive_task = [](std::shared_ptr<coro::thread_pool>     tp,
+                                  coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void>
+    {
         co_await tp->schedule();
 
         std::cerr << "exclusive task lock()\n";
@@ -597,7 +606,8 @@ int main()
     coro::thread_pool tp{coro::thread_pool::options{.thread_count = 8}};
     coro::semaphore   semaphore{2};
 
-    auto make_rate_limited_task = [](coro::thread_pool& tp, coro::semaphore& semaphore, uint64_t task_num) -> coro::task<void>
+    auto make_rate_limited_task =
+        [](coro::thread_pool& tp, coro::semaphore& semaphore, uint64_t task_num) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -650,7 +660,8 @@ int main()
 
     std::vector<coro::task<void>> tasks{};
 
-    auto make_producer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m) -> coro::task<void>
+    auto make_producer_task =
+        [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -675,7 +686,8 @@ int main()
         co_return;
     };
 
-    auto make_consumer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m, size_t id) -> coro::task<void>
+    auto make_consumer_task =
+        [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m, size_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -743,17 +755,17 @@ int main()
         // Upon starting each worker thread an optional lambda callback with the worker's
         // index can be called to make thread changes, perhaps priority or change the thread's
         // name.
-        .on_thread_start_functor = [](std::size_t worker_idx) -> void {
-            std::cout << "thread pool worker " << worker_idx << " is starting up.\n";
-        },
+        .on_thread_start_functor = [](std::size_t worker_idx) -> void
+        { std::cout << "thread pool worker " << worker_idx << " is starting up.\n"; },
         // Upon stopping each worker thread an optional lambda callback with the worker's
         // index can b called.
-        .on_thread_stop_functor = [](std::size_t worker_idx) -> void {
-            std::cout << "thread pool worker " << worker_idx << " is shutting down.\n";
-        }}};
+        .on_thread_stop_functor = [](std::size_t worker_idx) -> void
+        { std::cout << "thread pool worker " << worker_idx << " is shutting down.\n"; }}};
 
-    auto primary_task = [](coro::thread_pool& tp) -> coro::task<uint64_t> {
-        auto offload_task = [](coro::thread_pool& tp, uint64_t child_idx) -> coro::task<uint64_t> {
+    auto primary_task = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+    {
+        auto offload_task = [](coro::thread_pool& tp, uint64_t child_idx) -> coro::task<uint64_t>
+        {
             // Start by scheduling this offload worker task onto the thread pool.
             co_await tp.schedule();
             // Now any code below this schedule() line will be executed on one of the thread pools

--- a/examples/coro_event.cpp
+++ b/examples/coro_event.cpp
@@ -6,7 +6,8 @@ int main()
     coro::event e;
 
     // These tasks will wait until the given event has been set before advancing.
-    auto make_wait_task = [](const coro::event& e, uint64_t i) -> coro::task<void> {
+    auto make_wait_task = [](const coro::event& e, uint64_t i) -> coro::task<void>
+    {
         std::cout << "task " << i << " is waiting on the event...\n";
         co_await e;
         std::cout << "task " << i << " event triggered, now resuming.\n";
@@ -14,7 +15,8 @@ int main()
     };
 
     // This task will trigger the event allowing all waiting tasks to proceed.
-    auto make_set_task = [](coro::event& e) -> coro::task<void> {
+    auto make_set_task = [](coro::event& e) -> coro::task<void>
+    {
         std::cout << "set task is triggering the event\n";
         e.set();
         co_return;

--- a/examples/coro_io_scheduler.cpp
+++ b/examples/coro_io_scheduler.cpp
@@ -26,7 +26,7 @@ int main()
             },
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
 
-    auto make_server_task = [&]() -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler) -> coro::task<void>
     {
         // Start by creating a tcp server, we'll do this before putting it into the scheduler so
         // it is immediately available for the client to connect since this will create a socket,
@@ -114,7 +114,7 @@ int main()
         co_return;
     };
 
-    auto make_client_task = [&]() -> coro::task<void>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler) -> coro::task<void>
     {
         // Immediately schedule onto the scheduler.
         co_await scheduler->schedule();
@@ -146,5 +146,5 @@ int main()
     };
 
     // Create and wait for the server and client tasks to complete.
-    coro::sync_wait(coro::when_all(make_server_task(), make_client_task()));
+    coro::sync_wait(coro::when_all(make_server_task(scheduler), make_client_task(scheduler)));
 }

--- a/examples/coro_mutex.cpp
+++ b/examples/coro_mutex.cpp
@@ -7,7 +7,7 @@ int main()
     std::vector<uint64_t> output{};
     coro::mutex           mutex;
 
-    auto make_critical_section_task = [&](uint64_t i) -> coro::task<void> {
+    auto make_critical_section_task = [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void> {
         co_await tp.schedule();
         // To acquire a mutex lock co_await its lock() function.  Upon acquiring the lock the
         // lock() function returns a coro::scoped_lock that holds the mutex and automatically
@@ -24,7 +24,7 @@ int main()
     tasks.reserve(num_tasks);
     for (size_t i = 1; i <= num_tasks; ++i)
     {
-        tasks.emplace_back(make_critical_section_task(i));
+        tasks.emplace_back(make_critical_section_task(tp, mutex, output, i));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/examples/coro_mutex.cpp
+++ b/examples/coro_mutex.cpp
@@ -7,7 +7,9 @@ int main()
     std::vector<uint64_t> output{};
     coro::mutex           mutex;
 
-    auto make_critical_section_task = [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void> {
+    auto make_critical_section_task =
+        [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void>
+    {
         co_await tp.schedule();
         // To acquire a mutex lock co_await its lock() function.  Upon acquiring the lock the
         // lock() function returns a coro::scoped_lock that holds the mutex and automatically

--- a/examples/coro_ring_buffer.cpp
+++ b/examples/coro_ring_buffer.cpp
@@ -11,7 +11,7 @@ int main()
 
     std::vector<coro::task<void>> tasks{};
 
-    auto make_producer_task = [&]() -> coro::task<void>
+    auto make_producer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -36,7 +36,7 @@ int main()
         co_return;
     };
 
-    auto make_consumer_task = [&](size_t id) -> coro::task<void>
+    auto make_consumer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m, size_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -65,10 +65,10 @@ int main()
     // Create N consumers
     for (size_t i = 0; i < consumers; ++i)
     {
-        tasks.emplace_back(make_consumer_task(i));
+        tasks.emplace_back(make_consumer_task(tp, rb, m, i));
     }
     // Create 1 producer.
-    tasks.emplace_back(make_producer_task());
+    tasks.emplace_back(make_producer_task(tp, rb, m));
 
     // Wait for all the values to be produced and consumed through the ring buffer.
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/examples/coro_ring_buffer.cpp
+++ b/examples/coro_ring_buffer.cpp
@@ -11,7 +11,8 @@ int main()
 
     std::vector<coro::task<void>> tasks{};
 
-    auto make_producer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m) -> coro::task<void>
+    auto make_producer_task =
+        [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -36,7 +37,8 @@ int main()
         co_return;
     };
 
-    auto make_consumer_task = [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m, size_t id) -> coro::task<void>
+    auto make_consumer_task =
+        [](coro::thread_pool& tp, coro::ring_buffer<uint64_t, 16>& rb, coro::mutex& m, size_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 

--- a/examples/coro_semaphore.cpp
+++ b/examples/coro_semaphore.cpp
@@ -7,7 +7,7 @@ int main()
     coro::thread_pool tp{coro::thread_pool::options{.thread_count = 8}};
     coro::semaphore   semaphore{2};
 
-    auto make_rate_limited_task = [&](uint64_t task_num) -> coro::task<void>
+    auto make_rate_limited_task = [](coro::thread_pool& tp, coro::semaphore& semaphore, uint64_t task_num) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -30,7 +30,7 @@ int main()
     std::vector<coro::task<void>> tasks{};
     for (size_t i = 1; i <= num_tasks; ++i)
     {
-        tasks.emplace_back(make_rate_limited_task(i));
+        tasks.emplace_back(make_rate_limited_task(tp, semaphore, i));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/examples/coro_semaphore.cpp
+++ b/examples/coro_semaphore.cpp
@@ -7,7 +7,8 @@ int main()
     coro::thread_pool tp{coro::thread_pool::options{.thread_count = 8}};
     coro::semaphore   semaphore{2};
 
-    auto make_rate_limited_task = [](coro::thread_pool& tp, coro::semaphore& semaphore, uint64_t task_num) -> coro::task<void>
+    auto make_rate_limited_task =
+        [](coro::thread_pool& tp, coro::semaphore& semaphore, uint64_t task_num) -> coro::task<void>
     {
         co_await tp.schedule();
 

--- a/examples/coro_shared_mutex.cpp
+++ b/examples/coro_shared_mutex.cpp
@@ -8,10 +8,13 @@ int main()
     // to also show the interleaving of coroutines acquiring the shared lock in shared and
     // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
-    auto               tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
     coro::shared_mutex<coro::thread_pool> mutex{tp};
 
-    auto make_shared_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex, uint64_t i) -> coro::task<void> {
+    auto make_shared_task = [](std::shared_ptr<coro::thread_pool>     tp,
+                               coro::shared_mutex<coro::thread_pool>& mutex,
+                               uint64_t                               i) -> coro::task<void>
+    {
         co_await tp->schedule();
         {
             std::cerr << "shared task " << i << " lock_shared()\n";
@@ -25,7 +28,9 @@ int main()
         co_return;
     };
 
-    auto make_exclusive_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void> {
+    auto make_exclusive_task = [](std::shared_ptr<coro::thread_pool>     tp,
+                                  coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void>
+    {
         co_await tp->schedule();
 
         std::cerr << "exclusive task lock()\n";

--- a/examples/coro_shared_mutex.cpp
+++ b/examples/coro_shared_mutex.cpp
@@ -9,9 +9,9 @@ int main()
     // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
     auto               tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
-    coro::shared_mutex mutex{tp};
+    coro::shared_mutex<coro::thread_pool> mutex{tp};
 
-    auto make_shared_task = [&](uint64_t i) -> coro::task<void> {
+    auto make_shared_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex, uint64_t i) -> coro::task<void> {
         co_await tp->schedule();
         {
             std::cerr << "shared task " << i << " lock_shared()\n";
@@ -25,7 +25,7 @@ int main()
         co_return;
     };
 
-    auto make_exclusive_task = [&]() -> coro::task<void> {
+    auto make_exclusive_task = [](std::shared_ptr<coro::thread_pool> tp, coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void> {
         co_await tp->schedule();
 
         std::cerr << "exclusive task lock()\n";
@@ -41,14 +41,14 @@ int main()
     std::vector<coro::task<void>> tasks{};
     for (size_t i = 1; i <= num_tasks; ++i)
     {
-        tasks.emplace_back(make_shared_task(i));
+        tasks.emplace_back(make_shared_task(tp, mutex, i));
     }
     // Create an exclusive task.
-    tasks.emplace_back(make_exclusive_task());
+    tasks.emplace_back(make_exclusive_task(tp, mutex));
     // Create 3 more shared tasks that will be blocked until the exclusive task completes.
     for (size_t i = num_tasks + 1; i <= num_tasks * 2; ++i)
     {
-        tasks.emplace_back(make_shared_task(i));
+        tasks.emplace_back(make_shared_task(tp, mutex, i));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/examples/coro_sync_wait.cpp
+++ b/examples/coro_sync_wait.cpp
@@ -14,11 +14,12 @@ int main()
     std::cout << "Inline Result = " << result << "\n";
 
     // We'll make a 1 thread coro::thread_pool to demonstrate offloading the task's
-    // execution to another thread.  We'll capture the thread pool in the lambda,
-    // note that you will need to guarantee the thread pool outlives the coroutine.
+    // execution to another thread.  We'll pass the thread pool as a parameter so
+    // the task can be scheduled.
+    // Note that you will need to guarantee the thread pool outlives the coroutine.
     coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
 
-    auto make_task_offload = [&tp](uint64_t x) -> coro::task<uint64_t>
+    auto make_task_offload = [](coro::thread_pool& tp, uint64_t x) -> coro::task<uint64_t>
     {
         co_await tp.schedule(); // Schedules execution on the thread pool.
         co_return x + x;        // This will execute on the thread pool.
@@ -26,6 +27,6 @@ int main()
 
     // This will still block the calling thread, but it will now offload to the
     // coro::thread_pool since the coroutine task is immediately scheduled.
-    result = coro::sync_wait(make_task_offload(10));
+    result = coro::sync_wait(make_task_offload(tp, 10));
     std::cout << "Offload Result = " << result << "\n";
 }

--- a/examples/coro_task.cpp
+++ b/examples/coro_task.cpp
@@ -3,13 +3,13 @@
 
 int main()
 {
-    // Task that takes a value and doubles it.
-    auto double_task = [](uint64_t x) -> coro::task<uint64_t> { co_return x * 2; };
-
     // Create a task that awaits the doubling of its given value and
     // then returns the result after adding 5.
-    auto double_and_add_5_task = [&](uint64_t input) -> coro::task<uint64_t>
+    auto double_and_add_5_task = [](uint64_t input) -> coro::task<uint64_t>
     {
+        // Task that takes a value and doubles it.
+        auto double_task = [](uint64_t x) -> coro::task<uint64_t> { co_return x * 2; };
+
         auto doubled = co_await double_task(input);
         co_return doubled + 5;
     };

--- a/examples/coro_thread_pool.cpp
+++ b/examples/coro_thread_pool.cpp
@@ -12,17 +12,17 @@ int main()
         // Upon starting each worker thread an optional lambda callback with the worker's
         // index can be called to make thread changes, perhaps priority or change the thread's
         // name.
-        .on_thread_start_functor = [](std::size_t worker_idx) -> void {
-            std::cout << "thread pool worker " << worker_idx << " is starting up.\n";
-        },
+        .on_thread_start_functor = [](std::size_t worker_idx) -> void
+        { std::cout << "thread pool worker " << worker_idx << " is starting up.\n"; },
         // Upon stopping each worker thread an optional lambda callback with the worker's
         // index can b called.
-        .on_thread_stop_functor = [](std::size_t worker_idx) -> void {
-            std::cout << "thread pool worker " << worker_idx << " is shutting down.\n";
-        }}};
+        .on_thread_stop_functor = [](std::size_t worker_idx) -> void
+        { std::cout << "thread pool worker " << worker_idx << " is shutting down.\n"; }}};
 
-    auto primary_task = [](coro::thread_pool& tp) -> coro::task<uint64_t> {
-        auto offload_task = [](coro::thread_pool& tp, uint64_t child_idx) -> coro::task<uint64_t> {
+    auto primary_task = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+    {
+        auto offload_task = [](coro::thread_pool& tp, uint64_t child_idx) -> coro::task<uint64_t>
+        {
             // Start by scheduling this offload worker task onto the thread pool.
             co_await tp.schedule();
             // Now any code below this schedule() line will be executed on one of the thread pools

--- a/examples/coro_thread_pool.cpp
+++ b/examples/coro_thread_pool.cpp
@@ -21,44 +21,44 @@ int main()
             std::cout << "thread pool worker " << worker_idx << " is shutting down.\n";
         }}};
 
-    auto offload_task = [&](uint64_t child_idx) -> coro::task<uint64_t> {
-        // Start by scheduling this offload worker task onto the thread pool.
-        co_await tp.schedule();
-        // Now any code below this schedule() line will be executed on one of the thread pools
-        // worker threads.
+    auto primary_task = [](coro::thread_pool& tp) -> coro::task<uint64_t> {
+        auto offload_task = [](coro::thread_pool& tp, uint64_t child_idx) -> coro::task<uint64_t> {
+            // Start by scheduling this offload worker task onto the thread pool.
+            co_await tp.schedule();
+            // Now any code below this schedule() line will be executed on one of the thread pools
+            // worker threads.
 
-        // Mimic some expensive task that should be run on a background thread...
-        std::random_device              rd;
-        std::mt19937                    gen{rd()};
-        std::uniform_int_distribution<> d{0, 1};
+            // Mimic some expensive task that should be run on a background thread...
+            std::random_device              rd;
+            std::mt19937                    gen{rd()};
+            std::uniform_int_distribution<> d{0, 1};
 
-        size_t calculation{0};
-        for (size_t i = 0; i < 1'000'000; ++i)
-        {
-            calculation += d(gen);
-
-            // Lets be nice and yield() to let other coroutines on the thread pool have some cpu
-            // time.  This isn't necessary but is illustrated to show how tasks can cooperatively
-            // yield control at certain points of execution.  Its important to never call the
-            // std::this_thread::sleep_for() within the context of a coroutine, that will block
-            // and other coroutines which are ready for execution from starting, always use yield()
-            // or within the context of a coro::io_scheduler you can use yield_for(amount).
-            if (i == 500'000)
+            size_t calculation{0};
+            for (size_t i = 0; i < 1'000'000; ++i)
             {
-                std::cout << "Task " << child_idx << " is yielding()\n";
-                co_await tp.yield();
-            }
-        }
-        co_return calculation;
-    };
+                calculation += d(gen);
 
-    auto primary_task = [&]() -> coro::task<uint64_t> {
+                // Lets be nice and yield() to let other coroutines on the thread pool have some cpu
+                // time.  This isn't necessary but is illustrated to show how tasks can cooperatively
+                // yield control at certain points of execution.  Its important to never call the
+                // std::this_thread::sleep_for() within the context of a coroutine, that will block
+                // and other coroutines which are ready for execution from starting, always use yield()
+                // or within the context of a coro::io_scheduler you can use yield_for(amount).
+                if (i == 500'000)
+                {
+                    std::cout << "Task " << child_idx << " is yielding()\n";
+                    co_await tp.yield();
+                }
+            }
+            co_return calculation;
+        };
+
         const size_t                      num_children{10};
         std::vector<coro::task<uint64_t>> child_tasks{};
         child_tasks.reserve(num_children);
         for (size_t i = 0; i < num_children; ++i)
         {
-            child_tasks.emplace_back(offload_task(i));
+            child_tasks.emplace_back(offload_task(tp, i));
         }
 
         // Wait for the thread pool workers to process all child tasks.
@@ -73,6 +73,6 @@ int main()
         co_return calculation;
     };
 
-    auto result = coro::sync_wait(primary_task());
+    auto result = coro::sync_wait(primary_task(tp));
     std::cout << "calculated thread pool result = " << result << "\n";
 }

--- a/include/coro/detail/task_self_deleting.hpp
+++ b/include/coro/detail/task_self_deleting.hpp
@@ -27,6 +27,7 @@ public:
     auto unhandled_exception() -> void;
 
     auto task_container_size(std::atomic<std::size_t>& task_container_size) -> void;
+
 private:
     /**
      * The coro::task_container<executor_t> m_size member to decrement upon the coroutine completing.
@@ -58,7 +59,11 @@ public:
     auto operator=(task_self_deleting&&) -> task_self_deleting&;
 
     auto promise() -> promise_self_deleting& { return *m_promise; }
-    auto handle() -> std::coroutine_handle<promise_self_deleting> { return std::coroutine_handle<promise_self_deleting>::from_promise(*m_promise); }
+    auto handle() -> std::coroutine_handle<promise_self_deleting>
+    {
+        return std::coroutine_handle<promise_self_deleting>::from_promise(*m_promise);
+    }
+
 private:
     promise_self_deleting* m_promise{nullptr};
 };

--- a/include/coro/task_container.hpp
+++ b/include/coro/task_container.hpp
@@ -10,14 +10,13 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <thread>
 #include <queue>
+#include <thread>
 #include <vector>
 
 namespace coro
 {
 class io_scheduler;
-
 
 template<concepts::executor executor_type>
 class task_container
@@ -28,9 +27,7 @@ public:
      *           from a coro::io_scheduler, this would usually be that coro::io_scheduler instance.
      * @param opts Task container options.
      */
-    task_container(
-        std::shared_ptr<executor_type> e)
-        : m_executor(std::move(e))
+    task_container(std::shared_ptr<executor_type> e) : m_executor(std::move(e))
     {
         if (m_executor == nullptr)
         {

--- a/include/coro/when_all.hpp
+++ b/include/coro/when_all.hpp
@@ -5,11 +5,11 @@
 #include "coro/detail/void_value.hpp"
 
 #include <atomic>
+#include <cassert>
 #include <coroutine>
 #include <ranges>
 #include <tuple>
 #include <vector>
-#include <cassert>
 
 namespace coro
 {

--- a/src/detail/task_self_deleting.cpp
+++ b/src/detail/task_self_deleting.cpp
@@ -12,13 +12,11 @@ promise_self_deleting::promise_self_deleting()
 
 promise_self_deleting::~promise_self_deleting()
 {
-
 }
 
 promise_self_deleting::promise_self_deleting(promise_self_deleting&& other)
     : m_task_container_size(std::exchange(other.m_task_container_size, nullptr))
 {
-
 }
 
 auto promise_self_deleting::operator=(promise_self_deleting&& other) -> promise_self_deleting&
@@ -68,21 +66,16 @@ auto promise_self_deleting::task_container_size(std::atomic<std::size_t>& task_c
     m_task_container_size = &task_container_size;
 }
 
-task_self_deleting::task_self_deleting(promise_self_deleting& promise)
-    : m_promise(&promise)
+task_self_deleting::task_self_deleting(promise_self_deleting& promise) : m_promise(&promise)
 {
-
 }
 
 task_self_deleting::~task_self_deleting()
 {
-
 }
 
-task_self_deleting::task_self_deleting(task_self_deleting&& other)
-    : m_promise(other.m_promise)
+task_self_deleting::task_self_deleting(task_self_deleting&& other) : m_promise(other.m_promise)
 {
-
 }
 
 auto task_self_deleting::operator=(task_self_deleting&& other) -> task_self_deleting&

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -34,7 +34,7 @@ auto mutex::lock_operation::await_ready() const noexcept -> bool
 auto mutex::lock_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
 {
     m_awaiting_coroutine = awaiting_coroutine;
-    void* current = m_mutex.m_state.load(std::memory_order::acquire);
+    void* current        = m_mutex.m_state.load(std::memory_order::acquire);
     void* new_value;
 
     const void* unlocked_value = m_mutex.unlocked_value();

--- a/test/bench.cpp
+++ b/test/bench.cpp
@@ -31,7 +31,7 @@ TEST_CASE("benchmark counter func direct call", "[benchmark]")
 {
     constexpr std::size_t iterations = default_iterations;
     std::atomic<uint64_t> counter{0};
-    auto                  func = [&]() -> void
+    auto                  func = [](std::atomic<uint64_t>& counter) -> void
     {
         counter.fetch_add(1, std::memory_order::relaxed);
         return;
@@ -41,7 +41,7 @@ TEST_CASE("benchmark counter func direct call", "[benchmark]")
 
     for (std::size_t i = 0; i < iterations; ++i)
     {
-        func();
+        func(counter);
     }
 
     print_stats("benchmark counter func direct call", iterations, start, sc::now());
@@ -244,7 +244,7 @@ TEST_CASE("benchmark counter task scheduler{1} yield", "[benchmark]")
     std::vector<coro::task<void>> tasks{};
     tasks.reserve(iterations);
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await s->schedule();
         co_await s->yield();
@@ -256,7 +256,7 @@ TEST_CASE("benchmark counter task scheduler{1} yield", "[benchmark]")
 
     for (std::size_t i = 0; i < iterations; ++i)
     {
-        tasks.emplace_back(make_task());
+        tasks.emplace_back(make_task(s, counter));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
@@ -279,7 +279,7 @@ TEST_CASE("benchmark counter task scheduler{1} yield_for", "[benchmark]")
     std::vector<coro::task<void>> tasks{};
     tasks.reserve(iterations);
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await s->schedule();
         co_await s->yield_for(std::chrono::milliseconds{1});
@@ -291,7 +291,7 @@ TEST_CASE("benchmark counter task scheduler{1} yield_for", "[benchmark]")
 
     for (std::size_t i = 0; i < iterations; ++i)
     {
-        tasks.emplace_back(make_task());
+        tasks.emplace_back(make_task(s, counter));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
@@ -322,7 +322,7 @@ TEST_CASE("benchmark counter task scheduler await event from another coroutine",
 
     std::atomic<uint64_t> counter{0};
 
-    auto wait_func = [&](std::size_t index) -> coro::task<void>
+    auto wait_func = [](std::shared_ptr<coro::io_scheduler> s, std::vector<std::unique_ptr<coro::event>>& events, std::atomic<uint64_t>& counter, std::size_t index) -> coro::task<void>
     {
         co_await s->schedule();
         co_await *events[index];
@@ -330,7 +330,7 @@ TEST_CASE("benchmark counter task scheduler await event from another coroutine",
         co_return;
     };
 
-    auto resume_func = [&](std::size_t index) -> coro::task<void>
+    auto resume_func = [](std::shared_ptr<coro::io_scheduler> s, std::vector<std::unique_ptr<coro::event>>& events, std::size_t index) -> coro::task<void>
     {
         co_await s->schedule();
         events[index]->set();
@@ -341,8 +341,8 @@ TEST_CASE("benchmark counter task scheduler await event from another coroutine",
 
     for (std::size_t i = 0; i < iterations; ++i)
     {
-        tasks.emplace_back(wait_func(i));
-        tasks.emplace_back(resume_func(i));
+        tasks.emplace_back(wait_func(s, events, counter, i));
+        tasks.emplace_back(resume_func(s, events, i));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
@@ -372,41 +372,41 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark]")
     std::atomic<uint64_t> accepted{0};
     std::atomic<uint64_t> clients_completed{0};
 
-    auto make_on_connection_task = [&](coro::net::tcp::client client, coro::latch& wait_for_clients) -> coro::task<void>
-    {
-        std::string in(64, '\0');
-
-        // Echo the messages until the socket is closed.
-        while (true)
-        {
-            auto pstatus = co_await client.poll(coro::poll_op::read);
-            REQUIRE(pstatus == coro::poll_status::event);
-
-            auto [rstatus, rspan] = client.recv(in);
-            if (rstatus == coro::net::recv_status::closed)
-            {
-                REQUIRE(rspan.empty());
-                break;
-            }
-            REQUIRE(rstatus == coro::net::recv_status::ok);
-
-            in.resize(rspan.size());
-
-            auto [sstatus, remaining] = client.send(in);
-            REQUIRE(sstatus == coro::net::send_status::ok);
-            REQUIRE(remaining.empty());
-        }
-
-        wait_for_clients.count_down();
-        std::cerr << "wait_for_clients.count_down(1) -> " << wait_for_clients.remaining() << "\n";
-        co_return;
-    };
-
     auto server_scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
-    auto make_server_task = [&]() -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> server_scheduler, std::atomic<uint64_t>& listening, std::atomic<uint64_t>& accepted) -> coro::task<void>
     {
+        auto make_on_connection_task = [](coro::net::tcp::client client, coro::latch& wait_for_clients) -> coro::task<void>
+        {
+            std::string in(64, '\0');
+
+            // Echo the messages until the socket is closed.
+            while (true)
+            {
+                auto pstatus = co_await client.poll(coro::poll_op::read);
+                REQUIRE(pstatus == coro::poll_status::event);
+
+                auto [rstatus, rspan] = client.recv(in);
+                if (rstatus == coro::net::recv_status::closed)
+                {
+                    REQUIRE(rspan.empty());
+                    break;
+                }
+                REQUIRE(rstatus == coro::net::recv_status::ok);
+
+                in.resize(rspan.size());
+
+                auto [sstatus, remaining] = client.send(in);
+                REQUIRE(sstatus == coro::net::send_status::ok);
+                REQUIRE(remaining.empty());
+            }
+
+            wait_for_clients.count_down();
+            std::cerr << "wait_for_clients.count_down(1) -> " << wait_for_clients.remaining() << "\n";
+            co_return;
+        };
+
         co_await server_scheduler->schedule();
 
         coro::latch            wait_for_clients{connections};
@@ -440,7 +440,12 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark]")
     auto client_scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
-    auto make_client_task = [&]() -> coro::task<void>
+    auto make_client_task = [](
+        std::shared_ptr<coro::io_scheduler> client_scheduler,
+        const std::string& msg,
+        std::atomic<uint64_t>& clients_completed,
+        std::map<std::chrono::milliseconds, uint64_t>& g_histogram,
+        std::mutex& g_histogram_mutex) -> coro::task<void>
     {
         co_await client_scheduler->schedule();
         std::map<std::chrono::milliseconds, uint64_t> histogram;
@@ -486,7 +491,7 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark]")
     auto start = sc::now();
 
     // Create the server to accept incoming tcp connections.
-    auto server_thread = std::thread{[&]() { coro::sync_wait(make_server_task()); }};
+    auto server_thread = std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted)); }};
 
     // The server can take a small bit of time to start up, if we don't wait for it to notify then
     // the first few connections can easily fail to connect causing this test to fail.
@@ -500,7 +505,7 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark]")
                                          std::vector<coro::task<void>> tasks{};
                                          for (size_t i = 0; i < connections; ++i)
                                          {
-                                             tasks.emplace_back(make_client_task());
+                                             tasks.emplace_back(make_client_task(client_scheduler, msg, clients_completed, g_histogram, g_histogram_mutex));
                                          }
                                          coro::sync_wait(coro::when_all(std::move(tasks)));
                                      }};
@@ -555,43 +560,43 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark]")
         std::vector<coro::task<void>>       tasks{};
     };
 
-    auto make_on_connection_task = [&](server& s, coro::net::tcp::client client) -> coro::task<void>
+    auto make_server_task = [](server& s, std::atomic<uint64_t>& listening, std::atomic<uint64_t>& accepted) -> coro::task<void>
     {
-        std::string in(64, '\0');
-
-        // Echo the messages until the socket is closed.
-        while (true)
+        auto make_on_connection_task = [](server& s, coro::net::tcp::client client) -> coro::task<void>
         {
-            auto pstatus = co_await client.poll(coro::poll_op::read);
-            REQUIRE(pstatus == coro::poll_status::event);
+            std::string in(64, '\0');
 
-            auto [rstatus, rspan] = client.recv(in);
-            if (rstatus == coro::net::recv_status::closed)
+            // Echo the messages until the socket is closed.
+            while (true)
             {
-                REQUIRE(rspan.empty());
-                break;
+                auto pstatus = co_await client.poll(coro::poll_op::read);
+                REQUIRE(pstatus == coro::poll_status::event);
+
+                auto [rstatus, rspan] = client.recv(in);
+                if (rstatus == coro::net::recv_status::closed)
+                {
+                    REQUIRE(rspan.empty());
+                    break;
+                }
+                REQUIRE(rstatus == coro::net::recv_status::ok);
+
+                in.resize(rspan.size());
+
+                auto [sstatus, remaining] = client.send(in);
+                REQUIRE(sstatus == coro::net::send_status::ok);
+                REQUIRE(remaining.empty());
             }
-            REQUIRE(rstatus == coro::net::recv_status::ok);
 
-            in.resize(rspan.size());
+            s.live_clients--;
+            std::cerr << "s.live_clients=" << s.live_clients << std::endl;
+            if (s.live_clients == 0)
+            {
+                std::cerr << "s.wait_for_clients.set()" << std::endl;
+                s.wait_for_clients.set();
+            }
+            co_return;
+        };
 
-            auto [sstatus, remaining] = client.send(in);
-            REQUIRE(sstatus == coro::net::send_status::ok);
-            REQUIRE(remaining.empty());
-        }
-
-        s.live_clients--;
-        std::cerr << "s.live_clients=" << s.live_clients << std::endl;
-        if (s.live_clients == 0)
-        {
-            std::cerr << "s.wait_for_clients.set()" << std::endl;
-            s.wait_for_clients.set();
-        }
-        co_return;
-    };
-
-    auto make_server_task = [&](server& s) -> coro::task<void>
-    {
         co_await s.scheduler->schedule();
 
         coro::net::tcp::server server{s.scheduler};
@@ -623,7 +628,7 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark]")
     std::mutex                                    g_histogram_mutex;
     std::map<std::chrono::milliseconds, uint64_t> g_histogram;
 
-    auto make_client_task = [&](client& c) -> coro::task<void>
+    auto make_client_task = [](client& c, const std::string& msg, std::atomic<uint64_t>& clients_completed, std::map<std::chrono::milliseconds, uint64_t>& g_histogram, std::mutex& g_histogram_mutex) -> coro::task<void>
     {
         co_await c.scheduler->schedule();
         std::map<std::chrono::milliseconds, uint64_t> histogram;
@@ -677,7 +682,7 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark]")
                                                     server s{};
                                                     s.id = server_id++;
                                                     std::cerr << "coro::sync_wait(make_server_task(s));\n";
-                                                    coro::sync_wait(make_server_task(s));
+                                                    coro::sync_wait(make_server_task(s, listening, accepted));
                                                     std::cerr << "server.scheduler->shutdown()\n";
                                                     s.scheduler->shutdown();
                                                     std::cerr << "server thread exiting\n";
@@ -701,7 +706,7 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark]")
                                                     client c{};
                                                     for (size_t i = 0; i < connections / client_count; ++i)
                                                     {
-                                                        c.tasks.emplace_back(make_client_task(c));
+                                                        c.tasks.emplace_back(make_client_task(c, msg, clients_completed, g_histogram, g_histogram_mutex));
                                                     }
                                                     std::cerr << "coro::sync_wait(coro::when_all(std::move(c.tasks)));\n";
                                                     coro::sync_wait(coro::when_all(std::move(c.tasks)));
@@ -743,67 +748,66 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
     std::atomic<uint64_t> accepted{0};
     std::atomic<uint64_t> clients_completed{0};
 
-    auto make_on_connection_task = [&](coro::net::tls::client client, coro::latch& wait_for_clients) -> coro::task<void>
-    {
-        std::string in(64, '\0');
-
-        auto closed = false;
-        // Echo the messages until the socket is closed.
-        while (!closed)
-        {
-            auto [rstatus, rspan] = co_await client.recv(in);
-            // std::cerr << "SERVER CONNECTION: rstatus =" << coro::net::tls::to_string(rstatus) << "\n";
-            std::string_view data{};
-            switch (rstatus)
-            {
-                case coro::net::tls::recv_status::ok:
-                    REQUIRE(rstatus == coro::net::tls::recv_status::ok);
-                    data = std::string_view{rspan.begin(), rspan.end()};
-                    // std::cerr << "SERVER CONNECTION: recv() -> " << data << "\n";
-                    break;
-                case coro::net::tls::recv_status::closed:
-                    // std::cerr << "SERVER CONNECTION: closed\n";
-                    REQUIRE(rspan.empty());
-                    closed = true;
-                    break;
-                case coro::net::tls::recv_status::want_read:
-                {
-                    // std::cerr << "SERVER CONNECTION: want_read\n";
-                }
-                    continue;
-                case coro::net::tls::recv_status::want_write:
-                {
-                    // std::cerr << "SERVER CONNECTION: want_write\n";
-                }
-                    continue;
-                default:
-                    // std::cerr << "SERVER CONNECTION: error (closing)\n";
-                    closed = true;
-                    break;
-            }
-
-            if (closed)
-            {
-                break;
-            }
-
-            // std::cerr << "SERVER CONNECTION: client.send()\n";
-            auto [sstatus, remaining] = co_await client.send(data);
-            REQUIRE(sstatus == coro::net::tls::send_status::ok);
-            REQUIRE(remaining.empty());
-            // std::cerr << "SERVER CONNECTION: send() -> " << data << "\n";
-        }
-
-        wait_for_clients.count_down();
-        // std::cerr << "SERVER CONNECTION: wait_for_clients.count_down(1) -> " << wait_for_clients.remaining() << "\n";
-        co_return;
-    };
-
     auto server_scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
-    auto make_server_task = [&]() -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> server_scheduler, std::atomic<uint64_t>& listening, std::atomic<uint64_t>& accepted) -> coro::task<void>
     {
+        auto make_on_connection_task = [](coro::net::tls::client client, coro::latch& wait_for_clients) -> coro::task<void>
+        {
+            std::string in(64, '\0');
+
+            auto closed = false;
+            // Echo the messages until the socket is closed.
+            while (!closed)
+            {
+                auto [rstatus, rspan] = co_await client.recv(in);
+                // std::cerr << "SERVER CONNECTION: rstatus =" << coro::net::tls::to_string(rstatus) << "\n";
+                std::string_view data{};
+                switch (rstatus)
+                {
+                    case coro::net::tls::recv_status::ok:
+                        REQUIRE(rstatus == coro::net::tls::recv_status::ok);
+                        data = std::string_view{rspan.begin(), rspan.end()};
+                        // std::cerr << "SERVER CONNECTION: recv() -> " << data << "\n";
+                        break;
+                    case coro::net::tls::recv_status::closed:
+                        // std::cerr << "SERVER CONNECTION: closed\n";
+                        REQUIRE(rspan.empty());
+                        closed = true;
+                        break;
+                    case coro::net::tls::recv_status::want_read:
+                    {
+                        // std::cerr << "SERVER CONNECTION: want_read\n";
+                    }
+                        continue;
+                    case coro::net::tls::recv_status::want_write:
+                    {
+                        // std::cerr << "SERVER CONNECTION: want_write\n";
+                    }
+                        continue;
+                    default:
+                        // std::cerr << "SERVER CONNECTION: error (closing)\n";
+                        closed = true;
+                        break;
+                }
+
+                if (closed)
+                {
+                    break;
+                }
+
+                // std::cerr << "SERVER CONNECTION: client.send()\n";
+                auto [sstatus, remaining] = co_await client.send(data);
+                REQUIRE(sstatus == coro::net::tls::send_status::ok);
+                REQUIRE(remaining.empty());
+                // std::cerr << "SERVER CONNECTION: send() -> " << data << "\n";
+            }
+
+            wait_for_clients.count_down();
+            // std::cerr << "SERVER CONNECTION: wait_for_clients.count_down(1) -> " << wait_for_clients.remaining() << "\n";
+            co_return;
+        };
         co_await server_scheduler->schedule();
 
         coro::latch            wait_for_clients{connections};
@@ -840,7 +844,12 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
     auto client_scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
-    auto make_client_task = [&](coro::mutex& histogram_mutex) -> coro::task<void>
+    auto make_client_task = [](
+        std::shared_ptr<coro::io_scheduler> client_scheduler,
+        const std::string& msg,
+        std::atomic<uint64_t>& clients_completed,
+        std::map<std::chrono::milliseconds, uint64_t>& g_histogram,
+        coro::mutex& histogram_mutex) -> coro::task<void>
     {
         co_await client_scheduler->schedule();
         {
@@ -929,7 +938,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
     auto start = sc::now();
 
     // Create the server to accept incoming tcp connections.
-    auto server_thread = std::thread{[&]() { coro::sync_wait(make_server_task()); }};
+    auto server_thread = std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted)); }};
 
     // The server can take a small bit of time to start up, if we don't wait for it to notify then
     // the first few connections can easily fail to connect causing this test to fail.
@@ -943,7 +952,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
                                          std::vector<coro::task<void>> tasks{};
                                          for (size_t i = 0; i < connections; ++i)
                                          {
-                                             tasks.emplace_back(make_client_task(histogram_mutex));
+                                             tasks.emplace_back(make_client_task(client_scheduler, msg, clients_completed, g_histogram, histogram_mutex));
                                          }
                                          coro::sync_wait(coro::when_all(std::move(tasks)));
                                      }};

--- a/test/net/test_dns_resolver.cpp
+++ b/test/net/test_dns_resolver.cpp
@@ -12,7 +12,7 @@ TEST_CASE("dns_resolver basic", "[dns]")
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
     coro::net::dns::resolver<coro::io_scheduler> dns_resolver{scheduler, std::chrono::milliseconds{5000}};
 
-    auto make_host_by_name_task = [&](coro::net::hostname hn) -> coro::task<void>
+    auto make_host_by_name_task = [](std::shared_ptr<coro::io_scheduler>& scheduler, coro::net::dns::resolver<coro::io_scheduler>& dns_resolver, coro::net::hostname hn) -> coro::task<void>
     {
         co_await scheduler->schedule();
         auto result_ptr = co_await std::move(dns_resolver.host_by_name(hn));
@@ -28,7 +28,7 @@ TEST_CASE("dns_resolver basic", "[dns]")
         co_return;
     };
 
-    coro::sync_wait(make_host_by_name_task(coro::net::hostname{"www.example.com"}));
+    coro::sync_wait(make_host_by_name_task(scheduler, dns_resolver, coro::net::hostname{"www.example.com"}));
 
     std::cerr << "io_scheduler.size() before shutdown = " << scheduler->size() << "\n";
     scheduler->shutdown();

--- a/test/net/test_dns_resolver.cpp
+++ b/test/net/test_dns_resolver.cpp
@@ -12,7 +12,9 @@ TEST_CASE("dns_resolver basic", "[dns]")
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
     coro::net::dns::resolver<coro::io_scheduler> dns_resolver{scheduler, std::chrono::milliseconds{5000}};
 
-    auto make_host_by_name_task = [](std::shared_ptr<coro::io_scheduler>& scheduler, coro::net::dns::resolver<coro::io_scheduler>& dns_resolver, coro::net::hostname hn) -> coro::task<void>
+    auto make_host_by_name_task = [](std::shared_ptr<coro::io_scheduler>&          scheduler,
+                                     coro::net::dns::resolver<coro::io_scheduler>& dns_resolver,
+                                     coro::net::hostname                           hn) -> coro::task<void>
     {
         co_await scheduler->schedule();
         auto result_ptr = co_await std::move(dns_resolver.host_by_name(hn));

--- a/test/net/test_tcp_server.cpp
+++ b/test/net/test_tcp_server.cpp
@@ -14,7 +14,9 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_client_task = [](std::shared_ptr<coro::io_scheduler>& scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler>& scheduler,
+                               const std::string&                   client_msg,
+                               const std::string&                   server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::tcp::client client{scheduler};
@@ -47,7 +49,9 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
         co_return;
     };
 
-    auto make_server_task = [](std::shared_ptr<coro::io_scheduler>& scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler>& scheduler,
+                               const std::string&                   client_msg,
+                               const std::string&                   server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::tcp::server server{scheduler};
@@ -83,7 +87,8 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_server_task(scheduler, client_msg, server_msg), make_client_task(scheduler, client_msg, server_msg)));
+    coro::sync_wait(coro::when_all(
+        make_server_task(scheduler, client_msg, server_msg), make_client_task(scheduler, client_msg, server_msg)));
 }
 
 TEST_CASE("tcp_server concurrent polling on the same socket", "[tcp_server]")

--- a/test/net/test_tls_server.cpp
+++ b/test/net/test_tls_server.cpp
@@ -12,10 +12,10 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    std::string client_msg = "Hello world from TLS client!";
-    std::string server_msg = "Hello world from TLS server!!";
+    const std::string client_msg = "Hello world from TLS client!";
+    const std::string server_msg = "Hello world from TLS server!!";
 
-    auto make_client_task = [&]() -> coro::task<void>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
 
@@ -48,7 +48,7 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
         co_return;
     };
 
-    auto make_server_task = [&]() -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
 
@@ -84,7 +84,7 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_server_task(), make_client_task()));
+    coro::sync_wait(coro::when_all(make_server_task(scheduler, client_msg, server_msg), make_client_task(scheduler, client_msg, server_msg)));
 }
 
     #endif // LIBCORO_FEATURE_TLS

--- a/test/net/test_tls_server.cpp
+++ b/test/net/test_tls_server.cpp
@@ -15,7 +15,9 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
     const std::string client_msg = "Hello world from TLS client!";
     const std::string server_msg = "Hello world from TLS server!!";
 
-    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+                               const std::string&                  client_msg,
+                               const std::string&                  server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
 
@@ -48,7 +50,9 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
         co_return;
     };
 
-    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& client_msg, const std::string& server_msg) -> coro::task<void>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+                               const std::string&                  client_msg,
+                               const std::string&                  server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
 
@@ -84,7 +88,8 @@ TEST_CASE("tls_server hello world server", "[tls_server]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_server_task(scheduler, client_msg, server_msg), make_client_task(scheduler, client_msg, server_msg)));
+    coro::sync_wait(coro::when_all(
+        make_server_task(scheduler, client_msg, server_msg), make_client_task(scheduler, client_msg, server_msg)));
 }
 
     #endif // LIBCORO_FEATURE_TLS

--- a/test/net/test_udp_peers.cpp
+++ b/test/net/test_udp_peers.cpp
@@ -57,13 +57,12 @@ TEST_CASE("udp echo peers")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_peer_task = [](
-                              std::shared_ptr<coro::io_scheduler> scheduler,
-                              uint16_t          my_port,
-                              uint16_t          peer_port,
-                              bool              send_first,
-                              const std::string my_msg,
-                              const std::string peer_msg) -> coro::task<void>
+    auto make_peer_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+                             uint16_t                            my_port,
+                             uint16_t                            peer_port,
+                             bool                                send_first,
+                             const std::string                   my_msg,
+                             const std::string                   peer_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::udp::peer::info my_info{.address = coro::net::ip_address::from_string("0.0.0.0"), .port = my_port};

--- a/test/net/test_udp_peers.cpp
+++ b/test/net/test_udp_peers.cpp
@@ -11,7 +11,7 @@ TEST_CASE("udp one way")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_send_task = [&]() -> coro::task<void>
+    auto make_send_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::udp::peer       peer{scheduler};
@@ -24,7 +24,7 @@ TEST_CASE("udp one way")
         co_return;
     };
 
-    auto make_recv_task = [&]() -> coro::task<void>
+    auto make_recv_task = [](std::shared_ptr<coro::io_scheduler> scheduler, const std::string& msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::udp::peer::info self_info{.address = coro::net::ip_address::from_string("0.0.0.0")};
@@ -46,7 +46,7 @@ TEST_CASE("udp one way")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_recv_task(), make_send_task()));
+    coro::sync_wait(coro::when_all(make_recv_task(scheduler, msg), make_send_task(scheduler, msg)));
 }
 
 TEST_CASE("udp echo peers")
@@ -57,7 +57,8 @@ TEST_CASE("udp echo peers")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_peer_task = [&scheduler](
+    auto make_peer_task = [](
+                              std::shared_ptr<coro::io_scheduler> scheduler,
                               uint16_t          my_port,
                               uint16_t          peer_port,
                               bool              send_first,
@@ -118,8 +119,8 @@ TEST_CASE("udp echo peers")
     };
 
     coro::sync_wait(coro::when_all(
-        make_peer_task(8081, 8080, false, peer2_msg, peer1_msg),
-        make_peer_task(8080, 8081, true, peer1_msg, peer2_msg)));
+        make_peer_task(scheduler, 8081, 8080, false, peer2_msg, peer1_msg),
+        make_peer_task(scheduler, 8080, 8081, true, peer1_msg, peer2_msg)));
 }
 
 #endif // LIBCORO_FEATURE_NETWORKING

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -105,7 +105,8 @@ TEST_CASE("event fifo", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+    auto make_waiter =
+        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -124,8 +125,13 @@ TEST_CASE("event fifo", "[event]")
         co_return;
     };
 
-    coro::sync_wait(
-        coro::when_all(make_waiter(tp, e, counter, 1), make_waiter(tp, e, counter, 2), make_waiter(tp, e, counter, 3), make_waiter(tp, e, counter, 4), make_waiter(tp, e, counter, 5), make_setter(tp, e, counter)));
+    coro::sync_wait(coro::when_all(
+        make_waiter(tp, e, counter, 1),
+        make_waiter(tp, e, counter, 2),
+        make_waiter(tp, e, counter, 3),
+        make_waiter(tp, e, counter, 4),
+        make_waiter(tp, e, counter, 5),
+        make_setter(tp, e, counter)));
 
     REQUIRE(counter == 5);
 }
@@ -161,7 +167,8 @@ TEST_CASE("event fifo single", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+    auto make_waiter =
+        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -194,7 +201,8 @@ TEST_CASE("event fifo executor", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+    auto make_waiter =
+        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -213,8 +221,13 @@ TEST_CASE("event fifo executor", "[event]")
         co_return;
     };
 
-    coro::sync_wait(
-        coro::when_all(make_waiter(tp, e, counter, 1), make_waiter(tp, e, counter, 2), make_waiter(tp, e, counter, 3), make_waiter(tp, e, counter, 4), make_waiter(tp, e, counter, 5), make_setter(tp, e, counter)));
+    coro::sync_wait(coro::when_all(
+        make_waiter(tp, e, counter, 1),
+        make_waiter(tp, e, counter, 2),
+        make_waiter(tp, e, counter, 3),
+        make_waiter(tp, e, counter, 4),
+        make_waiter(tp, e, counter, 5),
+        make_setter(tp, e, counter)));
 
     REQUIRE(counter == 5);
 }
@@ -250,7 +263,8 @@ TEST_CASE("event fifo single executor", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+    auto make_waiter =
+        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -9,13 +9,13 @@ TEST_CASE("event single awaiter", "[event]")
 {
     coro::event e{};
 
-    auto func = [&]() -> coro::task<uint64_t>
+    auto func = [](coro::event& e) -> coro::task<uint64_t>
     {
         co_await e;
         co_return 42;
     };
 
-    auto task = func();
+    auto task = func(e);
 
     task.resume();
     REQUIRE_FALSE(task.is_ready());
@@ -105,7 +105,7 @@ TEST_CASE("event fifo", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [&](uint64_t value) -> coro::task<void>
+    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -116,7 +116,7 @@ TEST_CASE("event fifo", "[event]")
         co_return;
     };
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -125,7 +125,7 @@ TEST_CASE("event fifo", "[event]")
     };
 
     coro::sync_wait(
-        coro::when_all(make_waiter(1), make_waiter(2), make_waiter(3), make_waiter(4), make_waiter(5), make_setter()));
+        coro::when_all(make_waiter(tp, e, counter, 1), make_waiter(tp, e, counter, 2), make_waiter(tp, e, counter, 3), make_waiter(tp, e, counter, 4), make_waiter(tp, e, counter, 5), make_setter(tp, e, counter)));
 
     REQUIRE(counter == 5);
 }
@@ -139,7 +139,7 @@ TEST_CASE("event fifo none", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -147,7 +147,7 @@ TEST_CASE("event fifo none", "[event]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_setter()));
+    coro::sync_wait(coro::when_all(make_setter(tp, e, counter)));
 
     REQUIRE(counter == 0);
 }
@@ -161,7 +161,7 @@ TEST_CASE("event fifo single", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [&](uint64_t value) -> coro::task<void>
+    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -172,7 +172,7 @@ TEST_CASE("event fifo single", "[event]")
         co_return;
     };
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -180,7 +180,7 @@ TEST_CASE("event fifo single", "[event]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_waiter(1), make_setter()));
+    coro::sync_wait(coro::when_all(make_waiter(tp, e, counter, 1), make_setter(tp, e, counter)));
 
     REQUIRE(counter == 1);
 }
@@ -194,7 +194,7 @@ TEST_CASE("event fifo executor", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [&](uint64_t value) -> coro::task<void>
+    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -205,7 +205,7 @@ TEST_CASE("event fifo executor", "[event]")
         co_return;
     };
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -214,7 +214,7 @@ TEST_CASE("event fifo executor", "[event]")
     };
 
     coro::sync_wait(
-        coro::when_all(make_waiter(1), make_waiter(2), make_waiter(3), make_waiter(4), make_waiter(5), make_setter()));
+        coro::when_all(make_waiter(tp, e, counter, 1), make_waiter(tp, e, counter, 2), make_waiter(tp, e, counter, 3), make_waiter(tp, e, counter, 4), make_waiter(tp, e, counter, 5), make_setter(tp, e, counter)));
 
     REQUIRE(counter == 5);
 }
@@ -228,7 +228,7 @@ TEST_CASE("event fifo none executor", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -236,7 +236,7 @@ TEST_CASE("event fifo none executor", "[event]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_setter()));
+    coro::sync_wait(coro::when_all(make_setter(tp, e, counter)));
 
     REQUIRE(counter == 0);
 }
@@ -250,7 +250,7 @@ TEST_CASE("event fifo single executor", "[event]")
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_waiter = [&](uint64_t value) -> coro::task<void>
+    auto make_waiter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
         co_await tp.schedule();
         co_await e;
@@ -261,7 +261,7 @@ TEST_CASE("event fifo single executor", "[event]")
         co_return;
     };
 
-    auto make_setter = [&]() -> coro::task<void>
+    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await tp.schedule();
         REQUIRE(counter == 0);
@@ -269,7 +269,7 @@ TEST_CASE("event fifo single executor", "[event]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_waiter(1), make_setter()));
+    coro::sync_wait(coro::when_all(make_waiter(tp, e, counter, 1), make_setter(tp, e, counter)));
 
     REQUIRE(counter == 1);
 }

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -4,10 +4,10 @@
 
 TEST_CASE("generator single yield", "[generator]")
 {
-    std::string msg{"Hello World Generator!"};
-    auto        func = [&]() -> coro::generator<std::string> { co_yield msg; };
+    const std::string msg{"Hello World Generator!"};
+    auto        func = [](const std::string& msg) -> coro::generator<std::string> { co_yield std::string{msg}; };
 
-    for (const auto& v : func())
+    for (const auto& v : func(msg))
     {
         REQUIRE(v == msg);
     }
@@ -43,15 +43,15 @@ TEST_CASE("generator infinite incrementing integer yield", "[generator]")
 TEST_CASE("generator satisfies view concept for compatibility with std::views::take")
 {
     auto counter = size_t{0};
-    auto natural = [n = counter]() mutable -> coro::generator<size_t> {
+    auto natural = [](size_t n) mutable -> coro::generator<size_t> {
         while (true)
             co_yield ++n;
     };
-    auto nat = natural();
+    auto nat = natural(counter);
     static_assert(std::ranges::view<decltype(nat)>, "does not satisfy view concept");
     SECTION("Count the items")
     {
-        for (auto&& n : natural() | std::views::take(5))
+        for (auto&& n : natural(counter) | std::views::take(5))
         {
             ++counter;
             REQUIRE(n == counter);

--- a/test/test_generator.cpp
+++ b/test/test_generator.cpp
@@ -5,7 +5,7 @@
 TEST_CASE("generator single yield", "[generator]")
 {
     const std::string msg{"Hello World Generator!"};
-    auto        func = [](const std::string& msg) -> coro::generator<std::string> { co_yield std::string{msg}; };
+    auto              func = [](const std::string& msg) -> coro::generator<std::string> { co_yield std::string{msg}; };
 
     for (const auto& v : func(msg))
     {
@@ -43,7 +43,8 @@ TEST_CASE("generator infinite incrementing integer yield", "[generator]")
 TEST_CASE("generator satisfies view concept for compatibility with std::views::take")
 {
     auto counter = size_t{0};
-    auto natural = [](size_t n) mutable -> coro::generator<size_t> {
+    auto natural = [](size_t n) mutable -> coro::generator<size_t>
+    {
         while (true)
             co_yield ++n;
     };

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -21,13 +21,13 @@ TEST_CASE("io_scheduler schedule single task", "[io_scheduler]")
     auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s) -> coro::task<uint64_t>
     {
         co_await s->schedule();
         co_return 42;
     };
 
-    auto value = coro::sync_wait(make_task());
+    auto value = coro::sync_wait(make_task(s));
     REQUIRE(value == 42);
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -43,7 +43,7 @@ TEST_CASE("io_scheduler submit mutiple tasks", "[io_scheduler]")
     tasks.reserve(n);
     auto s = coro::io_scheduler::make_shared();
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
         co_await s->schedule();
         counter++;
@@ -51,7 +51,7 @@ TEST_CASE("io_scheduler submit mutiple tasks", "[io_scheduler]")
     };
     for (std::size_t i = 0; i < n; ++i)
     {
-        tasks.emplace_back(make_task());
+        tasks.emplace_back(make_task(s, counter));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
@@ -74,7 +74,7 @@ TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
     coro::event e2;
     coro::event e3;
 
-    auto make_wait_task = [&]() -> coro::task<void>
+    auto make_wait_task = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<uint64_t>& counter, coro::event& e1, coro::event& e2, coro::event& e3) -> coro::task<void>
     {
         co_await s->schedule();
         co_await e1;
@@ -86,13 +86,13 @@ TEST_CASE("io_scheduler task with multiple events", "[io_scheduler]")
         co_return;
     };
 
-    auto make_set_task = [&](coro::event& e) -> coro::task<void>
+    auto make_set_task = [](std::shared_ptr<coro::io_scheduler> s, coro::event& e) -> coro::task<void>
     {
         co_await s->schedule();
         e.set();
     };
 
-    coro::sync_wait(coro::when_all(make_wait_task(), make_set_task(e1), make_set_task(e2), make_set_task(e3)));
+    coro::sync_wait(coro::when_all(make_wait_task(s, counter, e1, e2, e3), make_set_task(s, e1), make_set_task(s, e2), make_set_task(s, e3)));
 
     REQUIRE(counter == 3);
 
@@ -108,7 +108,7 @@ TEST_CASE("io_scheduler task with read poll", "[io_scheduler]")
     auto s          = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_poll_read_task = [&]() -> coro::task<void>
+    auto make_poll_read_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         co_await s->schedule();
         auto status = co_await s->poll(trigger_fd, coro::poll_op::read);
@@ -116,7 +116,7 @@ TEST_CASE("io_scheduler task with read poll", "[io_scheduler]")
         co_return;
     };
 
-    auto make_poll_write_task = [&]() -> coro::task<void>
+    auto make_poll_write_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         co_await s->schedule();
         uint64_t value{42};
@@ -125,7 +125,7 @@ TEST_CASE("io_scheduler task with read poll", "[io_scheduler]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_poll_read_task(), make_poll_write_task()));
+    coro::sync_wait(coro::when_all(make_poll_read_task(s, trigger_fd), make_poll_write_task(s, trigger_fd)));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -140,7 +140,7 @@ TEST_CASE("io_scheduler task with read poll with timeout", "[io_scheduler]")
     auto s          = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_poll_read_task = [&]() -> coro::task<void>
+    auto make_poll_read_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         co_await s->schedule();
         // Poll with a timeout but don't timeout.
@@ -149,7 +149,7 @@ TEST_CASE("io_scheduler task with read poll with timeout", "[io_scheduler]")
         co_return;
     };
 
-    auto make_poll_write_task = [&]() -> coro::task<void>
+    auto make_poll_write_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         co_await s->schedule();
         uint64_t value{42};
@@ -158,7 +158,7 @@ TEST_CASE("io_scheduler task with read poll with timeout", "[io_scheduler]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_poll_read_task(), make_poll_write_task()));
+    coro::sync_wait(coro::when_all(make_poll_read_task(s, trigger_fd), make_poll_write_task(s, trigger_fd)));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -173,7 +173,7 @@ TEST_CASE("io_scheduler task with read poll timeout", "[io_scheduler]")
     auto s          = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         co_await s->schedule();
         // Poll with a timeout and timeout.
@@ -182,7 +182,7 @@ TEST_CASE("io_scheduler task with read poll timeout", "[io_scheduler]")
         co_return;
     };
 
-    coro::sync_wait(make_task());
+    coro::sync_wait(make_task(s, trigger_fd));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -200,7 +200,7 @@ TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
 
     coro::event e{};
 
-    auto make_s1_task = [&]() -> coro::task<void>
+    auto make_s1_task = [](std::shared_ptr<coro::io_scheduler> s1, coro::event& e) -> coro::task<void>
     {
         co_await s1->schedule();
         auto tid = std::this_thread::get_id();
@@ -212,7 +212,7 @@ TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
         co_return;
     };
 
-    auto make_s2_task = [&]() -> coro::task<void>
+    auto make_s2_task = [](std::shared_ptr<coro::io_scheduler> s2, coro::event& e) -> coro::task<void>
     {
         co_await s2->schedule();
         // Wait a bit to be sure the wait on 'e' in the other scheduler is done first.
@@ -221,7 +221,7 @@ TEST_CASE("io_scheduler separate thread resume", "[io_scheduler]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_s1_task(), make_s2_task()));
+    coro::sync_wait(coro::when_all(make_s1_task(s1, e), make_s2_task(s2, e)));
 
     s1->shutdown();
     REQUIRE(s1->empty());
@@ -234,7 +234,7 @@ TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]"
     auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s) -> coro::task<void>
     {
         co_await s->schedule();
         coro::event e{};
@@ -259,7 +259,7 @@ TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]"
         REQUIRE(tid == std::this_thread::get_id());
     };
 
-    coro::sync_wait(make_task());
+    coro::sync_wait(make_task(s));
 
     s->shutdown();
     REQUIRE(s->empty());
@@ -287,23 +287,23 @@ TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
             service_done.set(*s);
         }};
 
-    auto third_party_service = [&](int multiplier) -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, coro::event& start_service, coro::event& service_done, std::atomic<uint64_t>& output) -> coro::task<void>
     {
-        start_service.set();
-        co_await service_done;
-        co_return output* multiplier;
-    };
+        auto third_party_service = [](coro::event& start_service, coro::event& service_done, int multiplier, std::atomic<uint64_t>& output) -> coro::task<uint64_t>
+        {
+            start_service.set();
+            co_await service_done;
+            co_return output * multiplier;
+        };
 
-    auto make_task = [&]() -> coro::task<void>
-    {
         co_await s->schedule();
 
         int      multiplier{5};
-        uint64_t value = co_await third_party_service(multiplier);
+        uint64_t value = co_await third_party_service(start_service, service_done, multiplier, output);
         REQUIRE(value == (expected_value * multiplier));
     };
 
-    coro::sync_wait(make_task());
+    coro::sync_wait(make_task(s, start_service, service_done, output));
 
     service.join();
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
@@ -318,17 +318,17 @@ TEST_CASE("io_scheduler with basic task", "[io_scheduler]")
     auto                  s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto add_data = [&](uint64_t val) -> coro::task<int>
+    auto func = [](std::shared_ptr<coro::io_scheduler> s) -> coro::task<int>
     {
-        co_await s->schedule();
-        co_return val;
-    };
+        auto add_data = [](std::shared_ptr<coro::io_scheduler> s, uint64_t val) -> coro::task<int>
+        {
+            co_await s->schedule();
+            co_return val;
+        };
 
-    auto func = [&]() -> coro::task<int>
-    {
         co_await s->schedule();
 
-        auto output_tasks = co_await coro::when_all(add_data(1), add_data(1), add_data(1), add_data(1), add_data(1));
+        auto output_tasks = co_await coro::when_all(add_data(s, 1), add_data(s, 1), add_data(s, 1), add_data(s, 1), add_data(s, 1));
 
         int counter{0};
         std::apply([&counter](auto&&... tasks) -> void { ((counter += tasks.return_value()), ...); }, output_tasks);
@@ -336,7 +336,7 @@ TEST_CASE("io_scheduler with basic task", "[io_scheduler]")
         co_return counter;
     };
 
-    auto counter = coro::sync_wait(func());
+    auto counter = coro::sync_wait(func(s));
 
     REQUIRE(counter == expected_value);
 
@@ -352,7 +352,7 @@ TEST_CASE("io_scheduler scheduler_after", "[io_scheduler]")
     std::atomic<uint64_t>               counter{0};
     std::thread::id                     tid;
 
-    auto func = [&](coro::io_scheduler& s, std::chrono::milliseconds amount) -> coro::task<void>
+    auto func = [](coro::io_scheduler& s, std::chrono::milliseconds amount, std::atomic<uint64_t>& counter, std::thread::id& tid) -> coro::task<void>
     {
         co_await s.schedule_after(amount);
         ++counter;
@@ -366,7 +366,7 @@ TEST_CASE("io_scheduler scheduler_after", "[io_scheduler]")
                 .pool = coro::thread_pool::options{
                     .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(*s, 0ms));
+        coro::sync_wait(func(*s, 0ms, counter, tid));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
@@ -384,7 +384,7 @@ TEST_CASE("io_scheduler scheduler_after", "[io_scheduler]")
                 .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(*s, wait_for));
+        coro::sync_wait(func(*s, wait_for, counter, tid));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
@@ -409,7 +409,7 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
         .pool = coro::thread_pool::options{
             .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
-    auto func = [&](std::chrono::steady_clock::time_point time) -> coro::task<void>
+    auto func = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<uint64_t>& counter, std::chrono::steady_clock::time_point time, std::thread::id& tid) -> coro::task<void>
     {
         co_await s->schedule_at(time);
         ++counter;
@@ -419,7 +419,7 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
 
     {
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(std::chrono::steady_clock::now() + wait_for));
+        coro::sync_wait(func(s, counter, std::chrono::steady_clock::now() + wait_for, tid));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
@@ -429,7 +429,7 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
 
     {
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(std::chrono::steady_clock::now()));
+        coro::sync_wait(func(s, counter, std::chrono::steady_clock::now(), tid));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
@@ -439,7 +439,7 @@ TEST_CASE("io_scheduler schedule_at", "[io_scheduler]")
 
     {
         auto start = std::chrono::steady_clock::now();
-        coro::sync_wait(func(std::chrono::steady_clock::now() - 1s));
+        coro::sync_wait(func(s, counter, std::chrono::steady_clock::now() - 1s, tid));
         auto stop     = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
@@ -455,7 +455,7 @@ TEST_CASE("io_scheduler yield", "[io_scheduler]")
                    .pool = coro::thread_pool::options{
                        .thread_count = 1, .on_thread_start_functor = [&](std::size_t) { tid = std::this_thread::get_id(); }}});
 
-    auto func = [&]() -> coro::task<void>
+    auto func = [](std::shared_ptr<coro::io_scheduler> s, std::thread::id& tid) -> coro::task<void>
     {
         REQUIRE(tid != std::this_thread::get_id());
         co_await s->schedule();
@@ -465,7 +465,7 @@ TEST_CASE("io_scheduler yield", "[io_scheduler]")
         co_return;
     };
 
-    coro::sync_wait(func());
+    coro::sync_wait(func(s, tid));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -480,7 +480,7 @@ TEST_CASE("io_scheduler yield_for", "[io_scheduler]")
 
     const std::chrono::milliseconds wait_for{50};
 
-    auto make_task = [&]() -> coro::task<std::chrono::milliseconds>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, std::chrono::milliseconds wait_for) -> coro::task<std::chrono::milliseconds>
     {
         co_await s->schedule();
         auto start = std::chrono::steady_clock::now();
@@ -488,7 +488,7 @@ TEST_CASE("io_scheduler yield_for", "[io_scheduler]")
         co_return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     };
 
-    auto duration = coro::sync_wait(make_task());
+    auto duration = coro::sync_wait(make_task(s, wait_for));
     REQUIRE(duration >= wait_for);
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
@@ -506,7 +506,7 @@ TEST_CASE("io_scheduler yield_until", "[io_scheduler]")
     const std::chrono::milliseconds epsilon{3};
     const std::chrono::milliseconds wait_for{50};
 
-    auto make_task = [&]() -> coro::task<std::chrono::milliseconds>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, std::chrono::milliseconds wait_for) -> coro::task<std::chrono::milliseconds>
     {
         co_await s->schedule();
         auto start = std::chrono::steady_clock::now();
@@ -514,7 +514,7 @@ TEST_CASE("io_scheduler yield_until", "[io_scheduler]")
         co_return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
     };
 
-    auto duration = coro::sync_wait(make_task());
+    auto duration = coro::sync_wait(make_task(s, wait_for));
     REQUIRE(duration >= (wait_for - epsilon));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
@@ -529,19 +529,19 @@ TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
     coro::event                 e{};
     auto                        s = coro::io_scheduler::make_shared();
 
-    auto func = [&]() -> coro::task<uint64_t>
+    auto spawn = [](std::shared_ptr<coro::io_scheduler> s, coro::event& e) -> coro::task<void>
     {
-        co_await e;
-        co_return 1;
-    };
+        auto func = [](coro::event& e) -> coro::task<uint64_t>
+        {
+            co_await e;
+            co_return 1;
+        };
 
-    auto spawn = [&]() -> coro::task<void>
-    {
         co_await s->schedule();
         std::vector<coro::task<uint64_t>> tasks;
         for (size_t i = 0; i < total; ++i)
         {
-            tasks.emplace_back(func());
+            tasks.emplace_back(func(e));
         }
 
         auto results = co_await coro::when_all(std::move(tasks));
@@ -554,13 +554,13 @@ TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
         REQUIRE(counter == total);
     };
 
-    auto release = [&]() -> coro::task<void>
+    auto release = [](std::shared_ptr<coro::io_scheduler> s, coro::event& e) -> coro::task<void>
     {
         co_await s->schedule_after(10ms);
         e.set(*s);
     };
 
-    coro::sync_wait(coro::when_all(spawn(), release()));
+    coro::sync_wait(coro::when_all(spawn(s, e), release(s, e)));
 
     std::cerr << "io_scheduler.size() before shutdown = " << s->size() << "\n";
     s->shutdown();
@@ -578,7 +578,7 @@ TEST_CASE("io_scheduler self generating coroutine (stack overflow check)", "[io_
     std::vector<coro::task<void>> tasks;
     tasks.reserve(total);
 
-    auto func = [&](auto f) -> coro::task<void>
+    auto func = [](std::shared_ptr<coro::io_scheduler>& s, uint64_t& counter, auto f, std::vector<coro::task<void>>& tasks) -> coro::task<void>
     {
         co_await s->schedule();
         ++counter;
@@ -591,12 +591,12 @@ TEST_CASE("io_scheduler self generating coroutine (stack overflow check)", "[io_
         // co_await f(f) _will_ stack overflow since each coroutine links to its parent, by storing
         // each new invocation into the vector they are not linked, but we can make sure the scheduler
         // doesn't choke on this many tasks being scheduled.
-        tasks.emplace_back(f(f));
+        tasks.emplace_back(f(s, counter, f, tasks));
         tasks.back().resume();
         co_return;
     };
 
-    coro::sync_wait(func(func));
+    coro::sync_wait(func(s, counter, func, tasks));
 
     while (tasks.size() < total - 1)
     {
@@ -622,7 +622,7 @@ TEST_CASE("io_scheduler manual process events thread pool", "[io_scheduler]")
 
     std::atomic<bool> polling{false};
 
-    auto make_poll_read_task = [&]() -> coro::task<void>
+    auto make_poll_read_task = [](std::shared_ptr<coro::io_scheduler> s, std::atomic<bool>& polling, int trigger_fd) -> coro::task<void>
     {
         std::cerr << "poll task start s.size() == " << s->size() << "\n";
         co_await s->schedule();
@@ -634,7 +634,7 @@ TEST_CASE("io_scheduler manual process events thread pool", "[io_scheduler]")
         co_return;
     };
 
-    auto make_poll_write_task = [&]() -> coro::task<void>
+    auto make_poll_write_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         std::cerr << "write task start s.size() == " << s->size() << "\n";
         co_await s->schedule();
@@ -646,8 +646,8 @@ TEST_CASE("io_scheduler manual process events thread pool", "[io_scheduler]")
         co_return;
     };
 
-    auto poll_task  = make_poll_read_task();
-    auto write_task = make_poll_write_task();
+    auto poll_task  = make_poll_read_task(s, polling, trigger_fd);
+    auto write_task = make_poll_write_task(s, trigger_fd);
 
     poll_task.resume(); // get to co_await s.poll();
     while (!polling)
@@ -674,7 +674,7 @@ TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
                  .thread_strategy    = coro::io_scheduler::thread_strategy_t::manual,
                  .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
-    auto make_poll_read_task = [&]() -> coro::task<void>
+    auto make_poll_read_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         std::cerr << "poll task start s.size() == " << s->size() << "\n";
         co_await s->schedule();
@@ -685,7 +685,7 @@ TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
         co_return;
     };
 
-    auto make_poll_write_task = [&]() -> coro::task<void>
+    auto make_poll_write_task = [](std::shared_ptr<coro::io_scheduler> s, int trigger_fd) -> coro::task<void>
     {
         std::cerr << "write task start s.size() == " << s->size() << "\n";
         co_await s->schedule();
@@ -697,8 +697,8 @@ TEST_CASE("io_scheduler manual process events inline", "[io_scheduler]")
         co_return;
     };
 
-    auto poll_task  = make_poll_read_task();
-    auto write_task = make_poll_write_task();
+    auto poll_task  = make_poll_read_task(s, trigger_fd);
+    auto write_task = make_poll_write_task(s, trigger_fd);
 
     // Start the tasks by scheduling them into the io scheduler.
     poll_task.resume();
@@ -727,14 +727,14 @@ TEST_CASE("io_scheduler task throws", "[io_scheduler]")
     auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto func = [&]() -> coro::task<uint64_t>
+    auto func = [](std::shared_ptr<coro::io_scheduler> s) -> coro::task<uint64_t>
     {
         co_await s->schedule();
         throw std::runtime_error{"I always throw."};
         co_return 42;
     };
 
-    REQUIRE_THROWS(coro::sync_wait(func()));
+    REQUIRE_THROWS(coro::sync_wait(func(s)));
 }
 
 TEST_CASE("io_scheduler task throws after resume", "[io_scheduler]")
@@ -742,7 +742,7 @@ TEST_CASE("io_scheduler task throws after resume", "[io_scheduler]")
     auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_thrower = [&]() -> coro::task<bool>
+    auto make_thrower = [](std::shared_ptr<coro::io_scheduler> s) -> coro::task<bool>
     {
         co_await s->schedule();
         std::cerr << "Throwing task is doing some work...\n";
@@ -751,7 +751,7 @@ TEST_CASE("io_scheduler task throws after resume", "[io_scheduler]")
         co_return true;
     };
 
-    REQUIRE_THROWS(coro::sync_wait(make_thrower()));
+    REQUIRE_THROWS(coro::sync_wait(make_thrower(s)));
 }
 
 TEST_CASE("issue-287", "[io_scheduler]")

--- a/test/test_latch.cpp
+++ b/test/test_latch.cpp
@@ -9,13 +9,13 @@ TEST_CASE("latch count=0", "[latch]")
 {
     coro::latch l{0};
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](coro::latch& l) -> coro::task<uint64_t>
     {
         co_await l;
         co_return 42;
     };
 
-    auto task = make_task();
+    auto task = make_task(l);
 
     task.resume();
     REQUIRE(task.is_ready()); // The latch never waits due to zero count.
@@ -26,14 +26,14 @@ TEST_CASE("latch count=1", "[latch]")
 {
     coro::latch l{1};
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](coro::latch& l) -> coro::task<uint64_t>
     {
         auto workers = l.remaining();
         co_await l;
         co_return workers;
     };
 
-    auto task = make_task();
+    auto task = make_task(l);
 
     task.resume();
     REQUIRE_FALSE(task.is_ready());
@@ -47,14 +47,14 @@ TEST_CASE("latch count=1 count_down=5", "[latch]")
 {
     coro::latch l{1};
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](coro::latch& l) -> coro::task<uint64_t>
     {
         auto workers = l.remaining();
         co_await l;
         co_return workers;
     };
 
-    auto task = make_task();
+    auto task = make_task(l);
 
     task.resume();
     REQUIRE_FALSE(task.is_ready());
@@ -68,14 +68,14 @@ TEST_CASE("latch count=5 count_down=1 x5", "[latch]")
 {
     coro::latch l{5};
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](coro::latch& l) -> coro::task<uint64_t>
     {
         auto workers = l.remaining();
         co_await l;
         co_return workers;
     };
 
-    auto task = make_task();
+    auto task = make_task(l);
 
     task.resume();
     REQUIRE_FALSE(task.is_ready());
@@ -97,14 +97,14 @@ TEST_CASE("latch count=5 count_down=5", "[latch]")
 {
     coro::latch l{5};
 
-    auto make_task = [&]() -> coro::task<uint64_t>
+    auto make_task = [](coro::latch& l) -> coro::task<uint64_t>
     {
         auto workers = l.remaining();
         co_await l;
         co_return workers;
     };
 
-    auto task = make_task();
+    auto task = make_task(l);
 
     task.resume();
     REQUIRE_FALSE(task.is_ready());

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -50,7 +50,8 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
     coro::mutex m; // acquires and holds the lock until the event is triggered
     coro::event e; // triggers the blocking thread to release the lock
 
-    auto make_task = [](coro::thread_pool& tp, coro::mutex& m, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
+    auto make_task =
+        [](coro::thread_pool& tp, coro::mutex& m, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp.schedule();
         std::cerr << "id = " << id << " waiting to acquire the lock\n";

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -12,7 +12,7 @@ TEST_CASE("mutex single waiter not locked", "[mutex]")
 
     coro::mutex m;
 
-    auto make_emplace_task = [&](coro::mutex& m) -> coro::task<void>
+    auto make_emplace_task = [](coro::mutex& m, std::vector<uint64_t>& output) -> coro::task<void>
     {
         std::cerr << "Acquiring lock\n";
         {
@@ -31,7 +31,7 @@ TEST_CASE("mutex single waiter not locked", "[mutex]")
         co_return;
     };
 
-    coro::sync_wait(make_emplace_task(m));
+    coro::sync_wait(make_emplace_task(m, output));
 
     REQUIRE(m.try_lock());
     m.unlock();
@@ -50,7 +50,7 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
     coro::mutex m; // acquires and holds the lock until the event is triggered
     coro::event e; // triggers the blocking thread to release the lock
 
-    auto make_task = [&](uint64_t id) -> coro::task<void>
+    auto make_task = [](coro::thread_pool& tp, coro::mutex& m, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp.schedule();
         std::cerr << "id = " << id << " waiting to acquire the lock\n";
@@ -65,7 +65,7 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
         co_return;
     };
 
-    auto make_block_task = [&]() -> coro::task<void>
+    auto make_block_task = [](coro::thread_pool& tp, coro::mutex& m, coro::event& e) -> coro::task<void>
     {
         co_await tp.schedule();
         std::cerr << "block task acquiring lock\n";
@@ -76,7 +76,7 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
         co_return;
     };
 
-    auto make_set_task = [&]() -> coro::task<void>
+    auto make_set_task = [](coro::thread_pool& tp, coro::event& e) -> coro::task<void>
     {
         co_await tp.schedule();
         std::cerr << "set task setting event\n";
@@ -85,15 +85,15 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
     };
 
     // Grab mutex so all threads block.
-    tasks.emplace_back(make_block_task());
+    tasks.emplace_back(make_block_task(tp, m, e));
 
     // Create N tasks that attempt to lock the mutex.
     for (uint64_t i = 1; i <= 4; ++i)
     {
-        tasks.emplace_back(make_task(i));
+        tasks.emplace_back(make_task(tp, m, value, i));
     }
 
-    tasks.emplace_back(make_set_task());
+    tasks.emplace_back(make_set_task(tp, e));
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
 
@@ -104,7 +104,7 @@ TEST_CASE("mutex scoped_lock unlock prior to scope exit", "[mutex]")
 {
     coro::mutex m;
 
-    auto make_task = [&]() -> coro::task<void>
+    auto make_task = [](coro::mutex& m) -> coro::task<void>
     {
         {
             auto lk = co_await m.lock();
@@ -115,5 +115,5 @@ TEST_CASE("mutex scoped_lock unlock prior to scope exit", "[mutex]")
         co_return;
     };
 
-    coro::sync_wait(make_task());
+    coro::sync_wait(make_task(m));
 }

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -22,7 +22,8 @@ TEST_CASE("ring_buffer single element", "[ring_buffer]")
         co_return;
     };
 
-    auto make_consumer_task = [](coro::ring_buffer<uint64_t, 1>& rb, size_t iterations, std::vector<uint64_t>& output) -> coro::task<void>
+    auto make_consumer_task =
+        [](coro::ring_buffer<uint64_t, 1>& rb, size_t iterations, std::vector<uint64_t>& output) -> coro::task<void>
     {
         for (size_t i = 1; i <= iterations; ++i)
         {

--- a/test/test_semaphore.cpp
+++ b/test/test_semaphore.cpp
@@ -3,8 +3,8 @@
 #include <coro/coro.hpp>
 
 #include <chrono>
-#include <thread>
 #include <iostream>
+#include <thread>
 #include <vector>
 
 TEST_CASE("semaphore binary", "[semaphore]")
@@ -113,7 +113,8 @@ TEST_CASE("semaphore ringbuffer", "[semaphore]")
 
     coro::semaphore s{2, 2};
 
-    auto make_consumer_task = [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
+    auto make_consumer_task =
+        [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -178,7 +179,8 @@ TEST_CASE("semaphore ringbuffer many producers and consumers", "[semaphore]")
 
     coro::thread_pool tp{}; // let er rip
 
-    auto make_consumer_task = [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
+    auto make_consumer_task =
+        [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -199,7 +201,8 @@ TEST_CASE("semaphore ringbuffer many producers and consumers", "[semaphore]")
         co_return;
     };
 
-    auto make_producer_task = [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
+    auto make_producer_task =
+        [](coro::thread_pool& tp, coro::semaphore& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp.schedule();
 

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -12,7 +12,8 @@ TEST_CASE("mutex single waiter not locked exclusive", "[shared_mutex]")
 
     coro::shared_mutex<coro::thread_pool> m{tp};
 
-    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m, std::vector<uint64_t>& output) -> coro::task<void>
+    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m,
+                                std::vector<uint64_t>&                 output) -> coro::task<void>
     {
         std::cerr << "Acquiring lock exclusive\n";
         {
@@ -47,7 +48,8 @@ TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
 
     coro::shared_mutex<coro::thread_pool> m{tp};
 
-    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m, std::vector<uint64_t>& values) -> coro::task<void>
+    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m,
+                                std::vector<uint64_t>&                 values) -> coro::task<void>
     {
         std::cerr << "Acquiring lock shared\n";
         {
@@ -89,7 +91,9 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
 
     std::atomic<bool> read_value{false};
 
-    auto make_exclusive_task = [](std::shared_ptr<coro::io_scheduler>& s, coro::shared_mutex<coro::io_scheduler>& m, std::atomic<bool>& read_value) -> coro::task<void>
+    auto make_exclusive_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+                                  coro::shared_mutex<coro::io_scheduler>& m,
+                                  std::atomic<bool>&                      read_value) -> coro::task<void>
     {
         // Let some readers get through.
         co_await s->yield_for(std::chrono::milliseconds{50});
@@ -107,9 +111,13 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
         co_return;
     };
 
-    auto make_shared_tasks_task = [](std::shared_ptr<coro::io_scheduler>& s, coro::shared_mutex<coro::io_scheduler>& m, std::atomic<bool>& read_value) -> coro::task<void>
+    auto make_shared_tasks_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+                                     coro::shared_mutex<coro::io_scheduler>& m,
+                                     std::atomic<bool>&                      read_value) -> coro::task<void>
     {
-        auto make_shared_task = [](std::shared_ptr<coro::io_scheduler>& s, coro::shared_mutex<coro::io_scheduler>& m, std::atomic<bool>& read_value) -> coro::task<bool>
+        auto make_shared_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+                                   coro::shared_mutex<coro::io_scheduler>& m,
+                                   std::atomic<bool>&                      read_value) -> coro::task<bool>
         {
             co_await s->schedule();
             std::cerr << "make_shared_task shared lock acquiring\n";

--- a/test/test_sync_wait.cpp
+++ b/test/test_sync_wait.cpp
@@ -18,26 +18,25 @@ TEST_CASE("sync_wait void", "[sync_wait]")
 {
     std::string output;
 
-    auto func = [&]() -> coro::task<void>
+    auto func = [](std::string& output) -> coro::task<void>
     {
         output = "hello from sync_wait<void>\n";
         co_return;
     };
 
-    coro::sync_wait(func());
+    coro::sync_wait(func(output));
     REQUIRE(output == "hello from sync_wait<void>\n");
 }
 
 TEST_CASE("sync_wait task co_await single", "[sync_wait]")
 {
-    auto answer = []() -> coro::task<int>
+    auto await_answer = []() -> coro::task<int>
     {
-        std::cerr << "\tThinking deep thoughts...\n";
-        co_return 42;
-    };
-
-    auto await_answer = [&]() -> coro::task<int>
-    {
+        auto answer = []() -> coro::task<int>
+        {
+            std::cerr << "\tThinking deep thoughts...\n";
+            co_return 42;
+        };
         std::cerr << "\tStarting to wait for answer.\n";
         auto a = answer();
         std::cerr << "\tGot the coroutine, getting the value.\n";
@@ -85,7 +84,7 @@ TEST_CASE("sync_wait very rarely hangs issue-270", "[sync_wait]")
 
     std::atomic<int> count{0};
 
-    auto make_task = [&](int i) -> coro::task<void>
+    auto make_task = [](coro::thread_pool& tp, std::unordered_set<int>& data, std::atomic<int>& count, int i) -> coro::task<void>
     {
         co_await tp.schedule();
 
@@ -101,7 +100,7 @@ TEST_CASE("sync_wait very rarely hangs issue-270", "[sync_wait]")
     tasks.reserve(ITERATIONS);
     for (int i = 0; i < ITERATIONS; ++i)
     {
-        tasks.emplace_back(make_task(i));
+        tasks.emplace_back(make_task(tp, data, count, i));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/test/test_sync_wait.cpp
+++ b/test/test_sync_wait.cpp
@@ -84,7 +84,8 @@ TEST_CASE("sync_wait very rarely hangs issue-270", "[sync_wait]")
 
     std::atomic<int> count{0};
 
-    auto make_task = [](coro::thread_pool& tp, std::unordered_set<int>& data, std::atomic<int>& count, int i) -> coro::task<void>
+    auto make_task =
+        [](coro::thread_pool& tp, std::unordered_set<int>& data, std::atomic<int>& count, int i) -> coro::task<void>
     {
         co_await tp.schedule();
 

--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -179,13 +179,13 @@ TEST_CASE("task multiple suspends return integer", "[task]")
 
 TEST_CASE("task resume from promise to coroutine handles of different types", "[task]")
 {
-    auto task1 = [&]() -> coro::task<int>
+    auto task1 = []() -> coro::task<int>
     {
         std::cerr << "Task ran\n";
         co_return 42;
     }();
 
-    auto task2 = [&]() -> coro::task<void>
+    auto task2 = []() -> coro::task<void>
     {
         std::cerr << "Task 2 ran\n";
         co_return;
@@ -323,8 +323,8 @@ TEST_CASE("task supports instantiation with rvalue reference", "[task]")
     // reference is supported.
 
     int  i         = 42;
-    auto make_task = [&i]() -> coro::task<int&&> { co_return std::move(i); };
-    int  ret       = coro::sync_wait(make_task());
+    auto make_task = [](int& i) -> coro::task<int&&> { co_return std::move(i); };
+    int  ret       = coro::sync_wait(make_task(i));
     REQUIRE(ret == 42);
 }
 
@@ -416,10 +416,10 @@ TEST_CASE("task supports instantiation with non assignable type", "[task]")
     REQUIRE(move_copy_construct_only::move_count == 2);
     REQUIRE(move_copy_construct_only::copy_count == 1);
 
-    auto make_tuple_task = [&i]() -> coro::task<std::tuple<int, int>> {
+    auto make_tuple_task = [](int i) -> coro::task<std::tuple<int, int>> {
         co_return {i, i * 2};
     };
-    auto tuple_ret = coro::sync_wait(make_tuple_task());
+    auto tuple_ret = coro::sync_wait(make_tuple_task(i));
     REQUIRE(std::get<0>(tuple_ret) == 42);
     REQUIRE(std::get<1>(tuple_ret) == 84);
 

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -238,12 +238,11 @@ TEST_CASE("issue-287", "[thread_pool]")
     const int ITERATIONS = 200000;
 
     std::atomic<uint32_t> g_count = 0;
-    auto thread_pool = std::make_shared<coro::thread_pool>(
-        coro::thread_pool::options{.thread_count = 1}
-    );
-    auto task_container = coro::task_container<coro::thread_pool>{thread_pool};
+    auto thread_pool              = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto task_container           = coro::task_container<coro::thread_pool>{thread_pool};
 
-    auto task = [](std::atomic<uint32_t>& count) -> coro::task<void> {
+    auto task = [](std::atomic<uint32_t>& count) -> coro::task<void>
+    {
         count++;
         co_return;
     };

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -175,7 +175,7 @@ TEST_CASE("thread_pool event jump threads", "[thread_pool]")
 
     coro::event e{};
 
-    auto make_tp1_task = [&]() -> coro::task<void>
+    auto make_tp1_task = [](coro::thread_pool& tp1, coro::event& e) -> coro::task<void>
     {
         co_await tp1.schedule();
         auto before_thread_id = std::this_thread::get_id();
@@ -189,7 +189,7 @@ TEST_CASE("thread_pool event jump threads", "[thread_pool]")
         co_return;
     };
 
-    auto make_tp2_task = [&]() -> coro::task<void>
+    auto make_tp2_task = [](coro::thread_pool& tp2, coro::event& e) -> coro::task<void>
     {
         co_await tp2.schedule();
         std::this_thread::sleep_for(std::chrono::milliseconds{10});
@@ -198,7 +198,7 @@ TEST_CASE("thread_pool event jump threads", "[thread_pool]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_tp1_task(), make_tp2_task()));
+    coro::sync_wait(coro::when_all(make_tp1_task(tp1, e), make_tp2_task(tp2, e)));
 }
 
 TEST_CASE("thread_pool high cpu usage when threadcount is greater than the number of tasks", "[thread_pool]")
@@ -210,14 +210,14 @@ TEST_CASE("thread_pool high cpu usage when threadcount is greater than the numbe
     // This was due to using m_size instead of m_queue.size() causing the threads
     // that had no work to go into a spin trying to acquire work.
 
-    auto sleep_for_task = [](std::chrono::seconds duration) -> coro::task<int>
+    auto wait_for_task = [](coro::thread_pool& pool, std::chrono::seconds delay) -> coro::task<>
     {
-        std::this_thread::sleep_for(duration);
-        co_return duration.count();
-    };
+        auto sleep_for_task = [](std::chrono::seconds duration) -> coro::task<int>
+        {
+            std::this_thread::sleep_for(duration);
+            co_return duration.count();
+        };
 
-    auto wait_for_task = [&](coro::thread_pool& pool, std::chrono::seconds delay) -> coro::task<>
-    {
         co_await pool.schedule();
         for (int i = 0; i < 5; ++i)
         {

--- a/test/test_when_all.cpp
+++ b/test/test_when_all.cpp
@@ -112,18 +112,18 @@ TEST_CASE("when_all multple task withs list container", "[when_all]")
 TEST_CASE("when_all inside coroutine", "[when_all]")
 {
     coro::thread_pool tp{};
-    auto              make_task = [&](uint64_t amount) -> coro::task<uint64_t>
+    auto              make_task = [](coro::thread_pool& tp, uint64_t amount) -> coro::task<uint64_t>
     {
         co_await tp.schedule();
         co_return amount;
     };
 
-    auto runner_task = [&]() -> coro::task<uint64_t>
+    auto runner_task = [](coro::thread_pool& tp, auto make_task) -> coro::task<uint64_t>
     {
         std::list<coro::task<uint64_t>> tasks;
-        tasks.emplace_back(make_task(1));
-        tasks.emplace_back(make_task(2));
-        tasks.emplace_back(make_task(3));
+        tasks.emplace_back(make_task(tp, 1));
+        tasks.emplace_back(make_task(tp, 2));
+        tasks.emplace_back(make_task(tp, 3));
 
         auto output_tasks = co_await coro::when_all(std::move(tasks));
 
@@ -135,7 +135,7 @@ TEST_CASE("when_all inside coroutine", "[when_all]")
         co_return result;
     };
 
-    auto result = coro::sync_wait(runner_task());
+    auto result = coro::sync_wait(runner_task(tp, make_task));
 
     REQUIRE(result == (1 + 2 + 3));
 }
@@ -144,18 +144,17 @@ TEST_CASE("when_all use std::ranges::view", "[when_all]")
 {
     coro::thread_pool tp{};
 
-    auto make_task = [&](uint64_t amount) -> coro::task<uint64_t>
+    auto make_runner_task = [](coro::thread_pool& tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule();
-        co_return amount;
-    };
-
-    auto make_runner_task = [&]() -> coro::task<uint64_t>
-    {
+        auto make_task = [](coro::thread_pool& tp, uint64_t amount) -> coro::task<uint64_t>
+        {
+            co_await tp.schedule();
+            co_return amount;
+        };
         std::vector<coro::task<uint64_t>> tasks;
-        tasks.emplace_back(make_task(1));
-        tasks.emplace_back(make_task(2));
-        tasks.emplace_back(make_task(3));
+        tasks.emplace_back(make_task(tp, 1));
+        tasks.emplace_back(make_task(tp, 2));
+        tasks.emplace_back(make_task(tp, 3));
 
         auto output_tasks = co_await coro::when_all(std::ranges::views::all(tasks));
 
@@ -167,7 +166,7 @@ TEST_CASE("when_all use std::ranges::view", "[when_all]")
         co_return result;
     };
 
-    auto result = coro::sync_wait(make_runner_task());
+    auto result = coro::sync_wait(make_runner_task(tp));
     REQUIRE(result == (1 + 2 + 3));
 }
 
@@ -175,7 +174,7 @@ TEST_CASE("when_all each task throws", "[when_all]")
 {
     coro::thread_pool tp{};
 
-    auto make_task = [&](uint64_t i) -> coro::task<uint64_t>
+    auto make_task = [](coro::thread_pool& tp, uint64_t i) -> coro::task<uint64_t>
     {
         co_await tp.schedule();
         if (i % 2 == 0)
@@ -188,7 +187,7 @@ TEST_CASE("when_all each task throws", "[when_all]")
     std::vector<coro::task<uint64_t>> tasks;
     for (auto i = 1; i <= 4; ++i)
     {
-        tasks.emplace_back(make_task(i));
+        tasks.emplace_back(make_task(tp, i));
     }
 
     auto output_tasks = coro::sync_wait(coro::when_all(std::move(tasks)));


### PR DESCRIPTION
Core guidlines point out that captures are only safe up until the first suspension point, so its recommended to remove them entirely.

Closes #285