### PR TITLE
condition_variable: mutual exclusion for notify/wait

### DIFF
--- a/test/test_condition_variable.cpp
+++ b/test/test_condition_variable.cpp
@@ -924,7 +924,7 @@ TEST_CASE("notify_all(executor)", "[condition_variable]")
         }
 
         std::cerr << "notify_all(s)\n";
-        cv.notify_all(s);
+        co_await cv.notify_all(s);
         co_return 0;
     };
 


### PR DESCRIPTION
To avoid lost wakeups, use an internal mutex to protect modification of the awaiter list.

Now, while we are notifying, if another notification task arrives it must wait for our modification of the awaiter list to complete. Hence waiters that were not ready and are pushed back on the list have a chance to be woken up by the next notification.

- Closes #398

I came back to the issue raised in #398 because we have a use case now where condvars make the most sense and we legitimately might have multiple simultaneous notification calls.

Since the modification awaiter list representing the suspended awaiters waiting for a notification crosses coroutine boundaries, I don't think we can protect it with a `std::mutex`. Hence I use a `coro::mutex` (internally managed by the condvar).