### PR TITLE
task_container: add back task_container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,8 @@ set(LIBCORO_SOURCE_FILES
     include/coro/attribute.hpp
     include/coro/condition_variable.hpp src/condition_variable.cpp
     include/coro/coro.hpp
-    include/coro/event.hpp src/event.cpp
     include/coro/default_executor.hpp src/default_executor.cpp
+    include/coro/event.hpp src/event.cpp
     include/coro/generator.hpp
     include/coro/latch.hpp
     include/coro/mutex.hpp src/mutex.cpp
@@ -105,6 +105,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/semaphore.hpp src/semaphore.cpp
     include/coro/shared_mutex.hpp
     include/coro/sync_wait.hpp src/sync_wait.cpp
+    include/coro/task_container.hpp
     include/coro/task.hpp
     include/coro/thread_pool.hpp src/thread_pool.cpp
     include/coro/time.hpp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
         - Can use `coro::thread_pool` for latency sensitive or long lived tasks.
         - Can use inline task processing for thread per core or short lived tasks.
         - Requires `LIBCORO_FEATURE_NETWORKING` to be supported.
+    - coro::task_container for dynamic task lifetimes
 * Coroutine Networking
     - coro::net::dns::resolver for async dns
         - Uses libc-ares
@@ -1043,8 +1044,9 @@ ss.request_stop()                       # request to stop, wakeup all waiters an
 
 #### Ways to schedule tasks onto a `coro::thread_pool`
 * `coro::thread_pool::schedule()` Use `co_await` on this method inside a coroutine to transfer the tasks execution to the `coro::thread_pool`.
-* `coro::thread_pool::spawn(coro::task<void&& task>)` Spawns the task to be detached and owned by the `coro::thread_pool`, use this if you want to fire and forget the task, the `coro::thread_pool` will maintain the task's lifetime.
+* `coro::thread_pool::spawn(coro::task<void>&& task)` Spawns the task to be detached and owned by the `coro::thread_pool`, use this if you want to fire and forget the task, the `coro::thread_pool` will maintain the task's lifetime.
 * `coro::thread_pool::schedule(coro::task<T> task) -> coro::task<T>` schedules the task on the `coro::thread_pool` and then returns the result in a task that must be awaited. This is useful if you want to schedule work on the `coro::thread_pool` and want to wait for the result.
+* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::thread_pool`. Use this when you want to share a `coro::thread_poll` while monitoring the progress of a subset of tasks.
 
 ```C++
 #include <coro/coro.hpp>
@@ -1173,6 +1175,7 @@ The `coro::io_scheduler` can use a dedicated spawned thread for processing event
 * `coro::io_scheduler::yield()` will yield execution of the current task and resume after other tasks have had a chance to execute. This effectively places the task at the back of the queue of waiting tasks.
 * `coro::io_scheduler::yield_for(std::chrono::milliseconds amount)` will yield for the given amount of time and then reschedule the task. This is a yield for at least this much time since its placed in the waiting execution queue and might take additional time to start executing again.
 * `coro::io_scheduler::yield_until(std::chrono::steady_clock::time_point time)` will yield execution until the time point.
+* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::io_scheduler`. Use this when you want to share a `coro::io_scheduler` while monitoring the progress of a subset of tasks.
 
 The example provided here shows an i/o scheduler that spins up a basic `coro::net::tcp::server` and a `coro::net::tcp::client` that will connect to each other and then send a request and a response.
 

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -30,8 +30,8 @@
 #endif
 
 #include "coro/condition_variable.hpp"
-#include "coro/event.hpp"
 #include "coro/default_executor.hpp"
+#include "coro/event.hpp"
 #include "coro/generator.hpp"
 #include "coro/latch.hpp"
 #include "coro/mutex.hpp"
@@ -40,6 +40,7 @@
 #include "coro/semaphore.hpp"
 #include "coro/shared_mutex.hpp"
 #include "coro/sync_wait.hpp"
+#include "coro/task_container.hpp"
 #include "coro/task.hpp"
 #include "coro/thread_pool.hpp"
 #include "coro/time.hpp"

--- a/include/coro/task_container.hpp
+++ b/include/coro/task_container.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "coro/attribute.hpp"
+#include "coro/concepts/executor.hpp"
+#include "coro/detail/task_self_deleting.hpp"
+#include "coro/task.hpp"
+
+#include <atomic>
+#include <iostream>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace coro
+{
+class io_scheduler;
+
+template<concepts::executor executor_type>
+class task_container
+{
+public:
+    /**
+     * @param e Tasks started in the container are scheduled onto this executor.  For tasks created
+     *           from a coro::io_scheduler, this would usually be that coro::io_scheduler instance.
+     * @param opts Task container options.
+     */
+    explicit task_container(std::shared_ptr<executor_type> e) : m_executor(std::move(e))
+    {
+        if (m_executor == nullptr)
+        {
+            throw std::runtime_error{"task_container cannot have a nullptr executor"};
+        }
+    }
+    task_container(const task_container&)                    = delete;
+    task_container(task_container&&)                         = delete;
+    auto operator=(const task_container&) -> task_container& = delete;
+    auto operator=(task_container&&) -> task_container&      = delete;
+    ~task_container()
+    {
+        // This will hang the current thread.. but if tasks are not complete thats also pretty bad.
+        while (!empty())
+        {
+            // Sleep a bit so the cpu doesn't totally churn.
+            std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        }
+    }
+
+    /**
+     * Stores a user task and starts its execution on the container's thread pool.
+     * @param user_task The scheduled user's task to store in this task container and start its execution.
+     * @return True if the task was succesfully started into the task container. This can fail if the task
+     *         is already completed or does not contain a valid coroutine anymore.
+     */
+    auto start(coro::task<void>&& user_task) -> bool
+    {
+        m_size.fetch_add(1, std::memory_order::relaxed);
+
+        auto task = make_self_deleting_task(std::move(user_task));
+        // Hook the promise to decrement the size upon its self deletion of the coroutine frame.
+        task.promise().executor_size(m_size);
+        return m_executor->resume(task.handle());
+    }
+
+    /**
+     * @return The number of active tasks in the container.
+     */
+    auto size() const -> std::size_t { return m_size.load(std::memory_order::acquire); }
+
+    /**
+     * @return True if there are no active tasks in the container.
+     */
+    auto empty() const -> bool { return size() == 0; }
+
+    /**
+     * Will continue to garbage collect and yield until all tasks are complete.  This method can be
+     * co_await'ed to make it easier to wait for the task container to have all its tasks complete.
+     *
+     * This does not shut down the task container, but can be used when shutting down, or if your
+     * logic requires all the tasks contained within to complete, it is similar to coro::latch.
+     */
+    auto yield_until_empty() -> coro::task<void>
+    {
+        while (!empty())
+        {
+            co_await m_executor->yield();
+        }
+    }
+
+private:
+    auto make_self_deleting_task(task<void> user_task) -> detail::task_self_deleting
+    {
+        co_await user_task;
+        co_return;
+    }
+
+    /// The number of alive tasks.
+    std::atomic<std::size_t> m_size{};
+    /// The executor to schedule tasks that have just started.
+    std::shared_ptr<executor_type> m_executor{nullptr};
+};
+
+} // namespace coro

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,11 +7,12 @@ set(LIBCORO_TEST_SOURCE_FILES
     test_generator.cpp
     test_latch.cpp
     test_mutex.cpp
-    test_ring_buffer.cpp
     test_queue.cpp
+    test_ring_buffer.cpp
     test_semaphore.cpp
     test_shared_mutex.cpp
     test_sync_wait.cpp
+    test_task_container.cpp
     test_task.cpp
     test_thread_pool.cpp
     test_when_all.cpp

--- a/test/test_task_container.cpp
+++ b/test/test_task_container.cpp
@@ -1,0 +1,61 @@
+#include "catch_amalgamated.hpp"
+
+#include <coro/coro.hpp>
+
+#include <atomic>
+#include <iostream>
+
+TEST_CASE("task_container", "[task_container]")
+{
+    std::cerr << "[task_container]\n\n";
+}
+
+using namespace std::chrono_literals;
+
+TEST_CASE("task_container schedule single task", "[task_container]")
+{
+    auto s = coro::thread_pool::make_shared(
+        coro::thread_pool::options{.thread_count = 1});
+
+    int value = 0;
+    auto make_task = [] (int &value) -> coro::task<void>
+    {
+        value = 37;
+        co_return;
+    };
+
+    coro::task_container<coro::thread_pool> tc{s};
+    tc.start(make_task(value));
+    REQUIRE(tc.size() == 1);
+    coro::sync_wait(tc.yield_until_empty());
+    REQUIRE(value == 37);
+    REQUIRE(tc.empty());
+}
+
+TEST_CASE("task_container submit mutiple tasks", "[task_container]")
+{
+    constexpr std::size_t n = 1000;
+    std::atomic<uint64_t> counter{0};
+    auto s = coro::thread_pool::make_shared(
+        coro::thread_pool::options{.thread_count = 1});
+    coro::task_container<coro::thread_pool> tc{s};
+
+    auto make_task = [](std::atomic<uint64_t>& counter) -> coro::task<void>
+    {
+        counter++;
+        co_return;
+    };
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        tc.start(make_task(counter));
+    }
+
+    coro::sync_wait(tc.yield_until_empty());
+    REQUIRE(counter == n);
+    REQUIRE(tc.empty());
+}
+
+TEST_CASE("~task_container", "[task_container]")
+{
+    std::cerr << "[~task_container]\n\n";
+}


### PR DESCRIPTION
Adds back `coro::task_container`. Since this has been removed, there has been no easy way to share a `thread_pool`/`io_scheduler` across an application, while retaining the ability to await the completion of a subset of tasks.

Task containers are also useful in cases where a class starts a task on a thread pool that references itself. If the task lives longer than the class, that reference begins to dangle. Task containers solve this by allowing the class to `yield_until_empty()` in the destructor to avoid dangling references.

Task containers can also function as latches in cases where `coro::when_all` is insufficient. If the data required to start multiple tasks becomes available at different times, tasks can be started immediately on the task container and then `yield_until_empty()` can function as the latch when necessary.