### PR TITLE
Avoid reference cycles in thread_pool and io_schedule

### DIFF
--- a/src/io_scheduler.cpp
+++ b/src/io_scheduler.cpp
@@ -42,7 +42,8 @@ auto io_scheduler::make_shared(options opts) -> std::shared_ptr<io_scheduler>
     // the background thread.
     if (s->m_opts.thread_strategy == thread_strategy_t::spawn)
     {
-        s->m_io_thread = std::thread([s]() { s->process_events_dedicated_thread(); });
+        // IO thread captures a raw pointer to avoid reference cycles
+        s->m_io_thread = std::thread([s = s.get()]() { s->process_events_dedicated_thread(); });
     }
     // else manual mode, the user must call process_events.
 

--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -26,7 +26,8 @@ auto thread_pool::make_shared(options opts) -> std::shared_ptr<thread_pool>
     // the background threads.
     for (uint32_t i = 0; i < tp->m_opts.thread_count; ++i)
     {
-        tp->m_threads.emplace_back([tp, i]() { tp->executor(i); });
+        // Threads capture a raw pointer to avoid reference cycles
+        tp->m_threads.emplace_back([tp = tp.get(), i]() { tp->executor(i); });
     }
 
     return tp;

--- a/test/test_io_scheduler.cpp
+++ b/test/test_io_scheduler.cpp
@@ -890,7 +890,7 @@ TEST_CASE("io_scheduler destruction with io thread", "[io_scheduler]")
         weakref = scheduler;
         REQUIRE(weakref.lock() != nullptr);
     }
-    REQUIRE_FALSE(weakref.lock() == nullptr);
+    REQUIRE(weakref.lock() == nullptr);
 }
 
 TEST_CASE("~io_scheduler", "[io_scheduler]")

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -282,7 +282,7 @@ TEST_CASE("thread_pool destruction", "[thread_pool]")
         weakref = tp;
         REQUIRE(weakref.lock() != nullptr);
     }
-    REQUIRE_FALSE(weakref.lock() == nullptr);
+    REQUIRE(weakref.lock() == nullptr);
 }
 
 TEST_CASE("~thread_pool", "[thread_pool]")

--- a/test/test_thread_pool.cpp
+++ b/test/test_thread_pool.cpp
@@ -3,6 +3,7 @@
 #include <coro/coro.hpp>
 
 #include <iostream>
+#include <memory>
 
 TEST_CASE("thread_pool", "[thread_pool]")
 {
@@ -271,6 +272,17 @@ TEST_CASE("thread_pool::schedule(task)", "[thread_pool]")
 
     REQUIRE(counter == 53);
     REQUIRE(main_tid != coroutine_tid);
+}
+
+TEST_CASE("thread_pool destruction", "[thread_pool]")
+{
+    std::weak_ptr<coro::thread_pool> weakref;
+    {
+        auto tp = coro::thread_pool::make_shared(coro::thread_pool::options{.thread_count = 1});
+        weakref = tp;
+        REQUIRE(weakref.lock() != nullptr);
+    }
+    REQUIRE_FALSE(weakref.lock() == nullptr);
 }
 
 TEST_CASE("~thread_pool", "[thread_pool]")


### PR DESCRIPTION
Previously, the background threads in a thread_pool and/or io_scheduler ran with a lambda capturing a shared pointer to the relevant instance. This caused a reference cycle such that the refcount of the shared pointer handed back to the user would never go to zero unless they explicitly called shutdown().

To fix this, just capture a raw pointer, this is safe because the dtor for the pool object joins the background threads and hence they can never see a dangling pointer.

Fixes #396.