### PR TITLE
Fix when any flakey tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ int main()
         // lock() function returns a coro::scoped_lock that holds the mutex and automatically
         // unlocks the mutex upon destruction.  This behaves just like std::scoped_lock.
         {
-            auto scoped_lock = co_await mutex.lock();
+            auto scoped_lock = co_await mutex.scoped_lock();
             output.emplace_back(i);
         } // <-- scoped lock unlocks the mutex here.
         co_return;
@@ -742,7 +742,7 @@ int main()
         // Now that the ring buffer is empty signal to all the consumers its time to stop.  Note that
         // the stop signal works on producers as well, but this example only uses 1 producer.
         {
-            auto scoped_lock = co_await m.lock();
+            auto scoped_lock = co_await m.scoped_lock();
             std::cerr << "\nproducer is sending stop signal";
         }
         rb.notify_waiters();
@@ -757,7 +757,7 @@ int main()
         while (true)
         {
             auto expected    = co_await rb.consume();
-            auto scoped_lock = co_await m.lock(); // just for synchronizing std::cout/cerr
+            auto scoped_lock = co_await m.scoped_lock(); // just for synchronizing std::cout/cerr
             if (!expected)
             {
                 std::cerr << "\nconsumer " << id << " shutting down, stop signal received";
@@ -854,7 +854,7 @@ int main()
                 break; // coro::queue is shutting down
             }
 
-            auto scoped_lock = co_await m.lock(); // Only used to make the output look nice.
+            auto scoped_lock = co_await m.scoped_lock(); // Only used to make the output look nice.
             std::cout << "consumed " << *expected << "\n";
         }
     };

--- a/examples/coro_mutex.cpp
+++ b/examples/coro_mutex.cpp
@@ -15,7 +15,7 @@ int main()
         // lock() function returns a coro::scoped_lock that holds the mutex and automatically
         // unlocks the mutex upon destruction.  This behaves just like std::scoped_lock.
         {
-            auto scoped_lock = co_await mutex.lock();
+            auto scoped_lock = co_await mutex.scoped_lock();
             output.emplace_back(i);
         } // <-- scoped lock unlocks the mutex here.
         co_return;

--- a/examples/coro_queue.cpp
+++ b/examples/coro_queue.cpp
@@ -48,7 +48,7 @@ int main()
                 break; // coro::queue is shutting down
             }
 
-            auto scoped_lock = co_await m.lock(); // Only used to make the output look nice.
+            auto scoped_lock = co_await m.scoped_lock(); // Only used to make the output look nice.
             std::cout << "consumed " << *expected << "\n";
         }
     };

--- a/examples/coro_ring_buffer.cpp
+++ b/examples/coro_ring_buffer.cpp
@@ -30,7 +30,7 @@ int main()
         // Now that the ring buffer is empty signal to all the consumers its time to stop.  Note that
         // the stop signal works on producers as well, but this example only uses 1 producer.
         {
-            auto scoped_lock = co_await m.lock();
+            auto scoped_lock = co_await m.scoped_lock();
             std::cerr << "\nproducer is sending stop signal";
         }
         rb.notify_waiters();
