### PR TITLE
Add coro::default_executor

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -34,6 +34,12 @@ done
 # template_contents=$(cat '.githooks/readme-template.md')
 cp .githooks/readme-template.md README.md
 
+# Disable patsub_replacement
+#
+# If the patsub_replacement shell option is enabled using shopt,
+# any unquoted instances of ‘&’ in string are replaced with the matching portion of pattern
+shopt -u patsub_replacement
+
 template_contents=$(cat 'README.md')
 example_contents=$(cat 'examples/coro_task.cpp')
 echo "${template_contents/\$\{EXAMPLE_CORO_TASK_CPP\}/$example_contents}" > README.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/attribute.hpp
     include/coro/coro.hpp
     include/coro/event.hpp src/event.cpp
+    include/coro/default_executor.hpp src/default_executor.cpp
     include/coro/generator.hpp
     include/coro/latch.hpp
     include/coro/mutex.hpp src/mutex.cpp

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -30,6 +30,7 @@
 #endif
 
 #include "coro/event.hpp"
+#include "coro/default_executor.hpp"
 #include "coro/generator.hpp"
 #include "coro/latch.hpp"
 #include "coro/mutex.hpp"

--- a/include/coro/default_executor.hpp
+++ b/include/coro/default_executor.hpp
@@ -10,7 +10,8 @@ namespace coro::default_executor
 {
 
 /**
- * Set up default coro::thread_pool::options before constructing a single instance of the default_executor
+ * Set up default coro::thread_pool::options before constructing a single instance of coro::thread_pool in
+ * coro::default_executor::executor()
  * @param thread_pool_options thread_pool options
  */
 void set_executor_options(thread_pool::options thread_pool_options);
@@ -22,7 +23,8 @@ std::shared_ptr<thread_pool> executor();
 
 #ifdef LIBCORO_FEATURE_NETWORKING
 /**
- * Set up default coro::io_scheduler::options before constructing a single instance of the default_io_executor
+ * Set up default coro::io_scheduler::options before constructing a single instance of coro::io_scheduler in
+ * coro::default_executor::io_executor()
  * @param io_scheduler_options io_scheduler options
  */
 void set_io_executor_options(io_scheduler::options io_scheduler_options);

--- a/include/coro/default_executor.hpp
+++ b/include/coro/default_executor.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#ifdef LIBCORO_FEATURE_NETWORKING
+    #include "coro/io_scheduler.hpp"
+#else
+    #include "coro/thread_pool.hpp"
+#endif
+
+namespace coro::default_executor
+{
+
+/**
+ * Set up default coro::thread_pool::options before constructing a single instance of the default_executor
+ * @param thread_pool_options thread_pool options
+ */
+void set_executor_options(thread_pool::options thread_pool_options);
+
+/**
+ * Get default coro::thread_pool
+ */
+std::shared_ptr<thread_pool> executor();
+
+#ifdef LIBCORO_FEATURE_NETWORKING
+/**
+ * Set up default coro::io_scheduler::options before constructing a single instance of the default_io_executor
+ * @param io_scheduler_options io_scheduler options
+ */
+void set_io_executor_options(io_scheduler::options io_scheduler_options);
+
+/**
+ * Get default coro::io_scheduler
+ */
+std::shared_ptr<io_scheduler> io_executor();
+#endif
+
+/**
+ * Get the perfect default executor
+ *
+ * This executor is ideal as a default argument in a library,
+ * in a place where thread_pool functionality is sufficient,
+ * but you don't want to have two executor instances per application for the same thing,
+ * one thread_pool and one io_scheduler.
+ */
+inline auto perfect()
+{
+#ifdef LIBCORO_FEATURE_NETWORKING
+    return io_executor();
+#else
+    return executor();
+#endif
+}
+
+} // namespace coro::default_executor

--- a/include/coro/io_scheduler.hpp
+++ b/include/coro/io_scheduler.hpp
@@ -77,7 +77,7 @@ public:
 
         /// If inline task processing is enabled then the io worker will resume tasks on its thread
         /// rather than scheduling them to be picked up by the thread pool.
-        const execution_strategy_t execution_strategy{execution_strategy_t::process_tasks_on_thread_pool};
+        execution_strategy_t execution_strategy{execution_strategy_t::process_tasks_on_thread_pool};
     };
 
     /**

--- a/include/coro/thread_pool.hpp
+++ b/include/coro/thread_pool.hpp
@@ -25,7 +25,7 @@ namespace coro
  * the thread pool will stop accepting new tasks but will complete all tasks that were scheduled
  * prior to the shutdown request.
  */
