### PR TITLE
free(): invalid pointer in when_any tests

### DIFF
--- a/test/test_when_any.cpp
+++ b/test/test_when_any.cpp
@@ -48,6 +48,11 @@ TEST_CASE("when_any return void", "[when_any]")
 
     coro::sync_wait(coro::when_any(std::move(tasks)));
     REQUIRE(counter.load() > 0);
+
+    while (!tp->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
 }
 
 TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
@@ -58,47 +63,41 @@ TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
     // is the first task to complete, otherwise there is a race condition if counter is atomic
     // as the other task could complete first (unlikely but happens) and cause the REQUIRE statements
     // between what is returned to mismatch from what is executed.
-    coro::mutex       m{};
+    coro::event can_return{};
     auto tp = coro::thread_pool::make_shared();
     std::atomic<uint64_t>          counter{0};
 
     auto make_task_return_void =
-        [](std::shared_ptr<coro::thread_pool> tp, coro::mutex& m, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<std::monostate>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& can_return, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<std::monostate>
     {
         co_await tp->schedule();
-        co_await m.lock();
-        if (counter == 0)
+
+        uint64_t expected{0};
+        if (!counter.compare_exchange_strong(expected, i, std::memory_order::acq_rel, std::memory_order::acquire))
         {
-            counter = i;
+            REQUIRE_THREAD_SAFE(counter.load(std::memory_order::acquire) == 2);
+            co_await can_return;
         }
-        else
-        {
-            REQUIRE_THREAD_SAFE(counter == 2);
-        }
+
         co_return std::monostate{};
     };
 
-    auto make_task = [](std::shared_ptr<coro::thread_pool> tp, coro::mutex& m, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::thread_pool> tp, coro::event& can_return, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<uint64_t>
     {
         co_await tp->schedule();
-        co_await m.lock();
-        if (counter == 0)
+        uint64_t expected{0};
+        if (!counter.compare_exchange_strong(expected, i, std::memory_order::acq_rel, std::memory_order::acquire))
         {
-            counter = i;
-        }
-        else
-        {
-            REQUIRE_THREAD_SAFE(counter == 1);
+            REQUIRE_THREAD_SAFE(counter.load(std::memory_order::acquire) == 1);
+            co_await can_return;
         }
         co_return i;
     };
 
     auto result =
-        coro::sync_wait(coro::when_any(make_task_return_void(tp, m, counter, 1), make_task(tp, m, counter, 2)));
-    // Because of how coro::mutex works.. we need to release it after when_any returns since it symetrically transfers to the other coroutine task
-    // and can cause a race condition where the result does not equal the counter. This guarantees the task has fully completed before issuing REQUIREs.
-    m.unlock();
-    std::atomic_thread_fence(std::memory_order::acq_rel);
+        coro::sync_wait(coro::when_any(make_task_return_void(tp, can_return, counter, 1), make_task(tp, can_return, counter, 2)));
+
+    can_return.set(); // resume the losing task.
 
     if (std::holds_alternative<std::monostate>(result))
     {
@@ -108,6 +107,13 @@ TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
     {
         REQUIRE(std::get<uint64_t>(result) == 2);
         REQUIRE(counter == 2);
+    }
+
+    // Wait for all tasks to complete before moving on, the REQUIRE's inside the tasks can execute
+    // on the 'losing' task after this returns, so we must wait for all tasks to explicitly finish.
+    while (!tp->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
     }
 }
 
@@ -119,21 +125,17 @@ TEST_CASE("when_any two tasks one long running", "[when_any]")
     auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
 
-    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, uint64_t amount) -> coro::task<uint64_t>
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s, uint64_t amount, std::chrono::milliseconds wait_for) -> coro::task<uint64_t>
     {
         co_await s->schedule();
         // Make sure both tasks are scheduled.
-        co_await s->yield_for(std::chrono::milliseconds{10});
-        if (amount == 1)
-        {
-            co_await s->yield_for(std::chrono::milliseconds{100});
-        }
+        co_await s->yield_for(wait_for);
         co_return amount;
     };
 
     std::vector<coro::task<uint64_t>> tasks{};
-    tasks.emplace_back(make_task(s, 1));
-    tasks.emplace_back(make_task(s, 2));
+    tasks.emplace_back(make_task(s, 1, std::chrono::milliseconds{110}));
+    tasks.emplace_back(make_task(s, 2, std::chrono::milliseconds{10}));
 
     auto result = coro::sync_wait(coro::when_any(std::move(tasks)));
     REQUIRE(result == 2);
