### PR TITLE
semaphore hang

### DIFF
--- a/include/coro/semaphore.hpp
+++ b/include/coro/semaphore.hpp
@@ -110,7 +110,7 @@ public:
                 {
                     return;
                 }
-            } while (m_counter.compare_exchange_weak(current, current + 1, std::memory_order::acq_rel, std::memory_order::acquire));
+            } while (!m_counter.compare_exchange_weak(current, current + 1, std::memory_order::acq_rel, std::memory_order::acquire));
         }
     }
 

--- a/test/test_semaphore.cpp
+++ b/test/test_semaphore.cpp
@@ -215,6 +215,7 @@ TEST_CASE("semaphore 1 producers and many consumers", "[semaphore]")
         [](std::shared_ptr<coro::thread_pool> tp, coro::semaphore<50>& s, std::atomic<uint64_t>& value, uint64_t id) -> coro::task<void>
     {
         co_await tp->schedule();
+        std::cerr << "consumer " << id << " starting\n";
 
         while (true)
         {


### PR DESCRIPTION
@Cra3z identified a missing '!' operator in a while loop for releasing a semaphore, this likely was spinning indefinitely in the tests and causing the hang.

Closes #367