@@ -45,7 +45,7 @@ int main()
         while (true)
         {
             auto expected    = co_await rb.consume();
-            auto scoped_lock = co_await m.lock(); // just for synchronizing std::cout/cerr
+            auto scoped_lock = co_await m.scoped_lock(); // just for synchronizing std::cout/cerr
             if (!expected)
             {
                 std::cerr << "\nconsumer " << id << " shutting down, stop signal received";

--- a/include/coro/when_any.hpp
+++ b/include/coro/when_any.hpp
@@ -9,11 +9,13 @@
     #include "coro/expected.hpp"
     #include "coro/mutex.hpp"
     #include "coro/task.hpp"
+    #include "coro/when_all.hpp"
 
     #include <atomic>
     #include <cassert>
     #include <coroutine>
     #include <stop_token>
+    #include <optional>
     #include <utility>
     #include <vector>
 

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -4,23 +4,9 @@
 
 namespace coro
 {
-scoped_lock::~scoped_lock()
+namespace detail
 {
-    unlock();
-}
-
-auto scoped_lock::unlock() -> void
-{
-    if (m_mutex != nullptr)
-    {
-        std::atomic_thread_fence(std::memory_order::release);
-        m_mutex->unlock();
-        // Only allow a scoped lock to unlock the mutex a single time.
-        m_mutex = nullptr;
-    }
-}
-
-auto mutex::lock_operation::await_ready() const noexcept -> bool
+auto lock_operation_base::await_ready() const noexcept -> bool
 {
     if (m_mutex.try_lock())
     {
@@ -31,7 +17,7 @@ auto mutex::lock_operation::await_ready() const noexcept -> bool
     return false;
 }
 
-auto mutex::lock_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+auto lock_operation_base::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
 {
     m_awaiting_coroutine = awaiting_coroutine;
     void* current        = m_mutex.m_state.load(std::memory_order::acquire);
@@ -49,7 +35,7 @@ auto mutex::lock_operation::await_suspend(std::coroutine_handle<> awaiting_corou
         {
             // If the current value is a waiting lock operation, or nullptr, set our next to that
             // lock op and attempt to set ourself as the head of the waiter list.
-            m_next    = static_cast<lock_operation*>(current);
+            m_next    = static_cast<lock_operation_base*>(current);
             new_value = static_cast<void*>(this);
         }
     } while (!m_mutex.m_state.compare_exchange_weak(current, new_value, std::memory_order::acq_rel));
@@ -63,6 +49,23 @@ auto mutex::lock_operation::await_suspend(std::coroutine_handle<> awaiting_corou
     }
 
     return true;
+}
+
+} // namespace detail
+
+scoped_lock::~scoped_lock()
+{
+    unlock();
+}
+
+auto scoped_lock::unlock() -> void
+{
+    if (m_mutex != nullptr)
+    {
+        std::atomic_thread_fence(std::memory_order::release);
+        m_mutex->unlock();
+        m_mutex = nullptr;
+    }
 }
 
 auto mutex::try_lock() -> bool
@@ -92,7 +95,7 @@ auto mutex::unlock() -> void
         }
 
         // There are waiters on the atomic list, acquire them and update the state for all others.
-        m_internal_waiters = static_cast<lock_operation*>(m_state.exchange(nullptr, std::memory_order::acq_rel));
+        m_internal_waiters = static_cast<detail::lock_operation_base*>(m_state.exchange(nullptr, std::memory_order::acq_rel));
 
         // Should internal waiters be reversed to allow for true FIFO, or should they be resumed
         // in this reverse order to maximum throuhgput?  If this list ever gets 'long' the reversal
@@ -105,8 +108,8 @@ auto mutex::unlock() -> void
 
     // assert m_internal_waiters != nullptr
 
-    lock_operation* to_resume = m_internal_waiters;
-    m_internal_waiters        = m_internal_waiters->m_next;
+    detail::lock_operation_base* to_resume = m_internal_waiters;
+    m_internal_waiters                     = m_internal_waiters->m_next;
     to_resume->m_awaiting_coroutine.resume();
 }
 

--- a/test/bench.cpp
+++ b/test/bench.cpp
@@ -940,7 +940,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
 
             {
                 // std::cerr << "CLIENT: writing histogram\n";
-                auto lock = co_await histogram_mutex.lock();
+                auto lock = co_await histogram_mutex.scoped_lock();
                 for (auto [ms, count] : histogram)
                 {
                     g_histogram[ms] += count;


### PR DESCRIPTION
* mutex now supports scoped_lock() and lock() where scoped lock returns a RAII object to auto-unlock and lock is a normal lock call on the mutex.
* when any tests just seem to have some race conditions, nothing identified in the tests points to problems in the when_any function.

Closes #325
Closes #316