### PR TITLE
Fix issue #360

### DIFF
--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -161,10 +161,6 @@ auto io_scheduler::shutdown() noexcept -> void
     // Only allow shutdown to occur once.
     if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
     {
-        if (m_thread_pool != nullptr)
-        {
-            m_thread_pool->shutdown();
-        }
 
         // Signal the event loop to stop asap, triggering the event fd is safe.
         const int value{1};
@@ -173,6 +169,11 @@ auto io_scheduler::shutdown() noexcept -> void
         if (m_io_thread.joinable())
         {
             m_io_thread.join();
+        }
+
+        if (m_thread_pool != nullptr)
+        {
+            m_thread_pool->shutdown();
         }
     }
 }

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -850,6 +850,19 @@ TEST_CASE("io_scheduler::schedule(task)", "[thread_pool]")
     REQUIRE(main_tid != coroutine_tid);
 }
 
+TEST_CASE("io_scheduler shutdown with background yielding task", "[thread_pool]")
+{
+    auto scheduler = coro::io_scheduler::make_shared(
+        coro::io_scheduler::options{.pool = coro::thread_pool::options{.thread_count = 1}});
+
+    auto background_task = [](coro::io_scheduler* scheduler) -> coro::task<void>
+    { co_await scheduler->yield_for(20ms); };
+    scheduler->spawn(background_task(scheduler.get()));
+
+    // std::this_thread::sleep_for(21ms);  //! Required to avoid hang at `yield_for`
+    scheduler->shutdown();
+}
+
 TEST_CASE("~io_scheduler", "[io_scheduler]")
 {
     std::cerr << "[~io_scheduler]\n\n";


### PR DESCRIPTION
Previously, shutdown() first stopped the thread pool (thread_pool), and then sent a termination signal to the I/O thread (io_thread). 

```
if (!m_handles_to_resume.empty())
    {
        if (m_opts.execution_strategy == execution_strategy_t::process_tasks_inline)
        {
            for (auto& handle : m_handles_to_resume)
            {
                handle.resume();
            }
        }
        else
        {
            m_thread_pool->resume(m_handles_to_resume); // Problem here
        }

        m_handles_to_resume.clear();
    }
```

We submitted tasks with timeouts to the thread pool, but since the thread pool had already been shut down, the tasks will never complete. If we simply reorder the shutdown of io_thread and thread_pool, everything should work fine.