### PR TITLE
sync_wait does not rethrow user exceptions

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -21,10 +21,11 @@ jobs:
                 run: |
                     apt-get clean
                     apt-get update
-                    apt-get -y upgrade
-                    apt install -y build-essential software-properties-common
+                    apt install -y --no-install-recommends \
+                        build-essential \
+                        software-properties-common
                     add-apt-repository ppa:ubuntu-toolchain-r/test
-                    apt-get install -y \
+                    apt-get install -y --no-install-recommends \
                         cmake \
                         git \
                         ninja-build \

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -73,11 +73,11 @@ jobs:
                 run: |
                     apt-get clean
                     apt-get update
-                    apt install -y \
+                    apt install -y --no-install-recommends \
                         build-essential \
                         software-properties-common
                     add-apt-repository ppa:ubuntu-toolchain-r/test
-                    apt-get install -y \
+                    apt-get install -y --no-install-recommends \
                         cmake \
                         git \
                         ninja-build \
@@ -123,10 +123,10 @@ jobs:
                 run: |
                     apt-get clean
                     apt-get update
-                    apt-get install -y \
+                    apt-get install -y --no-install-recommends \
                         build-essential \
                         software-properties-common
-                    apt-get install -y \
+                    apt-get install -y --no-install-recommends \
                         wget \
                         cmake \
                         git \

--- a/src/sync_wait.cpp
+++ b/src/sync_wait.cpp
@@ -10,8 +10,10 @@ auto sync_wait_event::set() noexcept -> void
 {
     // issue-270 100~ task's on a thread_pool within sync_wait(when_all(tasks)) can cause a deadlock/hang if using
     // release/acquire or even seq_cst.
-    m_set.exchange(true, std::memory_order::seq_cst);
-    std::unique_lock<std::mutex> lk{m_mutex};
+    {
+        std::unique_lock<std::mutex> lk{m_mutex};
+        m_set.exchange(true, std::memory_order::seq_cst);
+    }
     m_cv.notify_all();
 }
 


### PR DESCRIPTION
* The base class had a std::exception object that was supposed to be overriden in the sub-class that has a variant storage to hold a std::exception_ptr, this was missed in the original refactor.
* This moves the std::exception from the base class to the sub-class that returns void since it is only used there, the sub-class that returns values now properly rethrows exceptions from its variant storage.
* Updated the base class destructor to be virtual (seems like it was missing?) Also properly override'ed the sub class destructors.
* Reworked the sync_wait_event to properly hold the lock while updating the event for how condition variables are supposed to work.

Closes #320