### PR TITLE
task_group::start(task) reintroduce

### DIFF
--- a/test/test_task_group.cpp
+++ b/test/test_task_group.cpp
@@ -24,9 +24,7 @@ TEST_CASE("task_group schedule single task", "[task_group]")
         co_return;
     };
 
-    std::vector<coro::task<void>> tasks{};
-    tasks.emplace_back(make_task(value, can_start));
-    coro::task_group<coro::thread_pool> tc{s, std::move(tasks)};
+    coro::task_group<coro::thread_pool> tc{s, make_task(value, can_start)};
     REQUIRE(tc.size() == 1);
     // Only allow the task to complete once we have checked the container's size,
     // otherwise the REQUIRE could "spuriously" fail due to the task already being done.
@@ -58,6 +56,60 @@ TEST_CASE("task_group submit multiple tasks", "[task_group]")
     coro::sync_wait(group);
     REQUIRE(group.empty());
     REQUIRE(counter == n);
+}
+
+TEST_CASE("task_group start multiple tasks", "[task_group]")
+{
+    constexpr std::size_t n = 1000;
+    std::atomic<uint64_t> counter{0};
+    auto                  tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
+    coro::latch           all_started{n};
+
+    auto make_task = [](coro::latch& all_started, std::atomic<uint64_t>& counter) -> coro::task<void>
+    {
+        all_started.count_down();
+        ++counter;
+        co_return;
+    };
+
+    coro::task_group<coro::thread_pool> group{tp};
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        (void)group.start(make_task(all_started, counter));
+    }
+
+    // this is necessary since tasks do not all start so the task group counter can drop to zero before all tasks
+    // have even started, this guarantees the event we get after all have started truly denotes all tasks are complete.
+    coro::sync_wait(all_started);
+    coro::sync_wait(group);
+    REQUIRE(group.empty());
+    REQUIRE(counter.load() == n);
+}
+
+TEST_CASE("task_group empty multiple times with event", "[task_group]")
+{
+    auto        tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
+    coro::event e1;
+    coro::event e2;
+
+    auto make_task = [](coro::event& e) -> coro::task<void>
+    {
+        co_await e;
+        co_return;
+    };
+
+    coro::task_group group{tp, make_task(e1)};
+    REQUIRE(group.size() == 1);
+    e1.set();
+    coro::sync_wait(group);
+    REQUIRE(group.empty());
+
+    // This will reset the event by starting a new task.
+    (void)group.start(make_task(e2));
+    REQUIRE(group.size() == 1);
+    e2.set();
+    coro::sync_wait(group);
+    REQUIRE(group.empty());
 }
 
 TEST_CASE("~task_group", "[task_group]")


### PR DESCRIPTION
* This method appears to have been important and removing it was too aggressive.
* The group's co_await operator will reset the internal event if more tasks are added after its already fired.

Closes #424