### PR TITLE
Fixing UB - inplace construction over a variant

### DIFF
--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -114,7 +114,10 @@ public:
         }
     }
 
-    auto unhandled_exception() noexcept -> void { new (&m_storage) variant_type(std::current_exception()); }
+    auto unhandled_exception() noexcept -> void
+    {
+        m_storage.template emplace<std::exception_ptr>(std::current_exception());
+    }
 
     auto result() & -> decltype(auto)
     {


### PR DESCRIPTION
It seems like a line was missed when moving from aligned storage to a variant.

Using placement new can technically violate object lifetime rules by constructing a new variant_type over an existing variant_type without calling its destructor, which is **undefined behavior**.