-class thread_pool
+class thread_pool : public std::enable_shared_from_this<thread_pool>
 {
 public:
     /**

--- a/src/default_executor.cpp
+++ b/src/default_executor.cpp
@@ -1,0 +1,63 @@
+#include "coro/default_executor.hpp"
+#include <atomic>
+#include <memory>
+
+static coro::thread_pool::options         s_default_executor_options;
+static std::atomic<coro::thread_pool*>    s_default_executor = {nullptr};
+static std::shared_ptr<coro::thread_pool> s_default_executor_shared;
+
+#ifdef LIBCORO_FEATURE_NETWORKING
+static coro::io_scheduler::options         s_default_io_executor_options;
+static std::atomic<coro::io_scheduler*>    s_default_io_executor = {nullptr};
+static std::shared_ptr<coro::io_scheduler> s_default_io_executor_shared;
+#endif
+
+void coro::default_executor::set_executor_options(thread_pool::options thread_pool_options)
+{
+    s_default_executor_options = thread_pool_options;
+}
+
+std::shared_ptr<coro::thread_pool> coro::default_executor::executor()
+{
+    auto result = s_default_executor.load(std::memory_order::acquire);
+    if (result)
+    {
+        return result->shared_from_this();
+    }
+
+    auto ptr = std::make_shared<coro::thread_pool>(s_default_executor_options);
+    if (s_default_executor.compare_exchange_strong(
+            result, ptr.get(), std::memory_order::release, std::memory_order::acquire))
+    {
+        s_default_executor_shared = ptr;
+        return ptr;
+    }
+
+    return result->shared_from_this();
+}
+
+#ifdef LIBCORO_FEATURE_NETWORKING
+void coro::default_executor::set_io_executor_options(io_scheduler::options io_scheduler_options)
+{
+    s_default_io_executor_options = io_scheduler_options;
+}
+
+std::shared_ptr<coro::io_scheduler> coro::default_executor::io_executor()
+{
+    auto result = s_default_io_executor.load(std::memory_order::acquire);
+    if (result)
+    {
+        return result->shared_from_this();
+    }
+
+    auto ptr = coro::io_scheduler::make_shared(s_default_io_executor_options);
+    if (s_default_io_executor.compare_exchange_strong(
+            result, ptr.get(), std::memory_order::release, std::memory_order::acquire))
+    {
+        s_default_io_executor_shared = ptr;
+        return ptr;
+    }
+
+    return result->shared_from_this();
+}
+#endif

--- a/src/default_executor.cpp
+++ b/src/default_executor.cpp
@@ -2,14 +2,18 @@
 #include <atomic>
 #include <memory>
 
+static const auto s_initialization_check_interval = std::chrono::milliseconds(1);
+
 static coro::thread_pool::options         s_default_executor_options;
 static std::atomic<coro::thread_pool*>    s_default_executor = {nullptr};
 static std::shared_ptr<coro::thread_pool> s_default_executor_shared;
+static const auto s_default_executor_initializing = reinterpret_cast<coro::thread_pool*>(&s_default_executor);
 
 #ifdef LIBCORO_FEATURE_NETWORKING
 static coro::io_scheduler::options         s_default_io_executor_options;
 static std::atomic<coro::io_scheduler*>    s_default_io_executor = {nullptr};
 static std::shared_ptr<coro::io_scheduler> s_default_io_executor_shared;
+static const auto s_default_io_executor_initializing = reinterpret_cast<coro::io_scheduler*>(&s_default_io_executor);
 #endif
 
 void coro::default_executor::set_executor_options(thread_pool::options thread_pool_options)
@@ -19,21 +23,30 @@ void coro::default_executor::set_executor_options(thread_pool::options thread_po
 
 std::shared_ptr<coro::thread_pool> coro::default_executor::executor()
 {
-    auto result = s_default_executor.load(std::memory_order::acquire);
-    if (result)
+    do
     {
-        return result->shared_from_this();
-    }
+        auto result = s_default_executor.load(std::memory_order::acquire);
+        while (result == s_default_executor_initializing)
+        {
+            std::this_thread::sleep_for(s_initialization_check_interval);
+            result = s_default_executor.load(std::memory_order::acquire);
+        }
 
-    auto ptr = std::make_shared<coro::thread_pool>(s_default_executor_options);
-    if (s_default_executor.compare_exchange_strong(
-            result, ptr.get(), std::memory_order::release, std::memory_order::acquire))
-    {
-        s_default_executor_shared = ptr;
-        return ptr;
-    }
+        if (result)
+        {
+            return result->shared_from_this();
+        }
 
-    return result->shared_from_this();
+        if (s_default_executor.compare_exchange_strong(
+                result, s_default_executor_initializing, std::memory_order::release, std::memory_order::acquire))
+        {
+            break;
+        }
+    } while (true);
+
+    s_default_executor_shared = std::make_shared<coro::thread_pool>(s_default_executor_options);
+    s_default_executor.store(s_default_executor_shared.get(), std::memory_order::release);
+    return s_default_executor_shared;
 }
 
 #ifdef LIBCORO_FEATURE_NETWORKING
@@ -44,20 +57,29 @@ void coro::default_executor::set_io_executor_options(io_scheduler::options io_sc
 
 std::shared_ptr<coro::io_scheduler> coro::default_executor::io_executor()
 {
-    auto result = s_default_io_executor.load(std::memory_order::acquire);
-    if (result)
+    do
     {
-        return result->shared_from_this();
-    }
+        auto result = s_default_io_executor.load(std::memory_order::acquire);
+        while (result == s_default_io_executor_initializing)
+        {
+            std::this_thread::sleep_for(s_initialization_check_interval);
+            result = s_default_io_executor.load(std::memory_order::acquire);
+        }
 
-    auto ptr = coro::io_scheduler::make_shared(s_default_io_executor_options);
-    if (s_default_io_executor.compare_exchange_strong(
-            result, ptr.get(), std::memory_order::release, std::memory_order::acquire))
-    {
-        s_default_io_executor_shared = ptr;
-        return ptr;
-    }
+        if (result)
+        {
+            return result->shared_from_this();
+        }
 
-    return result->shared_from_this();
+        if (s_default_io_executor.compare_exchange_strong(
+                result, s_default_io_executor_initializing, std::memory_order::release, std::memory_order::acquire))
+        {
+            break;
+        }
+    } while (true);
+
+    s_default_io_executor_shared = coro::io_scheduler::make_shared(s_default_io_executor_options);
+    s_default_io_executor.store(s_default_io_executor_shared.get(), std::memory_order::release);
+    return s_default_io_executor_shared;
 }
 #endif


### PR DESCRIPTION
Add a common default executor for use both in the library (e.g. libcoro) and in code that uses libcoro