### PR TITLE
Support tasks with same type and treat task<void> as task<std::monostate> on variadic overload of when_any

### DIFF
--- a/include/coro/when_any.hpp
+++ b/include/coro/when_any.hpp
@@ -48,7 +48,7 @@ auto make_when_any_tuple_task(
         if (first_completed.compare_exchange_strong(
                 expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
         {
-            return_value.emplace(std::in_place_index_t<index>{}, std::monostate{});
+            return_value.emplace(std::in_place_index<index>, std::monostate{});
             notify.set();
         }
     }
@@ -58,7 +58,7 @@ auto make_when_any_tuple_task(
         if (first_completed.compare_exchange_strong(
                 expected, true, std::memory_order::acq_rel, std::memory_order::relaxed))
         {
-            return_value.emplace(std::in_place_index_t<index>{}, std::move(result));
+            return_value.emplace(std::in_place_index<index>, std::move(result));
             notify.set();
         }
     }

--- a/test/test_when_any.cpp
+++ b/test/test_when_any.cpp
@@ -25,6 +25,16 @@ TEST_CASE("when_any two tasks", "[when_any]")
     REQUIRE(result == 1);
 }
 
+TEST_CASE("when_any two tasks as tuple", "[when_any]")
+{
+    std::cerr << "BEGIN when_any two tasks as tuple\n";
+    auto make_task = [](uint64_t amount) -> coro::task<uint64_t> { co_return amount; };
+
+    auto result = coro::sync_wait(coro::when_any(make_task(1), make_task(2)));
+    REQUIRE(result.index() == 0);
+    REQUIRE(std::get<0>(result) == 1);
+}
+
 TEST_CASE("when_any return void", "[when_any]")
 {
     std::cerr << "BEGIN when_any return void\n";

--- a/test/test_when_any.cpp
+++ b/test/test_when_any.cpp
@@ -65,9 +65,9 @@ TEST_CASE("when_any return void", "[when_any]")
     }
 }
 
-TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
+TEST_CASE("when_any tuple return void", "[when_any]")
 {
-    std::cerr << "BEGIN when_any tuple return void (monostate)\n";
+    std::cerr << "BEGIN when_any tuple return void\n";
 
     // This test needs to use a mutex to guarantee that the task that sets the counter
     // is the first task to complete, otherwise there is a race condition if counter is atomic
@@ -78,7 +78,7 @@ TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
     std::atomic<uint64_t>          counter{0};
 
     auto make_task_return_void =
-        [](std::shared_ptr<coro::thread_pool> tp, coro::event& can_return, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<std::monostate>
+        [](std::shared_ptr<coro::thread_pool> tp, coro::event& can_return, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<void>
     {
         co_await tp->schedule();
 
@@ -88,8 +88,6 @@ TEST_CASE("when_any tuple return void (monostate)", "[when_any]")
             REQUIRE_THREAD_SAFE(counter.load(std::memory_order::acquire) == 2);
             co_await can_return;
         }
-
-        co_return std::monostate{};
     };
 
     auto make_task = [](std::shared_ptr<coro::thread_pool> tp, coro::event& can_return, std::atomic<uint64_t>& counter, uint64_t i) -> coro::task<uint64_t>


### PR DESCRIPTION
I have noticed that the variadic `coro::when_any` function can't be called if the awaitables have the same type. The issue is caused by the `return_value` assignment on `make_when_any_tuple_task` function. To fix it I just replaced it with `std::option::emplace` to invoke the constructor of the variant initializer list that explicitly state the index of the variant.

This should work now:
```cpp
auto make_task = [](int value) -> coro::task<int> { /* ... */ co_return value; };
auto result = co_await coro::when_any(make_task(1), make_task(2));

static_assert(std::same_as<decltype(result), std::variant<int, int>>);

switch (result.index()) {
    case 0: assert(std::get<0>(result) == 1); break;
    case 1: assert(std::get<1>(result) == 2); break;
}
```

I also noticed that awaitables that returns void can't be used in the variadic overload of `coro::when_any` function. I think it should be able to be used there by treating it like awaitable that returns an `std::monostate`.

```cpp
auto make_task = [] -> coro::task<int> { /* ... */ };
auto make_task_void = [] -> coro::task<void> { /* ... */ };

// assume the second task completes first
auto result = co_await coro::when_any(make_task(), make_task_void());

static_assert(std::same_as<decltype(result), std::variant<int, std::monostate>>);

assert(result.index() == 1);
assert(std::holds_alternative<std::monostate>(result))
```