### PR TITLE
const|mutable buffer concepts less restrictive.

### DIFF
--- a/include/coro/concepts/buffer.hpp
+++ b/include/coro/concepts/buffer.hpp
@@ -10,17 +10,31 @@ namespace coro::concepts
 template<typename type>
 concept const_buffer = requires(const type t)
 {
+    // The underlying data type must be a standard-layout type and trivially copyable
+    typename std::remove_pointer_t<decltype(t.data())>;
+    requires std::is_trivial_v<std::remove_pointer_t<decltype(t.data())>>;
+
+    // General buffer properties
     { t.empty() } -> std::same_as<bool>;
-    { t.data() } -> std::same_as<const char*>;
     { t.size() } -> std::same_as<std::size_t>;
+
+    // We check the return type of `data()` to be a const pointer to the underlying type
+    { t.data() } -> std::same_as<const typename std::remove_pointer_t<decltype(t.data())>*>;
 };
 
 template<typename type>
 concept mutable_buffer = requires(type t)
 {
+    // The underlying data type must be a standard-layout type and trivially copyable
+    typename std::remove_pointer_t<decltype(t.data())>;
+    requires std::is_trivial_v<std::remove_pointer_t<decltype(t.data())>>;
+
+    // General buffer properties
     { t.empty() } -> std::same_as<bool>;
-    { t.data() } -> std::same_as<char*>;
     { t.size() } -> std::same_as<std::size_t>;
+
+    // We check the return type of `data()` to be a non-const pointer to the underlying type
+    { t.data() } -> std::same_as<typename std::remove_pointer_t<decltype(t.data())>*>;
 };
 // clang-format on
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.12)
 project(libcoro_test)
 
 set(LIBCORO_TEST_SOURCE_FILES
+    concepts/test_concepts.cpp
+
     test_condition_variable.cpp
     test_event.cpp
     test_generator.cpp

--- a/test/concepts/test_concepts.cpp
+++ b/test/concepts/test_concepts.cpp
@@ -1,0 +1,59 @@
+#include "catch_amalgamated.hpp"
+
+#include <coro/coro.hpp>
+
+TEST_CASE("concepts", "[concepts]")
+{
+    std::cerr << "[concepts]\n\n";
+}
+
+struct char_buffer {
+    bool empty() const { return false; }
+    const char* data() const { return nullptr; }
+    std::size_t size() const { return 0; }
+    char* data() { return nullptr; }
+};
+
+struct uint8_buffer {
+    bool empty() const { return false; }
+    const uint8_t* data() const { return nullptr; }
+    std::size_t size() const { return 0; }
+    uint8_t* data() { return nullptr; }
+};
+
+struct std_byte_buffer {
+    bool empty() const { return false; }
+    const std::byte* data() const { return nullptr; }
+    std::size_t size() const { return 0; }
+    std::byte* data() { return nullptr; }
+};
+
+using coro::concepts::mutable_buffer;
+using coro::concepts::const_buffer;
+
+TEST_CASE("mutable_buffer", "[concepts]")
+{
+    static_assert(mutable_buffer<char_buffer>);
+    static_assert(mutable_buffer<uint8_buffer>);
+    static_assert(mutable_buffer<std_byte_buffer>);
+    static_assert(mutable_buffer<std::vector<char>>);
+    static_assert(mutable_buffer<std::vector<uint8_t>>);
+
+    REQUIRE(true);
+}
+
+TEST_CASE("const_buffer", "[concepts]")
+{
+    static_assert(const_buffer<char_buffer>);
+    static_assert(const_buffer<uint8_buffer>);
+    static_assert(const_buffer<std_byte_buffer>);
+    static_assert(const_buffer<std::vector<char>>);
+    static_assert(const_buffer<std::vector<uint8_t>>);
+
+    REQUIRE(true);
+}
+
+TEST_CASE("~concepts", "[concepts]")
+{
+    std::cerr << "[~concepts]\n\n";
+}


### PR DESCRIPTION
Previously only allowed for [const] char* buffers, this should allow for anything that is trivially copyable and buffer like to work.

Closes #390