### PR TITLE
Fix for Xcode hang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/concepts/range_of.hpp
 
     include/coro/detail/awaiter_list.hpp
-    include/coro/detail/task_self_deleting.hpp / src/detail/task_self_deleting.cpp
+    include/coro/detail/task_self_deleting.hpp src/detail/task_self_deleting.cpp
     include/coro/detail/void_value.hpp
 
     include/coro/attribute.hpp


### PR DESCRIPTION
This PR fixes an issue in the LIBCORO_SOURCE_FILES list that caused Xcode to hang indefinitely during project load.

Problem:
The file list contained this line:
`include/coro/detail/task_self_deleting.hpp / src/detail/task_self_deleting.cpp`

CMake interpreted / src/... as an absolute path (/src/detail/task_self_deleting.cpp), which doesn’t exist. This broke project generation and led to infinite loading in Xcode.

Fix:
Split the entry into two valid paths