### PR TITLE
TCP+TLS Client's use mutable|const buffers for send/recv return values

### DIFF
--- a/include/coro/concepts/buffer.hpp
+++ b/include/coro/concepts/buffer.hpp
@@ -22,6 +22,12 @@ concept const_buffer = requires(const type t)
     { t.data() } -> std::same_as<const typename std::remove_pointer_t<decltype(t.data())>*>;
 };
 
+template<const_buffer buffer_type>
+struct const_buffer_traits
+{
+    using element_type = std::add_const_t<std::remove_pointer_t<decltype(std::declval<buffer_type>().data())>>;
+};
+
 template<typename type>
 concept mutable_buffer = requires(type t)
 {
@@ -36,6 +42,13 @@ concept mutable_buffer = requires(type t)
     // We check the return type of `data()` to be a non-const pointer to the underlying type
     { t.data() } -> std::same_as<typename std::remove_pointer_t<decltype(t.data())>*>;
 };
+
+template<mutable_buffer buffer_type>
+struct mutable_buffer_traits
+{
+    using element_type = std::remove_pointer_t<decltype(std::declval<buffer_type>().data())>;
+};
+
 // clang-format on
 
 } // namespace coro::concepts

--- a/src/net/tcp/client.cpp
+++ b/src/net/tcp/client.cpp
@@ -36,7 +36,7 @@ client::client(const client& other)
 {
 }
 
-client::client(client&& other)
+client::client(client&& other) noexcept
     : m_io_scheduler(std::move(other.m_io_scheduler)),
       m_options(std::move(other.m_options)),
       m_socket(std::move(other.m_socket)),

--- a/src/net/tls/client.cpp
+++ b/src/net/tls/client.cpp
@@ -40,7 +40,7 @@ client::client(
     m_socket.blocking(coro::net::socket::blocking_t::no);
 }
 
-client::client(client&& other)
+client::client(client&& other) noexcept
     : m_io_scheduler(std::move(other.m_io_scheduler)),
       m_tls_ctx(std::move(other.m_tls_ctx)),
       m_options(std::move(other.m_options)),

--- a/test/net/test_udp_peers.cpp
+++ b/test/net/test_udp_peers.cpp
@@ -4,7 +4,7 @@
 
     #include <coro/coro.hpp>
 
-TEST_CASE("udp one way")
+TEST_CASE("udp one way", "[udp]")
 {
     const std::string msg{"aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbcccccccccccccccccc"};
 
@@ -49,7 +49,7 @@ TEST_CASE("udp one way")
     coro::sync_wait(coro::when_all(make_recv_task(scheduler, msg), make_send_task(scheduler, msg)));
 }
 
-TEST_CASE("udp echo peers")
+TEST_CASE("udp echo peers", "[udp]")
 {
     const std::string peer1_msg{"Hello from peer1!"};
     const std::string peer2_msg{"Hello from peer2!!"};


### PR DESCRIPTION
* This adds another templated parameter to send/recv for tls|tcp clients on the return value type so the returned buffers contain the same element_type instead of just char.

Closes #390