### PR TITLE
coro::shared_mutex use coro::mutex instead of std::mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,10 @@
 
 /build/
 /Debug/
+/cmake-build-debug/
 /RelWithDebInfo/
 /Release/
 /Testing/
 
 /.vscode/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -574,10 +574,10 @@ The `coro::shared_mutex` requires a `executor_type` when constructed to be able 
 
 int main()
 {
-    // Shared mutexes require an excutor type to be able to wake up multiple shared waiters when
-    // there is an exclusive lock holder releasing the lock.  This example uses a single thread
+    // Shared mutexes require an executor type to be able to wake up multiple shared waiters when
+    // there is an exclusive lock holder releasing the lock. This example uses a single thread
     // to also show the interleaving of coroutines acquiring the shared lock in shared and
-    // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
+    // exclusive mode as they resume and suspend in a linear manner. Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
     auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     coro::shared_mutex<coro::thread_pool> mutex{tp};
@@ -587,15 +587,19 @@ int main()
                                uint64_t                               i) -> coro::task<void>
     {
         co_await tp->schedule();
+        std::cerr << "shared task " << i << " lock_shared()\n";
+
+        // Note that to have a scoped shared lock a task must be passed in for the shared scoped lock to callback,
+        // this is required since coro::shared_mutex.unlock() and unlock_shared() are coroutines and cannot be
+        // awaited in a RAII destructor like coro::mutex.
+        co_await mutex.scoped_lock_shared([](std::shared_ptr<coro::thread_pool> tp, uint64_t i) -> coro::task<void>
         {
-            std::cerr << "shared task " << i << " lock_shared()\n";
-            auto scoped_lock = co_await mutex.lock_shared();
             std::cerr << "shared task " << i << " lock_shared() acquired\n";
             /// Immediately yield so the other shared tasks also acquire in shared state
             /// while this task currently holds the mutex in shared state.
             co_await tp->yield();
             std::cerr << "shared task " << i << " unlock_shared()\n";
-        }
+        }(tp, i));
         co_return;
     };
 
@@ -603,17 +607,19 @@ int main()
                                   coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void>
     {
         co_await tp->schedule();
-
-        std::cerr << "exclusive task lock()\n";
-        auto scoped_lock = co_await mutex.lock();
-        std::cerr << "exclusive task lock() acquired\n";
-        // Do the exclusive work..
-        std::cerr << "exclusive task unlock()\n";
+        co_await mutex.scoped_lock([](std::shared_ptr<coro::thread_pool> tp) -> coro::task<void>
+        {
+            std::cerr << "exclusive task lock()\n";
+            std::cerr << "exclusive task lock() acquired\n";
+            // Do the exclusive work...
+            co_await tp->yield();
+            std::cerr << "exclusive task unlock()\n";
+        }(tp));
         co_return;
     };
 
     // Create 3 shared tasks that will acquire the mutex in a shared state.
-    const size_t                  num_tasks{3};
+    constexpr size_t              num_tasks{3};
     std::vector<coro::task<void>> tasks{};
     for (size_t i = 1; i <= num_tasks; ++i)
     {

--- a/examples/coro_shared_mutex.cpp
+++ b/examples/coro_shared_mutex.cpp
@@ -3,10 +3,10 @@
 
 int main()
 {
-    // Shared mutexes require an excutor type to be able to wake up multiple shared waiters when
-    // there is an exclusive lock holder releasing the lock.  This example uses a single thread
+    // Shared mutexes require an executor type to be able to wake up multiple shared waiters when
+    // there is an exclusive lock holder releasing the lock. This example uses a single thread
     // to also show the interleaving of coroutines acquiring the shared lock in shared and
-    // exclusive mode as they resume and suspend in a linear manner.  Ideally the thread pool
+    // exclusive mode as they resume and suspend in a linear manner. Ideally the thread pool
     // executor would have more than 1 thread to resume all shared waiters in parallel.
     auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
     coro::shared_mutex<coro::thread_pool> mutex{tp};
@@ -16,15 +16,19 @@ int main()
                                uint64_t                               i) -> coro::task<void>
     {
         co_await tp->schedule();
+        std::cerr << "shared task " << i << " lock_shared()\n";
+
+        // Note that to have a scoped shared lock a task must be passed in for the shared scoped lock to callback,
+        // this is required since coro::shared_mutex.unlock() and unlock_shared() are coroutines and cannot be
+        // awaited in a RAII destructor like coro::mutex.
+        co_await mutex.scoped_lock_shared([](std::shared_ptr<coro::thread_pool> tp, uint64_t i) -> coro::task<void>
         {
-            std::cerr << "shared task " << i << " lock_shared()\n";
-            auto scoped_lock = co_await mutex.lock_shared();
             std::cerr << "shared task " << i << " lock_shared() acquired\n";
             /// Immediately yield so the other shared tasks also acquire in shared state
             /// while this task currently holds the mutex in shared state.
             co_await tp->yield();
             std::cerr << "shared task " << i << " unlock_shared()\n";
-        }
+        }(tp, i));
         co_return;
     };
 
