### PR TITLE
semaphore::max() is static

### DIFF
--- a/include/coro/semaphore.hpp
+++ b/include/coro/semaphore.hpp
@@ -141,7 +141,7 @@ public:
     /**
      * @return The maximum number of resources the semaphore can contain.
      */
-    [[nodiscard]] constexpr auto max() const noexcept -> std::ptrdiff_t { return max_value; }
+    [[nodiscard]] static constexpr auto max() noexcept -> std::ptrdiff_t { return max_value; }
 
     /**
      * The current number of resources available in this semaphore.

--- a/test/test_semaphore.cpp
+++ b/test/test_semaphore.cpp
@@ -275,6 +275,18 @@ TEST_CASE("semaphore 1 producers and many consumers", "[semaphore]")
     std::cerr << "END semaphore 1 producers and many consumers\n";
 }
 
+TEST_CASE("semaphore max()", "[semaphore]")
+{
+    std::cerr << "BEGIN semaphore max()\n";
+
+    coro::semaphore<64> s{32};
+
+    REQUIRE(s.max() == 64);
+    REQUIRE(s.value() == 32);
+
+    std::cerr << "END semaphore max()\n";
+}
+
 TEST_CASE("~semaphore", "[semaphore]")
 {
     std::cerr << "[~semaphore]\n\n";


### PR DESCRIPTION
* Previously this function wasn't static and would need to be called with the templated max_value, which isn't very useful.
* Users can now call as semaphore<64> s{32}; s.max(); to retreive the max value.

Closes #383