### PR TITLE
std::shared_ptr passed by value instead of by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ int main()
 
     // This task does 'work' and counts down on the latch when completed.  The final child task to
     // complete will end up resuming the latch task when the latch's count reaches zero.
-    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler>& tp, coro::latch& l, int64_t i) -> coro::task<void>
+    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler> tp, coro::latch& l, int64_t i) -> coro::task<void>
     {
         // Schedule the worker task onto the thread pool.
         co_await tp->schedule();

--- a/examples/coro_latch.cpp
+++ b/examples/coro_latch.cpp
@@ -27,7 +27,7 @@ int main()
 
     // This task does 'work' and counts down on the latch when completed.  The final child task to
     // complete will end up resuming the latch task when the latch's count reaches zero.
-    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler>& tp, coro::latch& l, int64_t i) -> coro::task<void>
+    auto make_worker_task = [](std::shared_ptr<coro::io_scheduler> tp, coro::latch& l, int64_t i) -> coro::task<void>
     {
         // Schedule the worker task onto the thread pool.
         co_await tp->schedule();

--- a/test/net/test_dns_resolver.cpp
+++ b/test/net/test_dns_resolver.cpp
@@ -12,7 +12,7 @@ TEST_CASE("dns_resolver basic", "[dns]")
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
     coro::net::dns::resolver<coro::io_scheduler> dns_resolver{scheduler, std::chrono::milliseconds{5000}};
 
-    auto make_host_by_name_task = [](std::shared_ptr<coro::io_scheduler>&          scheduler,
+    auto make_host_by_name_task = [](std::shared_ptr<coro::io_scheduler>           scheduler,
                                      coro::net::dns::resolver<coro::io_scheduler>& dns_resolver,
                                      coro::net::hostname                           hn) -> coro::task<void>
     {

--- a/test/net/test_tcp_server.cpp
+++ b/test/net/test_tcp_server.cpp
@@ -14,9 +14,9 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
     auto scheduler = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_client_task = [](std::shared_ptr<coro::io_scheduler>& scheduler,
-                               const std::string&                   client_msg,
-                               const std::string&                   server_msg) -> coro::task<void>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+                               const std::string&                  client_msg,
+                               const std::string&                  server_msg) -> coro::task<void>
     {
         co_await scheduler->schedule();
         coro::net::tcp::client client{scheduler};
@@ -49,7 +49,7 @@ TEST_CASE("tcp_server ping server", "[tcp_server]")
         co_return;
     };
 
-    auto make_server_task = [](std::shared_ptr<coro::io_scheduler>& scheduler,
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
                                const std::string&                   client_msg,
                                const std::string&                   server_msg) -> coro::task<void>
     {
@@ -99,7 +99,7 @@ TEST_CASE("tcp_server concurrent polling on the same socket", "[tcp_server]")
     auto scheduler = coro::io_scheduler::make_shared(coro::io_scheduler::options{
         .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_inline});
 
-    auto make_server_task = [](std::shared_ptr<coro::io_scheduler>& scheduler) -> coro::task<std::string>
+    auto make_server_task = [](std::shared_ptr<coro::io_scheduler> scheduler) -> coro::task<std::string>
     {
         auto make_read_task = [](coro::net::tcp::client client) -> coro::task<void>
         {
@@ -144,7 +144,7 @@ TEST_CASE("tcp_server concurrent polling on the same socket", "[tcp_server]")
         co_return data;
     };
 
-    auto make_client_task = [](std::shared_ptr<coro::io_scheduler>& scheduler) -> coro::task<std::string>
+    auto make_client_task = [](std::shared_ptr<coro::io_scheduler> scheduler) -> coro::task<std::string>
     {
         co_await scheduler->schedule();
         coro::net::tcp::client client{scheduler};

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -598,10 +598,10 @@ TEST_CASE("io_scheduler self generating coroutine (stack overflow check)", "[io_
     std::vector<coro::task<void>> tasks;
     tasks.reserve(total);
 
-    auto func = [](std::shared_ptr<coro::io_scheduler>& s,
-                   uint64_t&                            counter,
-                   auto                                 f,
-                   std::vector<coro::task<void>>&       tasks) -> coro::task<void>
+    auto func = [](std::shared_ptr<coro::io_scheduler> s,
+                   uint64_t&                           counter,
+                   auto                                f,
+                   std::vector<coro::task<void>>&      tasks) -> coro::task<void>
     {
         co_await s->schedule();
         ++counter;

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -92,7 +92,7 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
 
     std::atomic<bool> read_value{false};
 
-    auto make_exclusive_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+    auto make_exclusive_task = [](std::shared_ptr<coro::io_scheduler>     s,
                                   coro::shared_mutex<coro::io_scheduler>& m,
                                   std::atomic<bool>&                      read_value) -> coro::task<void>
     {
@@ -112,11 +112,11 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
         co_return;
     };
 
-    auto make_shared_tasks_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+    auto make_shared_tasks_task = [](std::shared_ptr<coro::io_scheduler>     s,
                                      coro::shared_mutex<coro::io_scheduler>& m,
                                      std::atomic<bool>&                      read_value) -> coro::task<void>
     {
-        auto make_shared_task = [](std::shared_ptr<coro::io_scheduler>&    s,
+        auto make_shared_task = [](std::shared_ptr<coro::io_scheduler>     s,
                                    coro::shared_mutex<coro::io_scheduler>& m,
                                    std::atomic<bool>&                      read_value) -> coro::task<bool>
         {


### PR DESCRIPTION
Modify `std::shared_ptr` to pass by value in the README and  tests.