@@ -32,17 +36,19 @@ int main()
                                   coro::shared_mutex<coro::thread_pool>& mutex) -> coro::task<void>
     {
         co_await tp->schedule();
-
-        std::cerr << "exclusive task lock()\n";
-        auto scoped_lock = co_await mutex.lock();
-        std::cerr << "exclusive task lock() acquired\n";
-        // Do the exclusive work..
-        std::cerr << "exclusive task unlock()\n";
+        co_await mutex.scoped_lock([](std::shared_ptr<coro::thread_pool> tp) -> coro::task<void>
+        {
+            std::cerr << "exclusive task lock()\n";
+            std::cerr << "exclusive task lock() acquired\n";
+            // Do the exclusive work...
+            co_await tp->yield();
+            std::cerr << "exclusive task unlock()\n";
+        }(tp));
         co_return;
     };
 
     // Create 3 shared tasks that will acquire the mutex in a shared state.
-    const size_t                  num_tasks{3};
+    constexpr size_t              num_tasks{3};
     std::vector<coro::task<void>> tasks{};
     for (size_t i = 1; i <= num_tasks; ++i)
     {

--- a/include/coro/mutex.hpp
+++ b/include/coro/mutex.hpp
@@ -53,7 +53,7 @@ struct lock_operation : public lock_operation_base
     {
         if constexpr (std::is_same_v<scoped_lock, return_type>)
         {
-            return scoped_lock{m_mutex};
+            return scoped_lock{this->m_mutex};
         }
         else
         {
@@ -92,7 +92,7 @@ public:
     ~scoped_lock();
 
     scoped_lock(const scoped_lock&) = delete;
-    scoped_lock(scoped_lock&& other)
+    scoped_lock(scoped_lock&& other) noexcept
         : m_mutex(std::exchange(other.m_mutex, nullptr)) {}
     auto operator=(const scoped_lock&) -> scoped_lock& = delete;
     auto operator=(scoped_lock&& other) noexcept -> scoped_lock&

--- a/include/coro/shared_mutex.hpp
+++ b/include/coro/shared_mutex.hpp
@@ -1,74 +1,96 @@
 #pragma once
 
 #include "coro/concepts/executor.hpp"
+#include "coro/mutex.hpp"
+#include "coro/task.hpp"
 
 #include <atomic>
 #include <coroutine>
-#include <mutex>
 
 namespace coro
 {
 template<concepts::executor executor_type>
 class shared_mutex;
 
-/**
- * A scoped RAII lock holder for a coro::shared_mutex.  It will call the appropriate unlock() or
- * unlock_shared() based on how the coro::shared_mutex was originally acquired, either shared or
- * exclusive modes.
- */
-template<concepts::executor executor_type>
-class shared_scoped_lock
+namespace detail
 {
-public:
-    shared_scoped_lock(shared_mutex<executor_type>& sm, bool exclusive) : m_shared_mutex(&sm), m_exclusive(exclusive) {}
+template<concepts::executor executor_type>
+struct shared_lock_operation
+{
+    explicit shared_lock_operation(coro::shared_mutex<executor_type>& shared_mutex, const bool exclusive)
+        : m_shared_mutex(shared_mutex),
+          m_exclusive(exclusive)
+    {}
+    ~shared_lock_operation() = default;
 
-    /**
-     * Unlocks the mutex upon this shared scoped lock destructing.
-     */
-    ~shared_scoped_lock() { unlock(); }
+    shared_lock_operation(const shared_lock_operation&) = delete;
+    shared_lock_operation(shared_lock_operation&&) = delete;
+    auto operator=(const shared_lock_operation&) -> shared_lock_operation& = delete;
+    auto operator=(shared_lock_operation&&) -> shared_lock_operation& = delete;
 
-    shared_scoped_lock(const shared_scoped_lock&) = delete;
-    shared_scoped_lock(shared_scoped_lock&& other)
-        : m_shared_mutex(std::exchange(other.m_shared_mutex, nullptr)),
-          m_exclusive(other.m_exclusive)
+    auto await_ready() const noexcept -> bool
     {
-    }
+        // If either mode can be acquired, unlock the internal mutex and resume.
 
-    auto operator=(const shared_scoped_lock&) -> shared_scoped_lock& = delete;
-    auto operator=(shared_scoped_lock&& other) noexcept -> shared_scoped_lock&
-    {
-        if (std::addressof(other) != this)
+        if (m_exclusive)
         {
-            m_shared_mutex = std::exchange(other.m_shared_mutex, nullptr);
-            m_exclusive    = other.m_exclusive;
+            if (m_shared_mutex.try_lock_locked())
+            {
+                m_shared_mutex.m_mutex.unlock();
+                return true;
+            }
         }
-        return *this;
-    }
-
-    /**
-     * Unlocks the shared mutex prior to this lock going out of scope.
-     */
-    auto unlock() -> void
-    {
-        if (m_shared_mutex != nullptr)
+        else if (m_shared_mutex.try_lock_shared_locked())
         {
-            if (m_exclusive)
-            {
-                m_shared_mutex->unlock();
-            }
-            else
-            {
-                m_shared_mutex->unlock_shared();
-            }
-
-            m_shared_mutex = nullptr;
+            m_shared_mutex.m_mutex.unlock();
+            return true;
         }
+
+        return false;
     }
 
-private:
-    shared_mutex<executor_type>* m_shared_mutex{nullptr};
-    bool                         m_exclusive{false};
+    auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+    {
+        // For sure the lock is currently held in a manner that it cannot be acquired, suspend ourself
+        // at the end of the waiter list.
+
+        auto* tail_waiter = m_shared_mutex.m_tail_waiter.load(std::memory_order::acquire);
+
+        if (tail_waiter == nullptr)
+        {
+            m_shared_mutex.m_head_waiter = this;
+            m_shared_mutex.m_tail_waiter = this;
+        }
+        else
+        {
+            tail_waiter->m_next = this;
+            m_shared_mutex.m_tail_waiter         = this;
+        }
+
+        // If this is an exclusive lock acquire then mark it as so so that shared locks after this
+        // exclusive one will also suspend so this exclusive lock doesn't get starved.
+        if (m_exclusive)
+        {
+            ++m_shared_mutex.m_exclusive_waiters;
+        }
+
+        m_awaiting_coroutine = awaiting_coroutine;
+        m_shared_mutex.m_mutex.unlock();
+        return true;
+    }
+
+    auto await_resume() noexcept -> void { }
+
+protected:
+    friend class coro::shared_mutex<executor_type>;
+
+    std::coroutine_handle<> m_awaiting_coroutine;
+    shared_lock_operation* m_next{nullptr};
+    coro::shared_mutex<executor_type>& m_shared_mutex;
+    bool m_exclusive{false};
 };
+
+} // namespace detail
 
 template<concepts::executor executor_type>
 class shared_mutex
@@ -83,7 +105,7 @@ public:
     {
         if (m_executor == nullptr)
         {
-            throw std::runtime_error{"shared_mutex cannot have a nullptr executor"};
+            throw std::runtime_error{"coro::shared_mutex cannot have a nullptr executor"};
         }
     }
     ~shared_mutex() = default;
@@ -93,95 +115,62 @@ public:
     auto operator=(const shared_mutex&) -> shared_mutex& = delete;
     auto operator=(shared_mutex&&) -> shared_mutex&      = delete;
 
-    struct lock_operation
+    /**
+     * Acquires the lock in a shared state, executes the scoped task, and then unlocks the shared lock.
+     * Because unlocking a coro::shared_mutex is a task this scoped version cannot be returned as a RAII
+     * object due to destructors not being able to be co_await'ed.
+     * @param scoped_task The user's scoped task to execute after acquiring the shared lock.
+     */
+    [[nodiscard]] auto scoped_lock_shared(coro::task<void> scoped_task) -> coro::task<void>
     {
-        lock_operation(shared_mutex& sm, bool exclusive) : m_shared_mutex(sm), m_exclusive(exclusive) {}
-
-        auto await_ready() const noexcept -> bool
-        {
-            if (m_exclusive)
-            {
-                return m_shared_mutex.try_lock();
-            }
-            else
-            {
-                return m_shared_mutex.try_lock_shared();
-            }
-        }
-
-        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
-        {
-            std::unique_lock lk{m_shared_mutex.m_mutex};
-            // Its possible the lock has been released between await_ready() and await_suspend(), double
-            // check and make sure we are not going to suspend when nobody holds the lock.
-            if (m_exclusive)
-            {
-                if (m_shared_mutex.try_lock_locked(lk))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (m_shared_mutex.try_lock_shared_locked(lk))
-                {
-                    return false;
-                }
-            }
-
-            // For sure the lock is currently held in a manner that it cannot be acquired, suspend ourself
-            // at the end of the waiter list.
-
-            if (m_shared_mutex.m_tail_waiter == nullptr)
-            {
-                m_shared_mutex.m_head_waiter = this;
-                m_shared_mutex.m_tail_waiter = this;
-            }
-            else
-            {
-                m_shared_mutex.m_tail_waiter->m_next = this;
-                m_shared_mutex.m_tail_waiter         = this;
-            }
-
-            // If this is an exclusive lock acquire then mark it as so so that shared locks after this
-            // exclusive one will also suspend so this exclusive lock doens't get starved.
-            if (m_exclusive)
-            {
-                ++m_shared_mutex.m_exclusive_waiters;
-            }
-
-            m_awaiting_coroutine = awaiting_coroutine;
-            return true;
-        }
-        auto await_resume() noexcept -> shared_scoped_lock<executor_type>
-        {
-            return shared_scoped_lock{m_shared_mutex, m_exclusive};
-        }
-
-    private:
-        friend class shared_mutex;
-
-        shared_mutex&           m_shared_mutex;
-        bool                    m_exclusive{false};
-        std::coroutine_handle<> m_awaiting_coroutine;
-        lock_operation*         m_next{nullptr};
-    };
+        co_await m_mutex.lock();
+        co_await detail::shared_lock_operation<executor_type>{*this, false};
+        co_await scoped_task;
+        co_await unlock_shared();
+        co_return;
+    }
 
     /**
-     * Locks the mutex in a shared state.  If there are any exclusive waiters then the shared waiters
-     * will also wait so the exclusive waiters are not starved.
+     * Acquires the lock in an exclusive state, executes the scoped task, and then unlocks the exclusive lock.
+     * Because unlocking a coro::shared_mutex is a task this scoped version cannot be returned as a RAII
+     * object due to destructors not being able to be co_await'ed.
+     * @param scoped_task The user's scoped task to execute after acquiring the exclusive lock.
      */
-    [[nodiscard]] auto lock_shared() -> lock_operation { return lock_operation{*this, false}; }
+    [[nodiscard]] auto scoped_lock(coro::task<void> scoped_task) -> coro::task<void>
+    {
+        co_await m_mutex.lock();
+        co_await detail::shared_lock_operation<executor_type>{*this, true};
+        co_await scoped_task;
+        co_await unlock();
+        co_return;
+    }
 
     /**
-     * Locks the mutex in an exclusive state.
+     * Acquires the lock in a shared state. The shared_mutex must be unlock_shared() to release.
+     * @return task
      */
-    [[nodiscard]] auto lock() -> lock_operation { return lock_operation{*this, true}; }
+    [[nodiscard]] auto lock_shared() -> coro::task<void>
+    {
+        co_await m_mutex.lock();
+        co_await detail::shared_lock_operation<executor_type>{*this, false};
+        co_return;
+    }
+
+    /**
+     * Acquires the lock in an exclusive state. The shared_mutex must be unlock()'ed to release.
+     * @return task
+     */
+    [[nodiscard]] auto lock() -> coro::task<void>
+    {
+        co_await m_mutex.lock();
+        co_await detail::shared_lock_operation<executor_type>{*this, true};
+        co_return;
+    }
 
     /**
      * @return True if the lock could immediately be acquired in a shared state.
      */
-    auto try_lock_shared() -> bool
+    [[nodiscard]] auto try_lock_shared() -> bool
     {
         // To acquire the shared lock the state must be one of two states:
         //   1) unlocked
@@ -189,100 +178,126 @@ public:
         //          Zero exclusive waiters prevents exclusive starvation if shared locks are
         //          always continuously happening.
 
-        std::unique_lock lk{m_mutex};
-        return try_lock_shared_locked(lk);
+        if (m_mutex.try_lock())
+        {
+            coro::scoped_lock lk{m_mutex};
+            return try_lock_shared_locked();
+        }
+        return false;
     }
 
     /**
      * @return True if the lock could immediately be acquired in an exclusive state.
      */
-    auto try_lock() -> bool
+    [[nodiscard]] auto try_lock() -> bool
     {
         // To acquire the exclusive lock the state must be unlocked.
-        std::unique_lock lk{m_mutex};
-        return try_lock_locked(lk);
+        if (m_mutex.try_lock())
+        {
+            coro::scoped_lock lk{m_mutex};
+            return try_lock_locked();
+        }
+        return false;
     }
 
     /**
-     * Unlocks a single shared state user.  *REQUIRES* that the lock was first acquired exactly once
+     * Unlocks a single shared state user. *REQUIRES* that the lock was first acquired exactly once
      * via `lock_shared()` or `try_lock_shared() -> True` before being called, otherwise undefined
      * behavior.
      *
      * If the shared user count drops to zero and this lock has an exclusive waiter then the exclusive
      * waiter acquires the lock.
      */
-    auto unlock_shared() -> void
+    [[nodiscard]] auto unlock_shared() -> coro::task<void>
     {
-        std::unique_lock lk{m_mutex};
-        --m_shared_users;
+        auto lk = co_await m_mutex.scoped_lock();
+        auto users = m_shared_users.fetch_sub(1, std::memory_order::acq_rel);
 
-        // Only wake waiters from shared state if all shared users have completed.
-        if (m_shared_users == 0)
+        // If this is the final unlock_shared() see if there is anyone to wakeup.
+        if (users == 1)
         {
-            if (m_head_waiter != nullptr)
+            auto* head_waiter = m_head_waiter.load(std::memory_order::acquire);
+            if (head_waiter != nullptr)
             {
-                wake_waiters(lk);
+                wake_waiters(lk, head_waiter);
             }
             else
             {
                 m_state = state::unlocked;
             }
         }
+
+        co_return;
     }
 
     /**
-     * Unlocks the mutex from its exclusive state.  If there is a following exclusive watier then
+     * Unlocks the mutex from its exclusive state. If there is a following exclusive waiter then
      * that exclusive waiter acquires the lock.  If there are 1 or more shared waiters then all the
      * shared waiters acquire the lock in a shared state in parallel and are resumed on the original
-     * thread pool this shared mutex was created with.
+     * executor this shared mutex was created with.
      */
-    auto unlock() -> void
+    [[nodiscard]] auto unlock() -> coro::task<void>
     {
-        std::unique_lock lk{m_mutex};
-        if (m_head_waiter != nullptr)
+        auto lk = co_await m_mutex.scoped_lock();
+        auto* head_waiter = m_head_waiter.load(std::memory_order::acquire);
+        if (head_waiter != nullptr)
         {
-            wake_waiters(lk);
+            wake_waiters(lk, head_waiter);
         }
         else
         {
             m_state = state::unlocked;
         }
+
+        co_return;
+    }
+
+    /**
+     * @brief Gets the executor that drives the shared mutex.
+     *
+     * @return std::shared_ptr<executor_type>
+     */
+    [[nodiscard]] auto executor() -> std::shared_ptr<executor_type>
+    {
+        return m_executor;
     }
 
 private:
-    friend struct lock_operation;
+    friend struct detail::shared_lock_operation<executor_type>;
 
     enum class state
     {
+        /// @brief The shared mutex is unlocked.
         unlocked,
+        /// @brief The shared mutex is locked in shared mode.
         locked_shared,
+        /// @brief The shared mutex is locked in exclusive mode.
         locked_exclusive
     };
 
-    /// This executor is for resuming multiple shared waiters.
+    /// @brief This executor is for resuming multiple shared waiters.
     std::shared_ptr<executor_type> m_executor{nullptr};
+    /// @brief Exclusive access for mutating the shared mutex's state.
+    coro::mutex m_mutex;
+    /// @brief The current state of the shared mutex.
+    std::atomic<state> m_state{state::unlocked};
 
-    std::mutex m_mutex;
+    /// @brief The current number of shared users that have acquired the lock.
+    std::atomic<uint64_t> m_shared_users{0};
+    /// @brief The current number of exclusive waiters waiting to acquire the lock.  This is used to block
+    ///        new incoming shared lock attempts so the exclusive waiter is not starved.
+    std::atomic<uint64_t> m_exclusive_waiters{0};
 
-    state m_state{state::unlocked};
+    std::atomic<detail::shared_lock_operation<executor_type>*> m_head_waiter{nullptr};
+    std::atomic<detail::shared_lock_operation<executor_type>*> m_tail_waiter{nullptr};
 
-    /// The current number of shared users that have acquired the lock.
-    uint64_t m_shared_users{0};
-    /// The current number of exclusive waiters waiting to acquire the lock.  This is used to block
-    /// new incoming shared lock attempts so the exclusive waiter is not starved.
-    uint64_t m_exclusive_waiters{0};
-
-    lock_operation* m_head_waiter{nullptr};
-    lock_operation* m_tail_waiter{nullptr};
-
-    auto try_lock_shared_locked(std::unique_lock<std::mutex>& lk) -> bool
+    auto try_lock_shared_locked() -> bool
     {
         if (m_state == state::unlocked)
         {
             // If the shared mutex is unlocked put it into shared mode and add ourself as using the lock.
             m_state = state::locked_shared;
             ++m_shared_users;
-            lk.unlock();
             return true;
         }
         else if (m_state == state::locked_shared && m_exclusive_waiters == 0)
@@ -290,7 +305,6 @@ private:
             // If the shared mutex is in a shared locked state and there are no exclusive waiters
             // the add ourself as using the lock.
             ++m_shared_users;
-            lk.unlock();
             return true;
         }
 
@@ -302,55 +316,70 @@ private:
         return false;
     }
 
-    auto try_lock_locked(std::unique_lock<std::mutex>& lk) -> bool
+    auto try_lock_locked() -> bool
     {
         if (m_state == state::unlocked)
         {
             m_state = state::locked_exclusive;
-            lk.unlock();
             return true;
         }
         return false;
     }
 
-    auto wake_waiters(std::unique_lock<std::mutex>& lk) -> void
+    auto wake_waiters(coro::scoped_lock& lk, detail::shared_lock_operation<executor_type>* head_waiter) -> void
     {
         // First determine what the next lock state will be based on the first waiter.
-        if (m_head_waiter->m_exclusive)
+        if (head_waiter->m_exclusive)
         {
             // If its exclusive then only this waiter can be woken up.
-            m_state                   = state::locked_exclusive;
-            lock_operation* to_resume = m_head_waiter;
-            m_head_waiter             = m_head_waiter->m_next;
-            --m_exclusive_waiters;
-            if (m_head_waiter == nullptr)
+            m_state.store(state::locked_exclusive, std::memory_order::release);
+            if (head_waiter->m_next == nullptr)
             {
-                m_tail_waiter = nullptr;
+                // This is the final waiter, set the list to null.
+                m_head_waiter.store(nullptr, std::memory_order::release);
+                m_tail_waiter.store(nullptr, std::memory_order::release);
             }
+            else
+            {
+                // Advance the head waiter to next.
+                m_head_waiter.store(head_waiter->m_next, std::memory_order::release);
+            }
+
+            m_exclusive_waiters.fetch_sub(1, std::memory_order::release);
 
             // Since this is an exclusive lock waiting we can resume it directly.
             lk.unlock();
-            to_resume->m_awaiting_coroutine.resume();
+            head_waiter->m_awaiting_coroutine.resume();
         }
         else
         {
             // If its shared then we will scan forward and awake all shared waiters onto the given
             // thread pool so they can run in parallel.
-            m_state = state::locked_shared;
-            do
+            m_state.store(state::locked_shared, std::memory_order::release);
+            while (true)
             {
-                lock_operation* to_resume = m_head_waiter;
-                m_head_waiter             = m_head_waiter->m_next;
-                if (m_head_waiter == nullptr)
+                auto* to_resume = m_head_waiter.load(std::memory_order::acquire);
+                if (to_resume == nullptr || to_resume->m_exclusive)
                 {
-                    m_tail_waiter = nullptr;
+                    break;
                 }
-                ++m_shared_users;
+
+                if (to_resume->m_next == nullptr)
+                {
+                    m_head_waiter.store(nullptr, std::memory_order::release);
+                    m_tail_waiter.store(nullptr, std::memory_order::release);
+                }
+                else
+                {
+                    m_head_waiter.store(to_resume->m_next, std::memory_order::release);
+                }
+
+                m_shared_users.fetch_add(1, std::memory_order::release);
 
                 m_executor->resume(to_resume->m_awaiting_coroutine);
-            } while (m_head_waiter != nullptr && !m_head_waiter->m_exclusive);
+            }
 
-            // Cannot unlock until the entire set of shared waiters has been traversed.  I think this
+            // Cannot unlock until the entire set of shared waiters has been traversed. I think this
             // makes more sense than allocating space for all the shared waiters, unlocking, and then
             // resuming in a batch?
             lk.unlock();

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -23,25 +23,79 @@ TEST_CASE("mutex single waiter not locked exclusive", "[shared_mutex]")
     {
         std::cerr << "Acquiring lock exclusive\n";
         {
-            auto scoped_lock = co_await m.lock();
+            co_await m.lock();
             REQUIRE_FALSE(m.try_lock());
             REQUIRE_FALSE(m.try_lock_shared());
             std::cerr << "lock acquired, emplacing back 1\n";
             output.emplace_back(1);
             std::cerr << "coroutine done\n";
+            co_await m.unlock();
         }
 
-        // The scoped lock should release the lock upon destructing.
-        REQUIRE(m.try_lock());
-        m.unlock();
+        // The scoped lock will release the lock upon destructing, but shared mutex
+        // scoped locks spawn the unlock() into the thread pool so it doesn't block.
+        while (!m.try_lock())
+        {
+            co_await m.executor()->yield();
+        }
+        co_await m.unlock();
 
         co_return;
     };
 
     coro::sync_wait(make_emplace_task(m, output));
 
+    // Wait for the spawned unlock() to complete.
+    tp->shutdown();
+
     REQUIRE(m.try_lock());
-    m.unlock();
+    coro::sync_wait(m.unlock());
+
+    REQUIRE(output.size() == 1);
+    REQUIRE(output[0] == 1);
+}
+
+TEST_CASE("mutex single waiter not locked exclusive with shared scoped lock", "[shared_mutex]")
+{
+    auto                  tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
+    std::vector<uint64_t> output;
+
+    coro::shared_mutex<coro::thread_pool> m{tp};
+
+    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m,
+                                std::vector<uint64_t>&                 output) -> coro::task<void>
+    {
+
+        std::cerr << "Acquiring lock exclusive\n";
+        co_await m.scoped_lock([](coro::shared_mutex<coro::thread_pool>& m,
+                                std::vector<uint64_t>&                 output) -> coro::task<void>
+        {
+            REQUIRE_FALSE(m.try_lock());
+            REQUIRE_FALSE(m.try_lock_shared());
+            std::cerr << "lock acquired, emplacing back 1\n";
+            output.emplace_back(1);
+            std::cerr << "coroutine done\n";
+            co_return;
+        }(m, output));
+
+        // The scoped lock will release the lock upon destructing, but shared mutex
+        // scoped locks spawn the unlock() into the thread pool so it doesn't block.
+        while (!m.try_lock())
+        {
+            co_await m.executor()->yield();
+        }
+        co_await m.unlock();
+
+        co_return;
+    };
+
+    coro::sync_wait(make_emplace_task(m, output));
+
+    // Wait for the spawned unlock() to complete.
+    tp->shutdown();
+
+    REQUIRE(m.try_lock());
+    coro::sync_wait(m.unlock());
 
     REQUIRE(output.size() == 1);
     REQUIRE(output[0] == 1);
@@ -59,7 +113,8 @@ TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
     {
         std::cerr << "Acquiring lock shared\n";
         {
-            auto scoped_lock = co_await m.lock_shared();
+            // auto scoped_lock = co_await m.scoped_lock_shared();
+            co_await m.lock_shared();
             REQUIRE_FALSE(m.try_lock());
             REQUIRE(m.try_lock_shared());
             std::cerr << "lock acquired, reading values\n";
@@ -68,24 +123,74 @@ TEST_CASE("mutex single waiter not locked shared", "[shared_mutex]")
                 std::cerr << v << ",";
             }
             std::cerr << "\ncoroutine done\n";
-
-            m.unlock_shared(); // manually locked shared on a shared, unlock
+            co_await m.unlock_shared(); // unlock shared twice due to lock_shared() and try_lock_shared()
+            co_await m.unlock_shared();
         }
 
-        // The scoped lock should release the lock upon destructing.
-        REQUIRE(m.try_lock());
-        m.unlock();
+        // The scoped lock will release the lock upon destructing.
+        while (!m.try_lock())
+        {
+            co_await m.executor()->yield();
+        }
+        co_await m.unlock();
 
         co_return;
     };
 
     coro::sync_wait(make_emplace_task(m, values));
 
+    tp->shutdown(); // wait for spawned unlock() to complete
+
     REQUIRE(m.try_lock_shared());
-    m.unlock_shared();
+    coro::sync_wait(m.unlock_shared());
 
     REQUIRE(m.try_lock());
-    m.unlock();
+    coro::sync_wait(m.unlock());
+}
+
+TEST_CASE("mutex single waiter not locked shared shared scope lock", "[shared_mutex]")
+{
+    auto                  tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
+    std::vector<uint64_t> values{1, 2, 3};
+
+    coro::shared_mutex<coro::thread_pool> m{tp};
+
+    auto make_emplace_task = [](coro::shared_mutex<coro::thread_pool>& m,
+                                std::vector<uint64_t>&                 values) -> coro::task<void>
+    {
+        std::cerr << "Acquiring lock shared\n";
+        co_await m.scoped_lock_shared([](coro::shared_mutex<coro::thread_pool>& m, std::vector<uint64_t>& values) -> coro::task<void>
+        {
+            REQUIRE_FALSE(m.try_lock());
+            REQUIRE(m.try_lock_shared());
+            std::cerr << "lock acquired, reading values\n";
+            for (const auto& v : values)
+            {
+                std::cerr << v << ",";
+            }
+            std::cerr << "\ncoroutine done\n";
+            co_await m.unlock_shared(); // manually shared unlock once
+        }(m, values));
+
+        // The scoped lock will release the lock upon destructing.
+        while (!m.try_lock())
+        {
+            co_await m.executor()->yield();
+        }
+        co_await m.unlock();
+
+        co_return;
+    };
+
+    coro::sync_wait(make_emplace_task(m, values));
+
+    tp->shutdown(); // wait for spawned unlock() to complete
+
+    REQUIRE(m.try_lock_shared());
+    coro::sync_wait(m.unlock_shared());
+
+    REQUIRE(m.try_lock());
+    coro::sync_wait(m.unlock());
 }
 
 #ifdef LIBCORO_FEATURE_NETWORKING
@@ -106,12 +211,13 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
 
         {
             std::cerr << "make_shared_task exclusive lock acquiring\n";
-            auto scoped_lock = co_await m.lock();
+            co_await m.lock();
             std::cerr << "make_shared_task exclusive lock acquired\n";
             // Stack readers on the mutex
             co_await s->yield_for(std::chrono::milliseconds{50});
             read_value.exchange(true, std::memory_order::release);
             std::cerr << "make_shared_task exclusive lock releasing\n";
+            co_await m.unlock();
         }
 
         co_return;
@@ -127,9 +233,10 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
         {
             co_await s->schedule();
             std::cerr << "make_shared_task shared lock acquiring\n";
-            auto scoped_lock = co_await m.lock_shared();
+            co_await m.lock_shared();
             std::cerr << "make_shared_task shared lock acquired\n";
             bool value = read_value.load(std::memory_order::acquire);
+            co_await m.unlock_shared();
             std::cerr << "make_shared_task shared lock releasing on thread_id = " << std::this_thread::get_id() << "\n";
             co_return value;
         };


### PR DESCRIPTION
Make this construct truely async.

Closes #337