### PR TITLE
Bugfix in generator: operator==(generator&&)

### DIFF
--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -3,6 +3,7 @@
 #include <coroutine>
 #include <exception>
 #include <iterator>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -134,7 +135,15 @@ public:
     auto operator=(const generator&) = delete;
     auto operator=(generator&& other) noexcept -> generator&
     {
-        m_coroutine = std::exchange(other.m_coroutine, nullptr);
+        if (std::addressof(other) != this)
+        {
+            if (m_coroutine)
+            {
+                m_coroutine.destroy();
+            }
+            m_coroutine = std::exchange(other.m_coroutine, nullptr);
+        }
+
         return *this;
     }
 


### PR DESCRIPTION
There was a memory leak in the operator. Additionally, the following code would not behave as expected:
```c++
generator<int> gen = ...
...
gen = std::move(gen);
```
