### PR TITLE
CMake project version now pulled from git describe

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -42,6 +42,11 @@ jobs:
                     conan profile detect
             -   name: Checkout
                 uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Install Conan Dependencies
                 run: |
                     conan install -r conancenter \

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -30,6 +30,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Debug

--- a/.github/workflows/ci-emscripten.yml
+++ b/.github/workflows/ci-emscripten.yml
@@ -27,6 +27,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             # Must be done after checkout since it requires the directory structure to be in place.
             -   name: Install emsdk
                 run: |

--- a/.github/workflows/ci-fedora.yml
+++ b/.github/workflows/ci-fedora.yml
@@ -29,6 +29,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Release
                 run: |
                     mkdir Release

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Mark repository as safe
+        run: git config --global --add safe.directory "*"
       - name: Release
         run: |
           brew --prefix llvm@${{ matrix.clang_version }}

--- a/.github/workflows/ci-opensuse.yml
+++ b/.github/workflows/ci-opensuse.yml
@@ -29,6 +29,9 @@ jobs:
                 uses: actions/checkout@v2
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Release

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -36,6 +36,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Release
@@ -87,6 +91,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Release
@@ -141,6 +149,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Release

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,6 +15,10 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
                     mkdir Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ execute_process(
     OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-## ERROR_QUIET
-
 message(STATUS "git describe last release tag: ${GIT_VERSION}")
 
 # The git describe tag is in the format of "vN.N.N-<hash>[-dirty]"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,31 @@
 cmake_minimum_required(VERSION 3.15)
 include(CMakeDependentOption)
+find_package(Git)
+
+# Define the libcoro version string based on `git describe` command for the latest tagged release.
+execute_process(
+    COMMAND "${GIT_EXECUTABLE}" describe --match v[0-9]* --always --tags --dirty=-dirty
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    OUTPUT_VARIABLE GIT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+## ERROR_QUIET
+
+message(STATUS "git describe last release tag: ${GIT_VERSION}")
+
+# The git describe tag is in the format of "vN.N.N-<hash>[-dirty]"
+# The cmake project VERSION parameter requires a semver, strip the v and the suffix.
+string(FIND ${GIT_VERSION} "-" GIT_VERSION_DASH_POSITION)
+math(EXPR GIT_VERSION_END "${GIT_VERSION_DASH_POSITION} - 1")
+string(SUBSTRING ${GIT_VERSION} 1 ${GIT_VERSION_END} PROJECT_VERSION)
+
 project(libcoro
-    VERSION 0.11.1
+    VERSION ${PROJECT_VERSION}
     LANGUAGES CXX
     DESCRIPTION "C++20 coroutine library"
 )
+
+message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX TRUE)
@@ -48,18 +69,18 @@ endif()
 cmake_dependent_option(LIBCORO_FEATURE_NETWORKING "Include networking features, Default=ON." ON "NOT EMSCRIPTEN; NOT MSVC" OFF)
 cmake_dependent_option(LIBCORO_FEATURE_TLS "Include TLS encryption features, Default=ON." ON "NOT EMSCRIPTEN; NOT MSVC" OFF)
 
-message("${PROJECT_NAME} LIBCORO_ENABLE_ASAN           = ${LIBCORO_ENABLE_ASAN}")
-message("${PROJECT_NAME} LIBCORO_ENABLE_MSAN           = ${LIBCORO_ENABLE_MSAN}")
-message("${PROJECT_NAME} LIBCORO_ENABLE_TSAN           = ${LIBCORO_ENABLE_TSAN}")
-message("${PROJECT_NAME} LIBCORO_ENABLE_USAN           = ${LIBCORO_ENABLE_USAN}")
-message("${PROJECT_NAME} LIBCORO_EXTERNAL_DEPENDENCIES = ${LIBCORO_EXTERNAL_DEPENDENCIES}")
-message("${PROJECT_NAME} LIBCORO_BUILD_TESTS           = ${LIBCORO_BUILD_TESTS}")
-message("${PROJECT_NAME} LIBCORO_CODE_COVERAGE         = ${LIBCORO_CODE_COVERAGE}")
-message("${PROJECT_NAME} LIBCORO_BUILD_EXAMPLES        = ${LIBCORO_BUILD_EXAMPLES}")
-message("${PROJECT_NAME} LIBCORO_FEATURE_NETWORKING    = ${LIBCORO_FEATURE_NETWORKING}")
-message("${PROJECT_NAME} LIBCORO_FEATURE_TLS           = ${LIBCORO_FEATURE_TLS}")
-message("${PROJECT_NAME} LIBCORO_RUN_GITCONFIG         = ${LIBCORO_RUN_GITCONFIG}")
-message("${PROJECT_NAME} LIBCORO_BUILD_SHARED_LIBS     = ${LIBCORO_BUILD_SHARED_LIBS}")
+message(STATUS "LIBCORO_ENABLE_ASAN           = ${LIBCORO_ENABLE_ASAN}")
+message(STATUS "LIBCORO_ENABLE_MSAN           = ${LIBCORO_ENABLE_MSAN}")
+message(STATUS "LIBCORO_ENABLE_TSAN           = ${LIBCORO_ENABLE_TSAN}")
+message(STATUS "LIBCORO_ENABLE_USAN           = ${LIBCORO_ENABLE_USAN}")
+message(STATUS "LIBCORO_EXTERNAL_DEPENDENCIES = ${LIBCORO_EXTERNAL_DEPENDENCIES}")
+message(STATUS "LIBCORO_BUILD_TESTS           = ${LIBCORO_BUILD_TESTS}")
+message(STATUS "LIBCORO_CODE_COVERAGE         = ${LIBCORO_CODE_COVERAGE}")
+message(STATUS "LIBCORO_BUILD_EXAMPLES        = ${LIBCORO_BUILD_EXAMPLES}")
+message(STATUS "LIBCORO_FEATURE_NETWORKING    = ${LIBCORO_FEATURE_NETWORKING}")
+message(STATUS "LIBCORO_FEATURE_TLS           = ${LIBCORO_FEATURE_TLS}")
+message(STATUS "LIBCORO_RUN_GITCONFIG         = ${LIBCORO_RUN_GITCONFIG}")
+message(STATUS "LIBCORO_BUILD_SHARED_LIBS     = ${LIBCORO_BUILD_SHARED_LIBS}")
 
 if(LIBCORO_EXTERNAL_DEPENDENCIES)
     if(LIBCORO_FEATURE_NETWORKING)


### PR DESCRIPTION
This change will now dynamically set the project VERSION in cmake to the latest git describe tag released.

Now requires find_package(Git) to properly get the latest tag.

The tag is in the format of "v<n>.<n>.<n>-<hash>[-dirty]". This must be parsed into a semver format of "<n>.<n>.<n>" for cmake's VERSION to accept it.

Closes #381