@@ -195,33 +197,38 @@ TEST_CASE("when_any two tasks one long running with cancellation", "[when_any]")
     {
         std::this_thread::sleep_for(std::chrono::milliseconds{250});
     }
+
+    while (!s->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
 }
 
 TEST_CASE("when_any timeout", "[when_any]")
 {
     std::cerr << "BEGIN when_any timeout\n";
-    auto scheduler = coro::io_scheduler::make_shared(
+    auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 2}});
 
-    auto make_long_running_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_long_running_task = [](std::shared_ptr<coro::io_scheduler> s,
                                      std::chrono::milliseconds           execution_time) -> coro::task<int64_t>
     {
-        co_await scheduler->schedule();
-        co_await scheduler->yield_for(execution_time);
+        co_await s->schedule();
+        co_await s->yield_for(execution_time);
         co_return 1;
     };
 
-    auto make_timeout_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_timeout_task = [](std::shared_ptr<coro::io_scheduler> s,
                                 std::chrono::milliseconds timeout) -> coro::task<int64_t>
     {
-        co_await scheduler->schedule_after(timeout);
+        co_await s->schedule_after(timeout);
         co_return -1;
     };
 
     {
         std::vector<coro::task<int64_t>> tasks{};
-        tasks.emplace_back(make_long_running_task(scheduler, std::chrono::milliseconds{50}));
-        tasks.emplace_back(make_timeout_task(scheduler, std::chrono::milliseconds{500}));
+        tasks.emplace_back(make_long_running_task(s, std::chrono::milliseconds{50}));
+        tasks.emplace_back(make_timeout_task(s, std::chrono::milliseconds{500}));
 
         auto result = coro::sync_wait(coro::when_any(std::move(tasks)));
         REQUIRE(result == 1);
@@ -229,39 +236,49 @@ TEST_CASE("when_any timeout", "[when_any]")
 
     {
         std::vector<coro::task<int64_t>> tasks{};
-        tasks.emplace_back(make_long_running_task(scheduler, std::chrono::milliseconds{500}));
-        tasks.emplace_back(make_timeout_task(scheduler, std::chrono::milliseconds{50}));
+        tasks.emplace_back(make_long_running_task(s, std::chrono::milliseconds{500}));
+        tasks.emplace_back(make_timeout_task(s, std::chrono::milliseconds{50}));
 
         auto result = coro::sync_wait(coro::when_any(std::move(tasks)));
         REQUIRE(result == -1);
+    }
+
+    while (!s->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
     }
 }
 
 TEST_CASE("when_any io_scheduler::schedule(task, timeout)", "[when_any]")
 {
     std::cerr << "BEGIN when_any io_scheduler::schedule(task, timeout)\n";
-    auto scheduler = coro::io_scheduler::make_shared(
+    auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 2}});
 
-    auto make_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s,
                         std::chrono::milliseconds           execution_time) -> coro::task<int64_t>
     {
-        co_await scheduler->yield_for(execution_time);
+        co_await s->yield_for(execution_time);
         co_return 1;
     };
 
     {
         auto result = coro::sync_wait(
-            scheduler->schedule(make_task(scheduler, std::chrono::milliseconds{10}), std::chrono::milliseconds{50}));
+            s->schedule(make_task(s, std::chrono::milliseconds{10}), std::chrono::milliseconds{50}));
         REQUIRE(result.has_value());
         REQUIRE(result.value() == 1);
     }
 
     {
         auto result = coro::sync_wait(
-            scheduler->schedule(make_task(scheduler, std::chrono::milliseconds{50}), std::chrono::milliseconds{10}));
+            s->schedule(make_task(s, std::chrono::milliseconds{50}), std::chrono::milliseconds{10}));
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error() == coro::timeout_status::timeout);
+    }
+
+    while (!s->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
     }
 }
 
@@ -269,14 +286,14 @@ TEST_CASE("when_any io_scheduler::schedule(task, timeout)", "[when_any]")
 TEST_CASE("when_any io_scheduler::schedule(task, timeout stop_token)", "[when_any]")
 {
     std::cerr << "BEGIN when_any io_scheduler::schedule(task, timeout stop_token)\n";
-    auto scheduler = coro::io_scheduler::make_shared(
+    auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 2}});
 
