### PR TITLE
peer: add getter functions for the backing net::socket

### DIFF
--- a/include/coro/net/udp/peer.hpp
+++ b/include/coro/net/udp/peer.hpp
@@ -50,6 +50,16 @@ public:
     ~peer()                                       = default;
 
     /**
+     * @return A reference to the underlying socket.
+     */
+    auto socket() noexcept -> net::socket& { return m_socket; }
+
+    /**
+     * @return A const reference to the underlying socket.
+     */
+    auto socket() const noexcept -> const net::socket& { return m_socket; }
+
+    /**
      * @param op The poll operation to perform on the udp socket.  Note that if this is a send only
      *           udp socket (did not bind) then polling for read will not work.
      * @param timeout The timeout for the poll operation to be ready.


### PR DESCRIPTION
Add const and non-const getters to `coro::net::udp::peer` for its `net::socket` object. This allows calls to `setsockopt()` which can enable things like sending data on broadcast addresses, which is not possible with the current design.