### PR TITLE
coro::thread_pool force usage as std::shared_ptr

### DIFF
--- a/examples/coro_mutex.cpp
+++ b/examples/coro_mutex.cpp
@@ -3,17 +3,17 @@
 
 int main()
 {
-    coro::thread_pool     tp{coro::thread_pool::options{.thread_count = 4}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 4});
     std::vector<uint64_t> output{};
-    coro::mutex           mutex;
+    coro::mutex           mutex{};
 
     auto make_critical_section_task =
-        [](coro::thread_pool& tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::mutex& mutex, std::vector<uint64_t>& output, uint64_t i) -> coro::task<void>
     {
-        co_await tp.schedule();
-        // To acquire a mutex lock co_await its lock() function.  Upon acquiring the lock the
-        // lock() function returns a coro::scoped_lock that holds the mutex and automatically
-        // unlocks the mutex upon destruction.  This behaves just like std::scoped_lock.
+        co_await tp->schedule();
+        // To acquire a mutex lock co_await its scoped_lock() function. Upon acquiring the lock the
+        // scoped_lock() function returns a coro::scoped_lock that holds the mutex and automatically
+        // unlocks the mutex upon destruction. This behaves just like std::scoped_lock.
         {
             auto scoped_lock = co_await mutex.scoped_lock();
             output.emplace_back(i);

--- a/examples/coro_semaphore.cpp
+++ b/examples/coro_semaphore.cpp
@@ -4,13 +4,13 @@
 int main()
 {
     // Have more threads/tasks than the semaphore will allow for at any given point in time.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 8}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 8});
     coro::semaphore<2>   semaphore{2};
 
     auto make_rate_limited_task =
-        [](coro::thread_pool& tp, coro::semaphore<2>& semaphore, uint64_t task_num) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::semaphore<2>& semaphore, uint64_t task_num) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
 
         // This will only allow 2 tasks through at any given point in time, all other tasks will
         // await the resource to be available before proceeding.

--- a/examples/coro_shared_mutex.cpp
+++ b/examples/coro_shared_mutex.cpp
@@ -8,7 +8,7 @@ int main()
     // to also show the interleaving of coroutines acquiring the shared lock in shared and
     // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
-    auto tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     coro::shared_mutex<coro::thread_pool> mutex{tp};
 
     auto make_shared_task = [](std::shared_ptr<coro::thread_pool>     tp,

--- a/examples/coro_sync_wait.cpp
+++ b/examples/coro_sync_wait.cpp
@@ -17,12 +17,12 @@ int main()
     // execution to another thread.  We'll pass the thread pool as a parameter so
     // the task can be scheduled.
     // Note that you will need to guarantee the thread pool outlives the coroutine.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
-    auto make_task_offload = [](coro::thread_pool& tp, uint64_t x) -> coro::task<uint64_t>
+    auto make_task_offload = [](std::shared_ptr<coro::thread_pool> tp, uint64_t x) -> coro::task<uint64_t>
     {
-        co_await tp.schedule(); // Schedules execution on the thread pool.
-        co_return x + x;        // This will execute on the thread pool.
+        co_await tp->schedule(); // Schedules execution on the thread pool.
+        co_return x + x;         // This will execute on the thread pool.
     };
 
     // This will still block the calling thread, but it will now offload to the

--- a/examples/coro_when_all.cpp
+++ b/examples/coro_when_all.cpp
@@ -4,11 +4,11 @@
 int main()
 {
     // Create a thread pool to execute all the tasks in parallel.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 4}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 4});
     // Create the task we want to invoke multiple times and execute in parallel on the thread pool.
-    auto twice = [](coro::thread_pool& tp, uint64_t x) -> coro::task<uint64_t>
+    auto twice = [](std::shared_ptr<coro::thread_pool> tp, uint64_t x) -> coro::task<uint64_t>
     {
-        co_await tp.schedule(); // Schedule onto the thread pool.
+        co_await tp->schedule(); // Schedule onto the thread pool.
         co_return x + x;        // Executed on the thread pool.
     };
 
@@ -35,9 +35,9 @@ int main()
     }
 
     // Use var args instead of a container as input to coro::when_all.
-    auto square = [](coro::thread_pool& tp, double x) -> coro::task<double>
+    auto square = [](std::shared_ptr<coro::thread_pool> tp, double x) -> coro::task<double>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_return x* x;
     };
 

--- a/include/coro/event.hpp
+++ b/include/coro/event.hpp
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <coroutine>
+#include <memory>
 
 namespace coro
 {
@@ -101,7 +102,7 @@ public:
      * the waiters across the executor's threads.
      */
     template<concepts::executor executor_type>
-    auto set(executor_type& e, resume_order_policy policy = resume_order_policy::lifo) noexcept -> void
+    auto set(std::shared_ptr<executor_type> e, resume_order_policy policy = resume_order_policy::lifo) noexcept -> void
     {
         void* old_value = m_state.exchange(this, std::memory_order::acq_rel);
         if (old_value != this)
@@ -117,7 +118,7 @@ public:
             while (waiters != nullptr)
             {
                 auto* next = waiters->m_next;
-                e.resume(waiters->m_awaiting_coroutine);
+                e->resume(waiters->m_awaiting_coroutine);
                 waiters = next;
             }
         }

--- a/include/coro/io_scheduler.hpp
+++ b/include/coro/io_scheduler.hpp
@@ -86,9 +86,9 @@ public:
     explicit io_scheduler(options&& opts, private_constructor);
 
     /**
-     * @brief Creates an io_scheduler.
+     * @brief Creates an io_scheduler executor.
      *
-     * @param opts
+     * @param opts The scheduler's options.
      * @return std::shared_ptr<io_scheduler>
      */
     static auto make_shared(
@@ -108,7 +108,7 @@ public:
     auto operator=(const io_scheduler&) -> io_scheduler& = delete;
     auto operator=(io_scheduler&&) -> io_scheduler&      = delete;
 
-    ~io_scheduler();
+    virtual ~io_scheduler();
 
     /**
      * Given a thread_strategy_t::manual this function should be called at regular intervals to
@@ -434,7 +434,7 @@ private:
     /// The background io worker threads.
     std::thread m_io_thread;
     /// Thread pool for executing tasks when not in inline mode.
-    std::unique_ptr<thread_pool> m_thread_pool{nullptr};
+    std::shared_ptr<thread_pool> m_thread_pool{nullptr};
 
     std::mutex m_timed_events_mutex{};
     /// The map of time point's to poll infos for tasks that are yielding for a period of time

--- a/include/coro/queue.hpp
+++ b/include/coro/queue.hpp
@@ -308,8 +308,8 @@ public:
      * @param e The executor to yield this task to wait for elements to be processed.
      * @return coro::task<void>
      */
-    template<coro::concepts::executor executor_t>
-    auto shutdown_drain(executor_t& e) -> coro::task<void>
+    template<coro::concepts::executor executor_type>
+    auto shutdown_drain(std::shared_ptr<executor_type> e) -> coro::task<void>
     {
         auto lk = co_await m_mutex.scoped_lock();
         auto expected = running_state_t::running;
@@ -322,7 +322,7 @@ public:
 
         while (!empty())
         {
-            co_await e.yield();
+            co_await e->yield();
         }
 
         co_return co_await shutdown();

--- a/include/coro/ring_buffer.hpp
+++ b/include/coro/ring_buffer.hpp
@@ -280,8 +280,8 @@ public:
         co_return;
     }
 
-    template<coro::concepts::executor executor_t>
-    [[nodiscard]] auto shutdown_drain(executor_t& e) -> coro::task<void>
+    template<coro::concepts::executor executor_type>
+    [[nodiscard]] auto shutdown_drain(std::shared_ptr<executor_type> e) -> coro::task<void>
     {
         auto lk = co_await m_mutex.scoped_lock();
         // Do not allow any more produces, the state must be in running to drain.
@@ -303,7 +303,7 @@ public:
 
         while (!empty())
         {
-            co_await e.yield();
+            co_await e->yield();
         }
 
         co_await shutdown();

--- a/src/default_executor.cpp
+++ b/src/default_executor.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<coro::thread_pool> coro::default_executor::executor()
         }
     } while (true);
 
-    s_default_executor_shared = std::make_shared<coro::thread_pool>(s_default_executor_options);
+    s_default_executor_shared = coro::thread_pool::make_shared(s_default_executor_options);
     s_default_executor.store(s_default_executor_shared.get(), std::memory_order::release);
     return s_default_executor_shared;
 }

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -101,14 +101,14 @@ TEST_CASE("event fifo", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
     auto make_waiter =
-        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_await e;
 
         counter++;
@@ -117,9 +117,9 @@ TEST_CASE("event fifo", "[event]")
         co_return;
     };
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(coro::resume_order_policy::fifo);
         co_return;
@@ -141,13 +141,13 @@ TEST_CASE("event fifo none", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(coro::resume_order_policy::fifo);
         co_return;
@@ -163,14 +163,14 @@ TEST_CASE("event fifo single", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
     auto make_waiter =
-        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_await e;
 
         counter++;
@@ -179,9 +179,9 @@ TEST_CASE("event fifo single", "[event]")
         co_return;
     };
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(coro::resume_order_policy::fifo);
         co_return;
@@ -197,14 +197,14 @@ TEST_CASE("event fifo executor", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
     auto make_waiter =
-        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_await e;
 
         counter++;
@@ -213,9 +213,9 @@ TEST_CASE("event fifo executor", "[event]")
         co_return;
     };
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(tp, coro::resume_order_policy::fifo);
         co_return;
@@ -237,13 +237,13 @@ TEST_CASE("event fifo none executor", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(tp, coro::resume_order_policy::fifo);
         co_return;
@@ -259,14 +259,14 @@ TEST_CASE("event fifo single executor", "[event]")
     coro::event e{};
 
     // Need consistency FIFO on a single thread to verify the execution order is correct.
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     std::atomic<uint64_t> counter{0};
 
     auto make_waiter =
-        [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter, uint64_t value) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_await e;
 
         counter++;
@@ -275,9 +275,9 @@ TEST_CASE("event fifo single executor", "[event]")
         co_return;
     };
 
-    auto make_setter = [](coro::thread_pool& tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_setter = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e, std::atomic<uint64_t>& counter) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         REQUIRE(counter == 0);
         e.set(tp, coro::resume_order_policy::fifo);
         co_return;

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -255,7 +255,7 @@ TEST_CASE("io_scheduler separate thread resume spawned thread", "[io_scheduler]"
             {
                 // mimic some expensive computation
                 // Resume the coroutine back onto the scheduler, not this background thread.
-                e.set(*s);
+                e.set(s);
             });
         third_party_thread.detach();
 
@@ -289,7 +289,7 @@ TEST_CASE("io_scheduler separate thread resume with return", "[io_scheduler]")
             }
 
             output = expected_value;
-            service_done.set(*s);
+            service_done.set(s);
         }};
 
     auto make_task = [](std::shared_ptr<coro::io_scheduler> s,
@@ -577,7 +577,7 @@ TEST_CASE("io_scheduler multipler event waiters", "[io_scheduler]")
     auto release = [](std::shared_ptr<coro::io_scheduler> s, coro::event& e) -> coro::task<void>
     {
         co_await s->schedule_after(10ms);
-        e.set(*s);
+        e.set(s);
     };
 
     coro::sync_wait(coro::when_all(spawn(s, e), release(s, e)));

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -45,15 +45,15 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
     std::atomic<uint64_t>         value{0};
     std::vector<coro::task<void>> tasks;
 
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     coro::mutex m; // acquires and holds the lock until the event is triggered
     coro::event e; // triggers the blocking thread to release the lock
 
     auto make_task =
-        [](coro::thread_pool& tp, coro::mutex& m, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::mutex& m, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         std::cerr << "id = " << id << " waiting to acquire the lock\n";
         auto scoped_lock = co_await m.scoped_lock();
 
@@ -66,9 +66,9 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
         co_return;
     };
 
-    auto make_block_task = [](coro::thread_pool& tp, coro::mutex& m, coro::event& e) -> coro::task<void>
+    auto make_block_task = [](std::shared_ptr<coro::thread_pool> tp, coro::mutex& m, coro::event& e) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         std::cerr << "block task acquiring lock\n";
         auto scoped_lock = co_await m.scoped_lock();
         REQUIRE_FALSE(m.try_lock());
@@ -77,9 +77,9 @@ TEST_CASE("mutex many waiters until event", "[mutex]")
         co_return;
     };
 
