### PR TITLE
`thread_pool::shutdown()`: avoid self join

### DIFF
--- a/src/thread_pool.cpp
+++ b/src/thread_pool.cpp
@@ -94,7 +94,7 @@ auto thread_pool::shutdown() noexcept -> void
 
         for (auto& thread : m_threads)
         {
-            if (thread.joinable())
+            if (thread.joinable() && std::this_thread::get_id() != thread.get_id())
             {
                 thread.join();
             }


### PR DESCRIPTION
Avoid deadlock or `Resource deadlock avoided` if shutdown is called from a thread in the thread_pool.

