### PR TITLE
ring_buffer: add max_size, full, notify_producers, and notify_consumers

### DIFF
--- a/include/coro/ring_buffer.hpp
+++ b/include/coro/ring_buffer.hpp
@@ -225,6 +225,14 @@ public:
     }
 
     /**
+     * @return The maximum number of elements the ring buffer can hold.
+     */
+    constexpr auto max_size() const noexcept -> size_t
+    {
+        return num_elements;
+    }
+
+    /**
      * @return The current number of elements contained in the ring buffer.
      */
     auto size() const -> size_t
@@ -236,6 +244,11 @@ public:
      * @return True if the ring buffer contains zero elements.
      */
     auto empty() const -> bool { return size() == 0; }
+
+    /**
+     * @return True if the ring buffer has no more space.
+     */
+    auto full() const -> bool { return size() == max_size(); }
 
     /**
      * @brief Wakes up all currently awaiting producers and consumers.  Their await_resume() function


### PR DESCRIPTION
[ring_buffer: add max_size and full functions](https://github.com/jbaldwin/libcoro/commit/823358caf1cf8f27821a5b6222d864bdd3da3bc3)

Add a `max_size()` function which returns the maximum size of the ring buffer. This returns the `num_elements` template parameter.

Add a `full()` function which checks if the size is equal to `max_size()`. This is useful in cases where code may not want to block on a `produce()` call.

[ring_buffer: add notify producer and consumer functions](https://github.com/jbaldwin/libcoro/commit/8baf1cce41ff2b7d4f4eada5d97bdb47b6c7ed6a)

Add ability to notify producers and consumers without shutting the ring buffer down. This is useful in cases where an operation should stop blocking the current execution without making the ring buffer non-functional