-    auto make_set_task = [](coro::thread_pool& tp, coro::event& e) -> coro::task<void>
+    auto make_set_task = [](std::shared_ptr<coro::thread_pool> tp, coro::event& e) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         std::cerr << "set task setting event\n";
         e.set();
         co_return;

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -8,7 +8,7 @@
 
 TEST_CASE("mutex single waiter not locked exclusive", "[shared_mutex]")
 {
-    auto                  tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto                  tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     std::vector<uint64_t> output;
 
     coro::shared_mutex<coro::thread_pool> m{tp};
@@ -44,7 +44,7 @@ TEST_CASE("mutex single waiter not locked exclusive", "[shared_mutex]")
 
 TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
 {
-    auto                  tp = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto                  tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     std::vector<uint64_t> values{1, 2, 3};
 
     coro::shared_mutex<coro::thread_pool> m{tp};

--- a/test/test_sync_wait.cpp
+++ b/test/test_sync_wait.cpp
@@ -118,7 +118,7 @@ TEST_CASE("sync_wait task int64_t that throws user exception inheriting std::exc
 
 TEST_CASE("sync_wait very rarely hangs issue-270", "[sync_wait]")
 {
-    coro::thread_pool tp{};
+    auto tp = coro::thread_pool::make_shared();
 
     const int ITERATIONS = 100;
 
@@ -137,9 +137,9 @@ TEST_CASE("sync_wait very rarely hangs issue-270", "[sync_wait]")
     std::atomic<int> count{0};
 
     auto make_task =
-        [](coro::thread_pool& tp, std::unordered_set<int>& data, std::atomic<int>& count, int i) -> coro::task<void>
+        [](std::shared_ptr<coro::thread_pool> tp, std::unordered_set<int>& data, std::atomic<int>& count, int i) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
 
         if (data.find(i) != data.end())
         {

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -6,29 +6,29 @@
 
 TEST_CASE("thread_pool one worker one task", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{1});
 
-    auto func = [&tp]() -> coro::task<uint64_t>
+    auto func = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule(); // Schedule this coroutine on the scheduler.
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
         co_return 42;
     };
 
-    auto result = coro::sync_wait(func());
+    auto result = coro::sync_wait(func(tp));
     REQUIRE(result == 42);
 }
 
 TEST_CASE("thread_pool one worker many tasks tuple", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{1});
 
-    auto f = [&tp]() -> coro::task<uint64_t>
+    auto f = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule(); // Schedule this coroutine on the scheduler.
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
         co_return 50;
     };
 
-    auto tasks = coro::sync_wait(coro::when_all(f(), f(), f(), f(), f()));
+    auto tasks = coro::sync_wait(coro::when_all(f(tp), f(tp), f(tp), f(tp), f(tp)));
     REQUIRE(std::tuple_size<decltype(tasks)>() == 5);
 
     uint64_t counter{0};
@@ -39,18 +39,18 @@ TEST_CASE("thread_pool one worker many tasks tuple", "[thread_pool]")
 
 TEST_CASE("thread_pool one worker many tasks vector", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{1});
 
-    auto f = [&tp]() -> coro::task<uint64_t>
+    auto f = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule(); // Schedule this coroutine on the scheduler.
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
         co_return 50;
     };
 
     std::vector<coro::task<uint64_t>> input_tasks;
-    input_tasks.emplace_back(f());
-    input_tasks.emplace_back(f());
-    input_tasks.emplace_back(f());
+    input_tasks.emplace_back(f(tp));
+    input_tasks.emplace_back(f(tp));
+    input_tasks.emplace_back(f(tp));
 
     auto output_tasks = coro::sync_wait(coro::when_all(std::move(input_tasks)));
 
@@ -68,11 +68,11 @@ TEST_CASE("thread_pool one worker many tasks vector", "[thread_pool]")
 TEST_CASE("thread_pool N workers 100k tasks", "[thread_pool]")
 {
     constexpr const std::size_t iterations = 100'000;
-    coro::thread_pool           tp{};
+    auto tp = coro::thread_pool::make_shared();
 
-    auto make_task = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_return 1;
     };
 
@@ -97,15 +97,15 @@ TEST_CASE("thread_pool N workers 100k tasks", "[thread_pool]")
 
 TEST_CASE("thread_pool 1 worker task spawns another task", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{1});
 
-    auto f1 = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+    auto f1 = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
 
-        auto f2 = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+        auto f2 = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
         {
-            co_await tp.schedule();
+            co_await tp->schedule();
             co_return 5;
         };
 
@@ -117,13 +117,13 @@ TEST_CASE("thread_pool 1 worker task spawns another task", "[thread_pool]")
 
 TEST_CASE("thread_pool shutdown", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{1});
 
-    auto f = [](coro::thread_pool& tp) -> coro::task<bool>
+    auto f = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<bool>
     {
         try
         {
-            co_await tp.schedule();
+            co_await tp->schedule();
         }
         catch (...)
         {
@@ -132,7 +132,7 @@ TEST_CASE("thread_pool shutdown", "[thread_pool]")
         co_return false;
     };
 
-    tp.shutdown();
+    tp->shutdown();
 
     REQUIRE(coro::sync_wait(f(tp)) == true);
 }
@@ -141,14 +141,14 @@ TEST_CASE("thread_pool event jump threads", "[thread_pool]")
 {
     // This test verifies that the thread that sets the event ends up executing every waiter on the event
 
-    coro::thread_pool tp1{coro::thread_pool::options{.thread_count = 1}};
-    coro::thread_pool tp2{coro::thread_pool::options{.thread_count = 1}};
+    auto tp1 = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
+    auto tp2 = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     coro::event e{};
 
-    auto make_tp1_task = [](coro::thread_pool& tp1, coro::event& e) -> coro::task<void>
+    auto make_tp1_task = [](std::shared_ptr<coro::thread_pool> tp1, coro::event& e) -> coro::task<void>
     {
-        co_await tp1.schedule();
+        co_await tp1->schedule();
         auto before_thread_id = std::this_thread::get_id();
         std::cerr << "before event thread_id = " << before_thread_id << "\n";
         co_await e;
@@ -160,9 +160,9 @@ TEST_CASE("thread_pool event jump threads", "[thread_pool]")
         co_return;
     };
 
-    auto make_tp2_task = [](coro::thread_pool& tp2, coro::event& e) -> coro::task<void>
+    auto make_tp2_task = [](std::shared_ptr<coro::thread_pool> tp2, coro::event& e) -> coro::task<void>
     {
-        co_await tp2.schedule();
+        co_await tp2->schedule();
         std::this_thread::sleep_for(std::chrono::milliseconds{10});
         std::cerr << "setting event\n";
         e.set();
@@ -181,7 +181,7 @@ TEST_CASE("thread_pool high cpu usage when threadcount is greater than the numbe
     // This was due to using m_size instead of m_queue.size() causing the threads
     // that had no work to go into a spin trying to acquire work.
 
-    auto wait_for_task = [](coro::thread_pool& pool, std::chrono::seconds delay) -> coro::task<>
+    auto wait_for_task = [](std::shared_ptr<coro::thread_pool> tp, std::chrono::seconds delay) -> coro::task<>
     {
         auto sleep_for_task = [](std::chrono::seconds duration) -> coro::task<int64_t>
         {
@@ -189,7 +189,7 @@ TEST_CASE("thread_pool high cpu usage when threadcount is greater than the numbe
             co_return duration.count();
         };
 
-        co_await pool.schedule();
+        co_await tp->schedule();
         for (int i = 0; i < 5; ++i)
         {
             co_await sleep_for_task(delay);
@@ -199,9 +199,9 @@ TEST_CASE("thread_pool high cpu usage when threadcount is greater than the numbe
         co_return;
     };
 
-    coro::thread_pool pool{coro::thread_pool::options{.thread_count = 3}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 3});
     coro::sync_wait(
-        coro::when_all(wait_for_task(pool, std::chrono::seconds{1}), wait_for_task(pool, std::chrono::seconds{3})));
+        coro::when_all(wait_for_task(tp, std::chrono::seconds{1}), wait_for_task(tp, std::chrono::seconds{3})));
 }
 
 TEST_CASE("issue-287", "[thread_pool]")
@@ -209,7 +209,7 @@ TEST_CASE("issue-287", "[thread_pool]")
     const int ITERATIONS = 200000;
 
     std::atomic<uint32_t> g_count = 0;
-    auto thread_pool              = std::make_shared<coro::thread_pool>(coro::thread_pool::options{.thread_count = 1});
+    auto tp              = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
 
     auto task = [](std::atomic<uint32_t>& count) -> coro::task<void>
     {
@@ -219,10 +219,10 @@ TEST_CASE("issue-287", "[thread_pool]")
 
     for (int i = 0; i < ITERATIONS; ++i)
     {
-        REQUIRE(thread_pool->spawn(task(g_count)));
+        REQUIRE(tp->spawn(task(g_count)));
     }
 
-    thread_pool->shutdown();
+    tp->shutdown();
 
     std::cerr << "g_count = \t" << g_count.load() << std::endl;
     REQUIRE(g_count.load() == ITERATIONS);
@@ -230,7 +230,7 @@ TEST_CASE("issue-287", "[thread_pool]")
 
 TEST_CASE("thread_pool::spawn", "[thread_pool]")
 {
-    coro::thread_pool     tp{coro::thread_pool::options{.thread_count = 2}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 2});
     std::atomic<uint64_t> counter{0};
 
     auto make_task = [](std::atomic<uint64_t>& counter, uint64_t amount) -> coro::task<void>
@@ -239,18 +239,18 @@ TEST_CASE("thread_pool::spawn", "[thread_pool]")
         co_return;
     };
 
-    REQUIRE(tp.spawn(make_task(counter, 1)));
-    REQUIRE(tp.spawn(make_task(counter, 2)));
-    REQUIRE(tp.spawn(make_task(counter, 3)));
+    REQUIRE(tp->spawn(make_task(counter, 1)));
+    REQUIRE(tp->spawn(make_task(counter, 2)));
+    REQUIRE(tp->spawn(make_task(counter, 3)));
 
-    tp.shutdown();
+    tp->shutdown();
 
     REQUIRE(counter == 6);
 }
 
 TEST_CASE("thread_pool::schedule(task)", "[thread_pool]")
 {
-    coro::thread_pool tp{coro::thread_pool::options{.thread_count = 1}};
+    auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     uint64_t          counter{0};
     std::thread::id   coroutine_tid;
 
@@ -262,7 +262,7 @@ TEST_CASE("thread_pool::schedule(task)", "[thread_pool]")
 
     auto main_tid = std::this_thread::get_id();
 
-    counter += coro::sync_wait(tp.schedule(make_task(53, coroutine_tid)));
+    counter += coro::sync_wait(tp->schedule(make_task(53, coroutine_tid)));
 
     REQUIRE(counter == 53);
     REQUIRE(main_tid != coroutine_tid);

--- a/test/test_when_all.cpp
+++ b/test/test_when_all.cpp
@@ -111,14 +111,14 @@ TEST_CASE("when_all multple task withs list container", "[when_all]")
 
 TEST_CASE("when_all inside coroutine", "[when_all]")
 {
-    coro::thread_pool tp{};
-    auto              make_task = [](coro::thread_pool& tp, uint64_t amount) -> coro::task<uint64_t>
+    auto tp = coro::thread_pool::make_shared();
+    auto              make_task = [](std::shared_ptr<coro::thread_pool> tp, uint64_t amount) -> coro::task<uint64_t>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         co_return amount;
     };
 
-    auto runner_task = [](coro::thread_pool& tp, auto make_task) -> coro::task<uint64_t>
+    auto runner_task = [](std::shared_ptr<coro::thread_pool> tp, auto make_task) -> coro::task<uint64_t>
     {
         std::list<coro::task<uint64_t>> tasks;
         tasks.emplace_back(make_task(tp, 1));
@@ -142,13 +142,13 @@ TEST_CASE("when_all inside coroutine", "[when_all]")
 
 TEST_CASE("when_all use std::ranges::view", "[when_all]")
 {
-    coro::thread_pool tp{};
+    auto tp = coro::thread_pool::make_shared();
 
-    auto make_runner_task = [](coro::thread_pool& tp) -> coro::task<uint64_t>
+    auto make_runner_task = [](std::shared_ptr<coro::thread_pool> tp) -> coro::task<uint64_t>
     {
-        auto make_task = [](coro::thread_pool& tp, uint64_t amount) -> coro::task<uint64_t>
+        auto make_task = [](std::shared_ptr<coro::thread_pool> tp, uint64_t amount) -> coro::task<uint64_t>
         {
-            co_await tp.schedule();
+            co_await tp->schedule();
             co_return amount;
         };
         std::vector<coro::task<uint64_t>> tasks;
@@ -172,11 +172,11 @@ TEST_CASE("when_all use std::ranges::view", "[when_all]")
 
 TEST_CASE("when_all each task throws", "[when_all]")
 {
-    coro::thread_pool tp{};
+    auto tp = coro::thread_pool::make_shared();
 
-    auto make_task = [](coro::thread_pool& tp, uint64_t i) -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::thread_pool> tp, uint64_t i) -> coro::task<uint64_t>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         if (i % 2 == 0)
         {
             throw std::runtime_error{std::to_string(i)};
@@ -207,12 +207,12 @@ TEST_CASE("when_all each task throws", "[when_all]")
 
 TEST_CASE("when_all return void", "[when_all]")
 {
-    coro::thread_pool     tp{};
+    auto tp = coro::thread_pool::make_shared();
     std::atomic<uint64_t> counter{0};
 
-    auto make_task = [](coro::thread_pool& tp, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<void>
+    auto make_task = [](std::shared_ptr<coro::thread_pool> tp, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<void>
     {
-        co_await tp.schedule();
+        co_await tp->schedule();
         counter += i;
         co_return;
     };


### PR DESCRIPTION
coro::io_scheduler has required this for some time, considering how the pool is used it should likely have been as a shared_ptr for quite some time, this PR finally forces the user to only be able to make thread_pool's as std::shared_ptr.

Closes #330