### PR TITLE
Adds coro::queue<T>

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -71,6 +71,10 @@ example_contents=$(cat 'examples/coro_ring_buffer.cpp')
 echo "${template_contents/\$\{EXAMPLE_CORO_RING_BUFFER_CPP\}/$example_contents}" > README.md
 
 template_contents=$(cat 'README.md')
+example_contents=$(cat 'examples/coro_queue.cpp')
+echo "${template_contents/\$\{EXAMPLE_CORO_QUEUE_CPP\}/$example_contents}" > README.md
+
+template_contents=$(cat 'README.md')
 example_contents=$(cat 'examples/coro_shared_mutex.cpp')
 echo "${template_contents/\$\{EXAMPLE_CORO_SHARED_MUTEX_CPP\}/$example_contents}" > README.md
 

--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -25,6 +25,7 @@
     - [coro::shared_mutex](#shared_mutex)
     - [coro::semaphore](#semaphore)
     - [coro::ring_buffer<element, num_elements>](#ring_buffer)
+    - [coro::queue](#queue)
 * Schedulers
     - [coro::thread_pool](#thread_pool) for coroutine cooperative multitasking
     - [coro::io_scheduler](#io_scheduler) for driving i/o events
@@ -264,6 +265,43 @@ consumer 0 shutting down, stop signal received
 consumer 1 shutting down, stop signal received
 consumer 2 shutting down, stop signal received
 consumer 3 shutting down, stop signal received
+```
+
+### queue
+The `coro::queue<element_type>` is thread safe async multi-producer multi-consumer queue. Producing into the queue is not an asynchronous operation, it will either immediately use a consumer that is awaiting on `pop()` to process the element, or if no consumer is available place the element into the queue. All consume waiters on the queue are resumed in a LIFO manner when an element becomes available to consume.
+
+```C++
+${EXAMPLE_CORO_QUEUE_CPP}
+```
+
+Expected output:
+```bash
+$ ./examples/coro_queue
+consumed 0
+consumed 1
+consumed 0
+consumed 2
+consumed 3
+consumed 4
+consumed 1
+consumed 0
+consumed 0
+consumed 0
+consumed 1
+consumed 1
+consumed 2
+consumed 2
+consumed 3
+consumed 4
+consumed 3
+consumed 4
+consumed 2
+consumed 3
+consumed 4
+consumed 1
+consumed 2
+consumed 3
+consumed 4
 ```
 
 ### thread_pool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/generator.hpp
     include/coro/latch.hpp
     include/coro/mutex.hpp src/mutex.cpp
+    include/coro/queue.hpp
     include/coro/ring_buffer.hpp
     include/coro/semaphore.hpp src/semaphore.cpp
     include/coro/shared_mutex.hpp

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     - [coro::shared_mutex](#shared_mutex)
     - [coro::semaphore](#semaphore)
     - [coro::ring_buffer<element, num_elements>](#ring_buffer)
+    - [coro::queue](#queue)
 * Schedulers
     - [coro::thread_pool](#thread_pool) for coroutine cooperative multitasking
     - [coro::io_scheduler](#io_scheduler) for driving i/o events
@@ -797,6 +798,115 @@ consumer 0 shutting down, stop signal received
 consumer 1 shutting down, stop signal received
 consumer 2 shutting down, stop signal received
 consumer 3 shutting down, stop signal received
+```
+
+### queue
+The `coro::queue<element_type>` is thread safe async multi-producer multi-consumer queue. Producing into the queue is not an asynchronous operation, it will either immediately use a consumer that is awaiting on `pop()` to process the element, or if no consumer is available place the element into the queue. All consume waiters on the queue are resumed in a LIFO manner when an element becomes available to consume.
+
+```C++
+#include <coro/coro.hpp>
+#include <iostream>
+
+int main()
+{
+    const size_t iterations      = 5;
+    const size_t producers_count = 5;
+    const size_t consumers_count = 2;
+
+    coro::thread_pool     tp{};
+    coro::queue<uint64_t> q{};
+    coro::latch           producers_done{producers_count};
+    coro::mutex           m{}; /// Just for making the console prints look nice.
+
+    auto make_producer_task =
+        [iterations](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& pd) -> coro::task<void>
+    {
+        co_await tp.schedule();
+
+        for (size_t i = 0; i < iterations; ++i)
+        {
+            q.push(i);
+        }
+
+        pd.count_down(); // Notify the shutdown task this producer is complete.
+        co_return;
+    };
+
+    auto make_shutdown_task = [](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& pd) -> coro::task<void>
+    {
+        // This task will wait for all the producers to complete and then for the
+        // entire queue to be drained before shutting it down.
+        co_await tp.schedule();
+        co_await pd;
+        while (!q.empty())
+        {
+            co_await tp.yield();
+        }
+        q.shutdown_notify_waiters();
+        co_return;
+    };
+
+    auto make_consumer_task = [](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::mutex& m) -> coro::task<void>
+    {
+        co_await tp.schedule();
+
+        while (true)
+        {
+            auto expected = co_await q.pop();
+            if (!expected)
+            {
+                break; // coro::queue is shutting down
+            }
+
+            auto scoped_lock = co_await m.lock(); // Only used to make the output look nice.
+            std::cout << "consumed " << *expected << "\n";
+        }
+    };
+
+    std::vector<coro::task<void>> tasks{};
+
+    for (size_t i = 0; i < producers_count; ++i)
+    {
+        tasks.push_back(make_producer_task(tp, q, producers_done));
+    }
+    for (size_t i = 0; i < consumers_count; ++i)
+    {
+        tasks.push_back(make_consumer_task(tp, q, m));
+    }
+    tasks.push_back(make_shutdown_task(tp, q, producers_done));
+
+    coro::sync_wait(coro::when_all(std::move(tasks)));
+}
+```
+
+Expected output:
+```bash
+$ ./examples/coro_queue
+consumed 0
+consumed 1
+consumed 0
+consumed 2
+consumed 3
+consumed 4
+consumed 1
+consumed 0
+consumed 0
+consumed 0
+consumed 1
+consumed 1
+consumed 2
+consumed 2
+consumed 3
+consumed 4
+consumed 3
+consumed 4
+consumed 2
+consumed 3
+consumed 4
+consumed 1
+consumed 2
+consumed 3
+consumed 4
 ```
 
 ### thread_pool

--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ int main()
 
         for (size_t i = 0; i < iterations; ++i)
         {
-            q.push(i);
+            co_await q.push(i);
         }
 
         pd.count_down(); // Notify the shutdown task this producer is complete.
@@ -838,11 +838,7 @@ int main()
         // entire queue to be drained before shutting it down.
         co_await tp.schedule();
         co_await pd;
-        while (!q.empty())
-        {
-            co_await tp.yield();
-        }
-        q.shutdown_notify_waiters();
+        co_await q.shutdown_notify_waiters_drain(tp);
         co_return;
     };
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,10 @@ add_executable(coro_shared_mutex coro_shared_mutex.cpp)
 target_link_libraries(coro_shared_mutex PUBLIC libcoro)
 target_compile_options(coro_shared_mutex PUBLIC ${LIBCORO_EXAMPLE_OPTIONS})
 
+add_executable(coro_queue coro_queue.cpp)
+target_link_libraries(coro_queue PUBLIC libcoro)
+target_compile_options(coro_queue PUBLIC ${LIBCORO_EXAMPLE_OPTIONS})
+
 add_executable(coro_sync_wait coro_sync_wait.cpp)
 target_link_libraries(coro_sync_wait PUBLIC libcoro)
 target_compile_options(coro_sync_wait PUBLIC ${LIBCORO_EXAMPLE_OPTIONS})

--- a/examples/coro_queue.cpp
+++ b/examples/coro_queue.cpp
@@ -1,0 +1,73 @@
+#include <coro/coro.hpp>
+#include <iostream>
+
+int main()
+{
+    const size_t iterations      = 5;
+    const size_t producers_count = 5;
+    const size_t consumers_count = 2;
+
+    coro::thread_pool     tp{};
+    coro::queue<uint64_t> q{};
+    coro::latch           producers_done{producers_count};
+    coro::mutex           m{}; /// Just for making the console prints look nice.
+
+    auto make_producer_task =
+        [iterations](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& pd) -> coro::task<void>
+    {
+        co_await tp.schedule();
+
+        for (size_t i = 0; i < iterations; ++i)
+        {
+            q.push(i);
+        }
+
+        pd.count_down(); // Notify the shutdown task this producer is complete.
+        co_return;
+    };
+
+    auto make_shutdown_task = [](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& pd) -> coro::task<void>
+    {
+        // This task will wait for all the producers to complete and then for the
+        // entire queue to be drained before shutting it down.
+        co_await tp.schedule();
+        co_await pd;
+        while (!q.empty())
+        {
+            co_await tp.yield();
+        }
+        q.shutdown_notify_waiters();
+        co_return;
+    };
+
+    auto make_consumer_task = [](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::mutex& m) -> coro::task<void>
+    {
+        co_await tp.schedule();
+
+        while (true)
+        {
+            auto expected = co_await q.pop();
+            if (!expected)
+            {
+                break; // coro::queue is shutting down
+            }
+
+            auto scoped_lock = co_await m.lock(); // Only used to make the output look nice.
+            std::cout << "consumed " << *expected << "\n";
+        }
+    };
+
+    std::vector<coro::task<void>> tasks{};
+
+    for (size_t i = 0; i < producers_count; ++i)
+    {
+        tasks.push_back(make_producer_task(tp, q, producers_done));
+    }
+    for (size_t i = 0; i < consumers_count; ++i)
+    {
+        tasks.push_back(make_consumer_task(tp, q, m));
+    }
+    tasks.push_back(make_shutdown_task(tp, q, producers_done));
+
+    coro::sync_wait(coro::when_all(std::move(tasks)));
+}

--- a/examples/coro_queue.cpp
+++ b/examples/coro_queue.cpp
@@ -19,7 +19,7 @@ int main()
 
         for (size_t i = 0; i < iterations; ++i)
         {
-            q.push(i);
+            co_await q.push(i);
         }
 
         pd.count_down(); // Notify the shutdown task this producer is complete.
@@ -32,11 +32,7 @@ int main()
         // entire queue to be drained before shutting it down.
         co_await tp.schedule();
         co_await pd;
-        while (!q.empty())
-        {
-            co_await tp.yield();
-        }
-        q.shutdown_notify_waiters();
+        co_await q.shutdown_notify_waiters_drain(tp);
         co_return;
     };
 

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -33,6 +33,7 @@
 #include "coro/generator.hpp"
 #include "coro/latch.hpp"
 #include "coro/mutex.hpp"
+#include "coro/queue.hpp"
 #include "coro/ring_buffer.hpp"
 #include "coro/semaphore.hpp"
 #include "coro/shared_mutex.hpp"

--- a/include/coro/queue.hpp
+++ b/include/coro/queue.hpp
@@ -1,0 +1,286 @@
+#pragma once
+
+#include "coro/expected.hpp"
+
+#include <mutex>
+#include <queue>
+
+namespace coro
+{
+
+/// @brief Enum used for push() expected result.
+enum class queue_produce_result
+{
+    produced,
+    queue_stopped
+};
+
+/// @brief Enum used for pop() expected result when the queue is shutting down.
+enum class queue_consume_result
+{
+    queue_stopped
+};
+
+/// @brief
+/// @tparam element_type
+template<typename element_type>
+class queue
+{
+public:
+    struct awaiter
+    {
+        explicit awaiter(queue<element_type>& q) noexcept : m_queue(q) {}
+
+        auto await_ready() noexcept -> bool
+        {
+            // This awaiter is ready when it has actually acquired an element or it is shutting down.
+            if (m_queue.m_stopped.load(std::memory_order::acquire))
+            {
+                return false;
+            }
+
+            std::scoped_lock lock{m_queue.m_mutex};
+            if (!m_queue.empty())
+            {
+                if constexpr (std::is_move_constructible_v<element_type>)
+                {
+                    m_element = std::move(m_queue.m_elements.front());
+                }
+                else
+                {
+                    m_element = m_queue.m_elements.front();
+                }
+
+                m_queue.m_elements.pop();
+                return true;
+            }
+
+            return false;
+        }
+
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+        {
+            // Don't suspend if the stop signal has been set.
+            if (m_queue.m_stopped.load(std::memory_order::acquire))
+            {
+                return false;
+            }
+
+            std::scoped_lock lock{m_queue.m_mutex};
+            if (!m_queue.empty())
+            {
+                if constexpr (std::is_move_constructible_v<element_type>)
+                {
+                    m_element = std::move(m_queue.m_elements.front());
+                }
+                else
+                {
+                    m_element = m_queue.m_elements.front();
+                }
+
+                m_queue.m_elements.pop();
+                return false;
+            }
+
+            // No element is ready, put ourselves on the waiter list and suspend.
+            this->m_next         = m_queue.m_waiters;
+            m_queue.m_waiters    = this;
+            m_awaiting_coroutine = awaiting_coroutine;
+
+            return true;
+        }
+
+        [[nodiscard]] auto await_resume() noexcept -> expected<element_type, queue_consume_result>
+        {
+            if (m_queue.m_stopped.load(std::memory_order::acquire))
+            {
+                return unexpected<queue_consume_result>(queue_consume_result::queue_stopped);
+            }
+
+            if constexpr (std::is_move_constructible_v<element_type>)
+            {
+                return std::move(m_element.value());
+            }
+            else
+            {
+                return m_element.value();
+            }
+        }
+
+        std::optional<element_type> m_element{std::nullopt};
+        queue&                      m_queue;
+        std::coroutine_handle<>     m_awaiting_coroutine{nullptr};
+        /// The next awaiter in line for this queue, nullptr if this is the end.
+        awaiter* m_next{nullptr};
+    };
+
+    queue() {}
+    ~queue() {}
+
+    queue(const queue&) = delete;
+    queue(queue&& other)
+    {
+        m_waiters  = std::exchange(other.m_waiters, nullptr);
+        m_mutex    = std::move(other.m_mutex);
+        m_elements = std::move(other.m_elements);
+    }
+
+    auto operator=(const queue&) -> queue& = delete;
+    auto operator=(queue&& other) -> queue&
+    {
+        if (std::addressof(other) != this)
+        {
+            m_waiters  = std::exchange(other.m_waiters, nullptr);
+            m_mutex    = std::move(other.m_mutex);
+            m_elements = std::move(other.m_elements);
+        }
+
+        return *this;
+    }
+
+    /// @brief Determines if the queue is empty.
+    /// @return True if the queue has no elements.
+    auto empty() const -> bool { return size() == 0; }
+
+    /// @brief Gets the current number of elements in the queue.
+    /// @return The number of elements in the queue.
+    auto size() const -> std::size_t
+    {
+        std::atomic_thread_fence(std::memory_order::acquire);
+        return m_elements.size();
+    }
+
+    /// @brief Pushes the element into the queue.
+    /// @param element The element to push.
+    /// @return void.
+    auto push(const element_type& element) -> queue_produce_result
+    {
+        if (m_stopped.load(std::memory_order::acquire))
+        {
+            return queue_produce_result::queue_stopped;
+        }
+
+        // The general idea is to see if anyone is waiting, and if so directly transfer the element
+        // to that waiter. If there is nobody waiting then move the element into the queue.
+        std::unique_lock lock{m_mutex};
+
+        if (m_waiters != nullptr)
+        {
+            awaiter* waiter = m_waiters;
+            m_waiters       = m_waiters->m_next;
+            lock.unlock();
+
+            // Transfer the element directly to the awaiter.
+            waiter->m_element = element;
+            waiter->m_awaiting_coroutine.resume();
+        }
+        else
+        {
+            m_elements.push(element);
+        }
+
+        return queue_produce_result::produced;
+    }
+
+    /// @brief Pushes the element into the queue.
+    /// @param element The element to push.
+    /// @return void.
+    auto push(element_type&& element) -> queue_produce_result
+    {
+        if (m_stopped.load(std::memory_order::acquire))
+        {
+            return queue_produce_result::queue_stopped;
+        }
+
+        std::unique_lock lock{m_mutex};
+
+        if (m_waiters != nullptr)
+        {
+            awaiter* waiter = m_waiters;
+            m_waiters       = m_waiters->m_next;
+            lock.unlock();
+
+            // Transfer the element directly to the awaiter.
+            waiter->m_element = std::move(element);
+            waiter->m_awaiting_coroutine.resume();
+        }
+        else
+        {
+            m_elements.push(std::move(element));
+        }
+
+        return queue_produce_result::produced;
+    }
+
+    /// @brief Emplaces the element into the queue.
+    /// @tparam ...args_type The element's constructor argument types.
+    /// @param ...args The element's constructor arguments.
+    /// @return void.
+    template<class... args_type>
+    auto emplace(args_type&&... args) -> queue_produce_result
+    {
+        if (m_stopped.load(std::memory_order::acquire))
+        {
+            return queue_produce_result::queue_stopped;
+        }
+
+        std::unique_lock lock{m_mutex};
+
+        if (m_waiters != nullptr)
+        {
+            awaiter* waiter = m_waiters;
+            m_waiters       = m_waiters->m_next;
+            lock.unlock();
+
+            waiter->m_element.emplace(std::forward<args_type>(args)...);
+            waiter->m_awaiting_coroutine.resume();
+        }
+        else
+        {
+            m_elements.emplace(std::forward<args_type>(args)...);
+        }
+
+        return queue_produce_result::produced;
+    }
+
+    /// @brief Pops the head element of the queue if available, or waits for one to
+    ///        be available.
+    /// @return The head element, or coro::queue_consume_result::queue_stopped if the
+    ///         queue has been shutdown.
+    [[nodiscard]] auto pop() -> awaiter { return awaiter{*this}; }
+
+    /// @brief Shutsdown the queue and notifies all waiters of pop() to stop waiting.
+    /// @return void.
+    auto shutdown_notify_waiters() -> void
+    {
+        auto expected = false;
+        if (!m_stopped.compare_exchange_strong(expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
+        {
+            return;
+        }
+
+        std::unique_lock lock{m_mutex};
+        while (m_waiters != nullptr)
+        {
+            auto* to_resume = m_waiters;
+            m_waiters       = m_waiters->m_next;
+
+            lock.unlock();
+            to_resume->m_awaiting_coroutine.resume();
+            lock.lock();
+        }
+    }
+
+private:
+    friend awaiter;
+    /// @brief The list of pop() awaiters.
+    awaiter* m_waiters{nullptr};
+    /// @brief Mutex for properly maintaining the queue.
+    std::mutex m_mutex{};
+    /// @brief The underlying queue datastructure.
+    std::queue<element_type> m_elements{};
+    /// @brief Has this queue been shutdown?
+    std::atomic<bool> m_stopped{false};
+};
+
+} // namespace coro

--- a/include/coro/queue.hpp
+++ b/include/coro/queue.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "coro/concepts/executor.hpp"
 #include "coro/expected.hpp"
+#include "coro/sync_wait.hpp"
 
 #include <mutex>
 #include <queue>
@@ -8,21 +10,35 @@
 namespace coro
 {
 
-/// @brief Enum used for push() expected result.
 enum class queue_produce_result
 {
+    /**
+     * @brief The item was successfully produced.
+     */
     produced,
+    /**
+     * @brief The queue is shutting down or stopped, no more items are allowed to be produced.
+     */
     queue_stopped
 };
 
-/// @brief Enum used for pop() expected result when the queue is shutting down.
 enum class queue_consume_result
 {
+    /**
+     * @brief The queue has shut down/stopped and the user should stop calling pop().
+     */
     queue_stopped
 };
 
-/// @brief
-/// @tparam element_type
+
+/**
+ * @brief An unbounded queue. If the queue is empty and there are waiters to consume then
+ *        there are no allocations and the coroutine context will simply be passed to the
+ *        waiter. If there are no waiters the item being produced will be placed into the
+ *        queue.
+ *
+ * @tparam element_type The type of items being produced and consumed.
+ */
 template<typename element_type>
 class queue
 {
@@ -30,6 +46,16 @@ public:
     struct awaiter
     {
         explicit awaiter(queue<element_type>& q) noexcept : m_queue(q) {}
+
+        /**
+         * @brief Acquires the coro::queue lock.
+         *
+         * @return coro::task<scoped_lock>
+         */
+        auto make_acquire_lock_task() -> coro::task<scoped_lock>
+        {
+            co_return co_await m_queue.m_mutex.lock();
+        }
 
         auto await_ready() noexcept -> bool
         {
@@ -39,7 +65,7 @@ public:
                 return false;
             }
 
-            std::scoped_lock lock{m_queue.m_mutex};
+            auto lock = coro::sync_wait(make_acquire_lock_task());
             if (!m_queue.empty())
             {
                 if constexpr (std::is_move_constructible_v<element_type>)
@@ -66,7 +92,7 @@ public:
                 return false;
             }
 
-            std::scoped_lock lock{m_queue.m_mutex};
+            auto lock = coro::sync_wait(make_acquire_lock_task());
             if (!m_queue.empty())
             {
                 if constexpr (std::is_move_constructible_v<element_type>)
@@ -92,18 +118,21 @@ public:
 
         [[nodiscard]] auto await_resume() noexcept -> expected<element_type, queue_consume_result>
         {
-            if (m_queue.m_stopped.load(std::memory_order::acquire))
+            if (m_element.has_value())
             {
-                return unexpected<queue_consume_result>(queue_consume_result::queue_stopped);
-            }
-
-            if constexpr (std::is_move_constructible_v<element_type>)
-            {
-                return std::move(m_element.value());
+                if constexpr (std::is_move_constructible_v<element_type>)
+                {
+                    return std::move(m_element.value());
+                }
+                else
+                {
+                    return m_element.value();
+                }
             }
             else
             {
-                return m_element.value();
+                // If we don't have an item the queue has stopped, the prior functions will have checked the state.
+                return unexpected<queue_consume_result>(queue_consume_result::queue_stopped);
             }
         }
 
@@ -123,6 +152,8 @@ public:
         m_waiters  = std::exchange(other.m_waiters, nullptr);
         m_mutex    = std::move(other.m_mutex);
         m_elements = std::move(other.m_elements);
+        m_shutting_down = std::move(other.m_shutting_down);
+        m_stopped = std::move(other.m_stopped);
     }
 
     auto operator=(const queue&) -> queue& = delete;
@@ -133,36 +164,50 @@ public:
             m_waiters  = std::exchange(other.m_waiters, nullptr);
             m_mutex    = std::move(other.m_mutex);
             m_elements = std::move(other.m_elements);
+            m_shutting_down = std::move(other.m_shutting_down);
+            m_stopped = std::move(other.m_stopped);
         }
 
         return *this;
     }
 
-    /// @brief Determines if the queue is empty.
-    /// @return True if the queue has no elements.
+    /**
+     * @brief Determines if the queue is empty.
+     *
+     * @return true If the queue is empty.
+     * @return false If the queue is not empty.
+     */
     auto empty() const -> bool { return size() == 0; }
 
-    /// @brief Gets the current number of elements in the queue.
-    /// @return The number of elements in the queue.
+    /**
+     * @brief Gets the number of elements in the queue.
+     *
+     * @return std::size_t The number of elements in the queue.
+     */
     auto size() const -> std::size_t
     {
         std::atomic_thread_fence(std::memory_order::acquire);
         return m_elements.size();
     }
 
-    /// @brief Pushes the element into the queue.
-    /// @param element The element to push.
-    /// @return void.
-    auto push(const element_type& element) -> queue_produce_result
+    /**
+     * @brief Pushes the element into the queue. If the queue is empty and there are waiters
+     *        then the element will be processed immediately by transfering the coroutine task
+     *        context to the waiter.
+     *
+     * @param element The element being produced.
+     * @return coro::task<queue_produce_result>
+     */
+    auto push(const element_type& element) -> coro::task<queue_produce_result>
     {
-        if (m_stopped.load(std::memory_order::acquire))
+        if (m_shutting_down.load(std::memory_order::acquire))
         {
-            return queue_produce_result::queue_stopped;
+            co_return queue_produce_result::queue_stopped;
         }
 
         // The general idea is to see if anyone is waiting, and if so directly transfer the element
         // to that waiter. If there is nobody waiting then move the element into the queue.
-        std::unique_lock lock{m_mutex};
+        auto lock = co_await m_mutex.lock();
 
         if (m_waiters != nullptr)
         {
@@ -179,20 +224,25 @@ public:
             m_elements.push(element);
         }
 
-        return queue_produce_result::produced;
+        co_return queue_produce_result::produced;
     }
 
-    /// @brief Pushes the element into the queue.
-    /// @param element The element to push.
-    /// @return void.
-    auto push(element_type&& element) -> queue_produce_result
+    /**
+     * @brief Pushes the element into the queue. If the queue is empty and there are waiters
+     *        then the element will be processed immediately by transfering the coroutine task
+     *        context to the waiter.
+     *
+     * @param element The element being produced.
+     * @return coro::task<queue_produce_result>
+     */
+    auto push(element_type&& element) -> coro::task<queue_produce_result>
     {
-        if (m_stopped.load(std::memory_order::acquire))
+        if (m_shutting_down.load(std::memory_order::acquire))
         {
-            return queue_produce_result::queue_stopped;
+            co_return queue_produce_result::queue_stopped;
         }
 
-        std::unique_lock lock{m_mutex};
+        auto lock = co_await m_mutex.lock();
 
         if (m_waiters != nullptr)
         {
@@ -209,22 +259,25 @@ public:
             m_elements.push(std::move(element));
         }
 
-        return queue_produce_result::produced;
+        co_return queue_produce_result::produced;
     }
 
-    /// @brief Emplaces the element into the queue.
-    /// @tparam ...args_type The element's constructor argument types.
-    /// @param ...args The element's constructor arguments.
-    /// @return void.
-    template<class... args_type>
-    auto emplace(args_type&&... args) -> queue_produce_result
+    /**
+     * @brief Emplaces an element into the queue. Has the same behavior as push if the queue
+     *        is empty and has waiters.
+     *
+     * @param args The element's constructor argument types and values.
+     * @return coro::task<queue_produce_result>
+     */
+    template<typename... args_type>
+    auto emplace(args_type&&... args) -> coro::task<queue_produce_result>
     {
-        if (m_stopped.load(std::memory_order::acquire))
+        if (m_shutting_down.load(std::memory_order::acquire))
         {
-            return queue_produce_result::queue_stopped;
+            co_return queue_produce_result::queue_stopped;
         }
 
-        std::unique_lock lock{m_mutex};
+        auto lock = co_await m_mutex.lock();
 
         if (m_waiters != nullptr)
         {
@@ -240,26 +293,34 @@ public:
             m_elements.emplace(std::forward<args_type>(args)...);
         }
 
-        return queue_produce_result::produced;
+        co_return queue_produce_result::produced;
     }
 
-    /// @brief Pops the head element of the queue if available, or waits for one to
-    ///        be available.
-    /// @return The head element, or coro::queue_consume_result::queue_stopped if the
-    ///         queue has been shutdown.
+    /**
+     * @brief Pops the head element of the queue if available, or waits for one to be available.
+     *
+     * @return awaiter A waiter task that upon co_await complete returns an element or the queue
+     *                 status that it is shut down.
+     */
     [[nodiscard]] auto pop() -> awaiter { return awaiter{*this}; }
 
-    /// @brief Shutsdown the queue and notifies all waiters of pop() to stop waiting.
-    /// @return void.
-    auto shutdown_notify_waiters() -> void
+    /**
+     * @brief Shuts down the queue immediately discarding any elements that haven't been processed.
+     *
+     * @return coro::task<void>
+     */
+    auto shutdown_notify_waiters() -> coro::task<void>
     {
         auto expected = false;
-        if (!m_stopped.compare_exchange_strong(expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
+        if (!m_shutting_down.compare_exchange_strong(expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
         {
-            return;
+            co_return;
         }
 
-        std::unique_lock lock{m_mutex};
+        // Since this isn't draining just let the awaiters know we're stopped.
+        m_stopped.exchange(true, std::memory_order::release);
+
+        auto lock = co_await m_mutex.lock();
         while (m_waiters != nullptr)
         {
             auto* to_resume = m_waiters;
@@ -267,19 +328,59 @@ public:
 
             lock.unlock();
             to_resume->m_awaiting_coroutine.resume();
-            lock.lock();
+            lock = co_await m_mutex.lock();
+        }
+    }
+
+    /**
+     * @brief Shuts down the queue but waits for it to be drained so all elements are processed.
+     *        Will yield on the given executor between checking if the queue is empty so the tasks
+     *        can be processed.
+     *
+     * @tparam executor_t The executor type.
+     * @param e The executor to yield this task to wait for elements to be processed.
+     * @return coro::task<void>
+     */
+    template<coro::concepts::executor executor_t>
+    auto shutdown_notify_waiters_drain(executor_t& e) -> coro::task<void>
+    {
+        auto expected = false;
+        if (!m_shutting_down.compare_exchange_strong(expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
+        {
+            co_return;
+        }
+
+        while(!empty())
+        {
+            co_await e.yield();
+        }
+
+        // Now that the queue is drained let all the awaiters know that we're stopped.
+        m_stopped.exchange(true, std::memory_order::release);
+
+        auto lock = co_await m_mutex.lock();
+        while (m_waiters != nullptr)
+        {
+            auto* to_resume = m_waiters;
+            m_waiters       = m_waiters->m_next;
+
+            lock.unlock();
+            to_resume->m_awaiting_coroutine.resume();
+            lock = co_await m_mutex.lock();
         }
     }
 
 private:
     friend awaiter;
-    /// @brief The list of pop() awaiters.
+    /// The list of pop() awaiters.
     awaiter* m_waiters{nullptr};
-    /// @brief Mutex for properly maintaining the queue.
-    std::mutex m_mutex{};
-    /// @brief The underlying queue datastructure.
+    /// Mutex for properly maintaining the queue.
+    coro::mutex m_mutex{};
+    /// The underlying queue data structure.
     std::queue<element_type> m_elements{};
-    /// @brief Has this queue been shutdown?
+    /// Has the shutdown process begun?
+    std::atomic<bool> m_shutting_down{false};
+    /// Has this queue been shutdown?
     std::atomic<bool> m_stopped{false};
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBCORO_TEST_SOURCE_FILES
     test_latch.cpp
     test_mutex.cpp
     test_ring_buffer.cpp
+    test_queue.cpp
     test_semaphore.cpp
     test_shared_mutex.cpp
     test_sync_wait.cpp

--- a/test/test_queue.cpp
+++ b/test/test_queue.cpp
@@ -1,0 +1,211 @@
+#include "catch_amalgamated.hpp"
+
+#include <coro/coro.hpp>
+
+TEST_CASE("queue shutdown produce", "[queue]")
+{
+    coro::queue<uint64_t> q{};
+
+    auto make_consumer_task = [](coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        auto expected = co_await q.pop();
+        if (!expected)
+        {
+            co_return 0;
+        }
+        co_return std::move(*expected);
+    };
+
+    q.shutdown_notify_waiters();
+    q.push(42);
+
+    auto result = coro::sync_wait(make_consumer_task(q));
+    REQUIRE(result == 0);
+    REQUIRE(q.empty());
+}
+
+TEST_CASE("queue single produce consume", "[queue]")
+{
+    coro::queue<uint64_t> q{};
+
+    auto make_consumer_task = [](coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        auto expected = co_await q.pop();
+        if (!expected)
+        {
+            co_return 0;
+        }
+        co_return std::move(*expected);
+    };
+
+    q.push(42);
+
+    auto result = coro::sync_wait(make_consumer_task(q));
+    REQUIRE(result == 42);
+    REQUIRE(q.empty());
+}
+
+TEST_CASE("queue multiple produce and consume", "[queue]")
+{
+    const uint64_t        ITERATIONS = 10;
+    coro::queue<uint64_t> q{};
+
+    auto make_consumer_task = [](coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        auto expected = co_await q.pop();
+        if (!expected)
+        {
+            co_return 0;
+        }
+        co_return std::move(*expected);
+    };
+
+    std::vector<coro::task<uint64_t>> tasks{};
+    for (uint64_t i = 0; i < ITERATIONS; ++i)
+    {
+        q.push(i);
+        tasks.emplace_back(make_consumer_task(q));
+    }
+
+    auto results = coro::sync_wait(coro::when_all(std::move(tasks)));
+    for (uint64_t i = 0; i < ITERATIONS; ++i)
+    {
+        REQUIRE(results[i].return_value() == i);
+    }
+}
+
+TEST_CASE("queue produce consume direct", "[queue]")
+{
+    const uint64_t        ITERATIONS = 10;
+    coro::queue<uint64_t> q{};
+    coro::thread_pool     tp{};
+
+    auto make_producer_task = [&ITERATIONS](coro::thread_pool& tp, coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        co_await tp.schedule();
+        for (uint64_t i = 0; i < ITERATIONS; ++i)
+        {
+            q.push(i);
+            co_await tp.yield();
+        }
+
+        // Wait for all elements to be consumed and then wake all waiters.
+        while (!q.empty())
+        {
+            co_await tp.yield();
+        }
+
+        q.shutdown_notify_waiters();
+
+        co_return 0;
+    };
+
+    auto make_consumer_task = [&ITERATIONS](coro::thread_pool& tp, coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        co_await tp.schedule();
+
+        uint64_t sum{0};
+
+        while (true)
+        {
+            auto expected = co_await q.pop();
+            if (!expected)
+            {
+                co_return sum;
+            }
+            sum += *expected;
+        }
+    };
+
+    auto results = coro::sync_wait(coro::when_all(make_consumer_task(tp, q), make_producer_task(tp, q)));
+    REQUIRE(std::get<0>(results).return_value() == 45);
+    REQUIRE(std::get<1>(results).return_value() == 0);
+}
+
+TEST_CASE("queue multithreaded produce consume", "[queue]")
+{
+    const uint64_t        WORKERS    = 3;
+    const uint64_t        ITERATIONS = 100;
+    coro::queue<uint64_t> q{};
+    coro::thread_pool     tp{};
+    std::atomic<uint64_t> counter{0};
+    coro::latch           wait{WORKERS};
+
+    auto make_producer_task =
+        [&ITERATIONS](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& w) -> coro::task<void>
+    {
+        co_await tp.schedule();
+        for (uint64_t i = 0; i < ITERATIONS; ++i)
+        {
+            q.push(i);
+            co_await tp.yield();
+        }
+
+        w.count_down();
+        co_return;
+    };
+
+    auto make_shutdown_task = [](coro::thread_pool& tp, coro::queue<uint64_t>& q, coro::latch& w) -> coro::task<void>
+    {
+        // Wait for all producers to complete.
+        co_await w;
+        // Wait for all elements to be consumed.
+        while (!q.empty())
+        {
+            co_await tp.yield();
+        }
+
+        // Wake up all waiters.
+        q.shutdown_notify_waiters();
+    };
+
+    auto make_consumer_task =
+        [&ITERATIONS](
+            coro::thread_pool& tp, coro::queue<uint64_t>& q, std::atomic<uint64_t>& counter) -> coro::task<void>
+    {
+        co_await tp.schedule();
+
+        while (true)
+        {
+            auto expected = co_await q.pop();
+            if (!expected)
+            {
+                co_return;
+            }
+            counter += *expected;
+        }
+    };
+
+    std::vector<coro::task<void>> tasks{};
+    for (uint64_t i = 0; i < WORKERS; ++i)
+    {
+        tasks.emplace_back(make_producer_task(tp, q, wait));
+        tasks.emplace_back(make_consumer_task(tp, q, counter));
+    }
+    tasks.emplace_back(make_shutdown_task(tp, q, wait));
+
+    coro::sync_wait(coro::when_all(std::move(tasks)));
+    REQUIRE(counter == 14850);
+}
+
+TEST_CASE("queue stopped", "[queue]")
+{
+    coro::queue<uint64_t> q{};
+
+    auto make_consumer_task = [](coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    {
+        auto expected = co_await q.pop();
+        if (!expected)
+        {
+            co_return 0;
+        }
+        co_return std::move(*expected);
+    };
+
+    q.push(42);
+    q.shutdown_notify_waiters();
+
+    auto result = coro::sync_wait(make_consumer_task(q));
+    REQUIRE(result == 0);
+    REQUIRE(q.size() == 1); // The item was not consumed due to shutdown.
+}


### PR DESCRIPTION
* Pushing elements into the queue will either wake a waiter to immediately consume the value, or push into the queue if there are no current waiters.
* Popping elements from the queue will either consume the front immediately if there are elements available, or wait for an element to be pushed.

This structure differs from `coro::ring_buffer` in that it has an unbounded size and also means that `push()` calls are not coroutines since instead of waiting for a slot to open will simply allocate memory to add the item. Only the `pop()` calls can be awaited and will suspend the coroutine until an item is available.

Use `coro::queue::notify_waiters()` to shutdown the queue and wake all waiters.

Closes #307