### PR TITLE
default_executor fix unused variable

### DIFF
--- a/src/default_executor.cpp
+++ b/src/default_executor.cpp
@@ -18,7 +18,7 @@ static std::unique_ptr<coro::io_scheduler> s_default_io_executor;
 
 void coro::default_executor::set_executor_options(thread_pool::options thread_pool_options)
 {
-    s_default_executor_options = thread_pool_options;
+    s_default_executor_options = std::move(thread_pool_options);
 }
 
 std::unique_ptr<coro::thread_pool>& coro::default_executor::executor()
@@ -41,13 +41,13 @@ std::unique_ptr<coro::thread_pool>& coro::default_executor::executor()
 #ifdef LIBCORO_FEATURE_NETWORKING
 void coro::default_executor::set_io_executor_options(io_scheduler::options io_scheduler_options)
 {
-    s_default_io_executor_options = io_scheduler_options;
+    s_default_io_executor_options = std::move(io_scheduler_options);
 }
 
 std::unique_ptr<coro::io_scheduler>& coro::default_executor::io_executor()
 {
     // If we're the first one here create the default executor.
-    if (s_default_executor_init.exchange(true) == false)
+    if (s_default_io_executor_init.exchange(true) == false)
     {
         s_default_io_executor = coro::io_scheduler::make_unique(s_default_io_executor_options);
         s_default_io_executor_ptr.store(s_default_io_executor.get(), std::memory_order::release);


### PR DESCRIPTION
The thread pool init variable was incorrectly used for the io scheduler's init.