### PR TITLE
sync_wait() remove extra move constructor call

### DIFF
--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -102,7 +102,7 @@ public:
         }
     }
 
-    auto return_value(stored_type value) -> void requires(not return_type_is_reference)
+    auto return_value(stored_type&& value) -> void requires(not return_type_is_reference)
     {
         if constexpr (std::is_move_constructible_v<stored_type>)
         {

--- a/test/test_sync_wait.cpp
+++ b/test/test_sync_wait.cpp
@@ -114,21 +114,21 @@ struct Foo
     static std::atomic<uint64_t> m_copies;
     static std::atomic<uint64_t> m_moves;
     int                          v;
-    Foo() { std::cerr << __PRETTY_FUNCTION__ << std::endl; }
+    Foo() { std::cerr << "Foo::Foo()" << std::endl; }
     Foo(const Foo& other) : v(other.v)
     {
-        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+        std::cerr << "Foo::Foo(const Foo&)" << std::endl;
         m_copies.fetch_add(1);
     }
     Foo(Foo&& other) : v(std::exchange(other.v, 0))
     {
-        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+        std::cerr << "Foo::Foo(Foo&&)" << std::endl;
         m_moves.fetch_add(1);
     }
 
     auto operator=(const Foo& other) -> Foo&
     {
-        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+        std::cerr << "Foo::operator=(const Foo&) -> Foo&" << std::endl;
         m_copies.fetch_add(1);
         if (std::addressof(other) != this)
         {
@@ -138,7 +138,7 @@ struct Foo
     }
     auto operator=(Foo&& other) -> Foo&
     {
-        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+        std::cerr << "Foo::operator=(Foo&&) -> Foo&" << std::endl;
         m_moves.fetch_add(1);
         if (std::addressof(other) != this)
         {
@@ -147,7 +147,11 @@ struct Foo
         return *this;
     }
 
-    ~Foo() { std::cerr << __PRETTY_FUNCTION__ << "v=" << this->v << std::endl; }
+    ~Foo()
+    {
+        std::cerr << "Foo::~Foo()"
+                  << "v=" << this->v << std::endl;
+    }
 };
 
 std::atomic<uint64_t> Foo::m_copies = std::atomic<uint64_t>{0};

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -183,7 +183,7 @@ TEST_CASE("thread_pool high cpu usage when threadcount is greater than the numbe
 
     auto wait_for_task = [](coro::thread_pool& pool, std::chrono::seconds delay) -> coro::task<>
     {
-        auto sleep_for_task = [](std::chrono::seconds duration) -> coro::task<int>
+        auto sleep_for_task = [](std::chrono::seconds duration) -> coro::task<int64_t>
         {
             std::this_thread::sleep_for(duration);
             co_return duration.count();


### PR DESCRIPTION
User @baderouaich identified that libcoro's sync_wait on a complex object would invoke an extra move constructor that other coroutine libraries did not. This change now correctly forwards the return_value into the promise if the object is move constructible instead of double moving.

Closes #286