### PR TITLE
coro::when_any test failure

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -33,6 +33,7 @@
         - Can use `coro::thread_pool` for latency sensitive or long lived tasks.
         - Can use inline task processing for thread per core or short lived tasks.
         - Requires `LIBCORO_FEATURE_NETWORKING` to be supported.
+    - coro::task_container for dynamic task lifetimes, used in conjunction of an executor.
 * Coroutine Networking
     - coro::net::dns::resolver for async dns
         - Uses libc-ares
@@ -351,8 +352,9 @@ ss.request_stop()                       # request to stop, wakeup all waiters an
 
 #### Ways to schedule tasks onto a `coro::thread_pool`
 * `coro::thread_pool::schedule()` Use `co_await` on this method inside a coroutine to transfer the tasks execution to the `coro::thread_pool`.
-* `coro::thread_pool::spawn(coro::task<void&& task>)` Spawns the task to be detached and owned by the `coro::thread_pool`, use this if you want to fire and forget the task, the `coro::thread_pool` will maintain the task's lifetime.
+* `coro::thread_pool::spawn(coro::task<void>&& task)` Spawns the task to be detached and owned by the `coro::thread_pool`, use this if you want to fire and forget the task, the `coro::thread_pool` will maintain the task's lifetime.
 * `coro::thread_pool::schedule(coro::task<T> task) -> coro::task<T>` schedules the task on the `coro::thread_pool` and then returns the result in a task that must be awaited. This is useful if you want to schedule work on the `coro::thread_pool` and want to wait for the result.
+* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::thread_pool`. Use this when you want to share a `coro::thread_pool` while monitoring the progress of a subset of tasks.
 
 ```C++
 ${EXAMPLE_CORO_THREAD_POOL_CPP}
@@ -404,6 +406,7 @@ The `coro::io_scheduler` can use a dedicated spawned thread for processing event
 * `coro::io_scheduler::yield()` will yield execution of the current task and resume after other tasks have had a chance to execute. This effectively places the task at the back of the queue of waiting tasks.
 * `coro::io_scheduler::yield_for(std::chrono::milliseconds amount)` will yield for the given amount of time and then reschedule the task. This is a yield for at least this much time since its placed in the waiting execution queue and might take additional time to start executing again.
 * `coro::io_scheduler::yield_until(std::chrono::steady_clock::time_point time)` will yield execution until the time point.
+* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::io_scheduler`. Use this when you want to share a `coro::io_scheduler` while monitoring the progress of a subset of tasks.
 
 The example provided here shows an i/o scheduler that spins up a basic `coro::net::tcp::server` and a `coro::net::tcp::client` that will connect to each other and then send a request and a response.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
         - Can use `coro::thread_pool` for latency sensitive or long lived tasks.
         - Can use inline task processing for thread per core or short lived tasks.
         - Requires `LIBCORO_FEATURE_NETWORKING` to be supported.
-    - coro::task_container for dynamic task lifetimes
+    - coro::task_container for dynamic task lifetimes, used in conjunction of an executor.
 * Coroutine Networking
     - coro::net::dns::resolver for async dns
         - Uses libc-ares
@@ -1046,7 +1046,7 @@ ss.request_stop()                       # request to stop, wakeup all waiters an
 * `coro::thread_pool::schedule()` Use `co_await` on this method inside a coroutine to transfer the tasks execution to the `coro::thread_pool`.
 * `coro::thread_pool::spawn(coro::task<void>&& task)` Spawns the task to be detached and owned by the `coro::thread_pool`, use this if you want to fire and forget the task, the `coro::thread_pool` will maintain the task's lifetime.
 * `coro::thread_pool::schedule(coro::task<T> task) -> coro::task<T>` schedules the task on the `coro::thread_pool` and then returns the result in a task that must be awaited. This is useful if you want to schedule work on the `coro::thread_pool` and want to wait for the result.
-* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::thread_pool`. Use this when you want to share a `coro::thread_poll` while monitoring the progress of a subset of tasks.
+* `coro::task_container::start(coro::task<void>&& task)` schedules the task on the `coro::thread_pool`. Use this when you want to share a `coro::thread_pool` while monitoring the progress of a subset of tasks.
 
 ```C++
 #include <coro/coro.hpp>


### PR DESCRIPTION
This test on github actions seems to fail quite regularly, giving it a bump in how long the task that shouldn't complete 4x the amount of time to see if this resolves the issuue (I think the github servers are just very overloaded and a 40ms difference isn't enough to have it trigger properly every time, lets see if 190ms is enough.)

Closes #355