-    auto make_task = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_task = [](std::shared_ptr<coro::io_scheduler> s,
                         std::chrono::milliseconds           execution_time,
                         std::stop_token                     stop_token) -> coro::task<int64_t>
     {
-        co_await scheduler->yield_for(execution_time);
+        co_await s->yield_for(execution_time);
         if (stop_token.stop_requested())
         {
             co_return -1;
@@ -286,9 +303,9 @@ TEST_CASE("when_any io_scheduler::schedule(task, timeout stop_token)", "[when_an
 
     {
         std::stop_source stop_source{};
-        auto             result = coro::sync_wait(scheduler->schedule(
+        auto             result = coro::sync_wait(s->schedule(
             std::move(stop_source),
-            make_task(scheduler, std::chrono::milliseconds{10}, stop_source.get_token()),
+            make_task(s, std::chrono::milliseconds{10}, stop_source.get_token()),
             std::chrono::milliseconds{50}));
         REQUIRE(result.has_value());
         REQUIRE(result.value() == 1);
@@ -296,12 +313,17 @@ TEST_CASE("when_any io_scheduler::schedule(task, timeout stop_token)", "[when_an
 
     {
         std::stop_source stop_source{};
-        auto             result = coro::sync_wait(scheduler->schedule(
+        auto             result = coro::sync_wait(s->schedule(
             std::move(stop_source),
-            make_task(scheduler, std::chrono::milliseconds{50}, stop_source.get_token()),
+            make_task(s, std::chrono::milliseconds{50}, stop_source.get_token()),
             std::chrono::milliseconds{10}));
         REQUIRE_FALSE(result.has_value());
         REQUIRE(result.error() == coro::timeout_status::timeout);
+    }
+
+    while (!s->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
     }
 }
     #endif
@@ -311,49 +333,54 @@ TEST_CASE("when_any tuple multiple", "[when_any]")
     std::cerr << "BEGIN when_any tuple multiple\n";
     using namespace std::chrono_literals;
 
-    auto scheduler = coro::io_scheduler::make_shared(
+    auto s = coro::io_scheduler::make_shared(
         coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 4}});
 
-    auto make_task1 = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_task1 = [](std::shared_ptr<coro::io_scheduler> s,
                          std::chrono::milliseconds           execution_time) -> coro::task<int>
     {
-        co_await scheduler->schedule_after(execution_time);
+        co_await s->schedule_after(execution_time);
         co_return 1;
     };
 
-    auto make_task2 = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_task2 = [](std::shared_ptr<coro::io_scheduler> s,
                          std::chrono::milliseconds           execution_time) -> coro::task<double>
     {
-        co_await scheduler->schedule_after(execution_time);
+        co_await s->schedule_after(execution_time);
         co_return 3.14;
     };
 
-    auto make_task3 = [](std::shared_ptr<coro::io_scheduler> scheduler,
+    auto make_task3 = [](std::shared_ptr<coro::io_scheduler> s,
                          std::chrono::milliseconds           execution_time) -> coro::task<std::string>
     {
-        co_await scheduler->schedule_after(execution_time);
+        co_await s->schedule_after(execution_time);
         co_return std::string{"hello world"};
     };
 
     {
         auto result = coro::sync_wait(
-            coro::when_any(make_task1(scheduler, 10ms), make_task2(scheduler, 150ms), make_task3(scheduler, 150ms)));
+            coro::when_any(make_task1(s, 10ms), make_task2(s, 150ms), make_task3(s, 150ms)));
         REQUIRE(result.index() == 0);
         REQUIRE(std::get<0>(result) == 1);
     }
 
     {
         auto result = coro::sync_wait(
-            coro::when_any(make_task1(scheduler, 150ms), make_task2(scheduler, 10ms), make_task3(scheduler, 150ms)));
+            coro::when_any(make_task1(s, 150ms), make_task2(s, 10ms), make_task3(s, 150ms)));
         REQUIRE(result.index() == 1);
         REQUIRE(std::get<1>(result) == 3.14);
     }
 
     {
         auto result = coro::sync_wait(
-            coro::when_any(make_task1(scheduler, 150ms), make_task2(scheduler, 150ms), make_task3(scheduler, 10ms)));
+            coro::when_any(make_task1(s, 150ms), make_task2(s, 150ms), make_task3(s, 10ms)));
         REQUIRE(result.index() == 2);
         REQUIRE(std::get<2>(result) == "hello world");
+    }
+
+    while (!s->empty())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
     }
 }
 


### PR DESCRIPTION
* Fixed missing first_completed cmpxchng on when_any return void, this was likely the segfault since it would have left a dangling pointer to the coro::event& notify on the intiating when_any callers stack frame.
* Fixed the tests, each test in this file now must explicitly wait at the end for all tasks in the thread pool or io scheduler to complete, there are intermintent failures if slow tasks end up executing after the task has completed since they are detached/orphaned causing REQUIRE's to fail. This is why you would see catch report a test AFTER the REQUIRE being the failed test but the REQUIRE line reported was from the prior test because the detached/orphaned when_any task executed that late.

Closes #347