### PR TITLE
Allow co_await inside coro::generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1233,28 +1233,29 @@ The example provided here shows an i/o scheduler that spins up a basic `coro::ne
 
 int main()
 {
-    auto scheduler = coro::io_scheduler::make_unique(coro::io_scheduler::options{
-        // The scheduler will spawn a dedicated event processing thread.  This is the default, but
-        // it is possible to use 'manual' and call 'process_events()' to drive the scheduler yourself.
-        .thread_strategy = coro::io_scheduler::thread_strategy_t::spawn,
-        // If the scheduler is in spawn mode this functor is called upon starting the dedicated
-        // event processor thread.
-        .on_io_thread_start_functor = [] { std::cout << "io_scheduler::process event thread start\n"; },
-        // If the scheduler is in spawn mode this functor is called upon stopping the dedicated
-        // event process thread.
-        .on_io_thread_stop_functor = [] { std::cout << "io_scheduler::process event thread stop\n"; },
-        // The io scheduler can use a coro::thread_pool to process the events or tasks it is given.
-        // You can use an execution strategy of `process_tasks_inline` to have the event loop thread
-        // directly process the tasks, this might be desirable for small tasks vs a thread pool for large tasks.
-        .pool =
-            coro::thread_pool::options{
-                .thread_count            = 2,
-                .on_thread_start_functor = [](size_t i)
-                { std::cout << "io_scheduler::thread_pool worker " << i << " starting\n"; },
-                .on_thread_stop_functor = [](size_t i)
-                { std::cout << "io_scheduler::thread_pool worker " << i << " stopping\n"; },
-            },
-        .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
+    auto scheduler = coro::io_scheduler::make_unique(
+        coro::io_scheduler::options{
+            // The scheduler will spawn a dedicated event processing thread.  This is the default, but
+            // it is possible to use 'manual' and call 'process_events()' to drive the scheduler yourself.
+            .thread_strategy = coro::io_scheduler::thread_strategy_t::spawn,
+            // If the scheduler is in spawn mode this functor is called upon starting the dedicated
+            // event processor thread.
+            .on_io_thread_start_functor = [] { std::cout << "io_scheduler::process event thread start\n"; },
+            // If the scheduler is in spawn mode this functor is called upon stopping the dedicated
+            // event process thread.
+            .on_io_thread_stop_functor = [] { std::cout << "io_scheduler::process event thread stop\n"; },
+            // The io scheduler can use a coro::thread_pool to process the events or tasks it is given.
+            // You can use an execution strategy of `process_tasks_inline` to have the event loop thread
+            // directly process the tasks, this might be desirable for small tasks vs a thread pool for large tasks.
+            .pool =
+                coro::thread_pool::options{
+                    .thread_count            = 2,
+                    .on_thread_start_functor = [](size_t i)
+                    { std::cout << "io_scheduler::thread_pool worker " << i << " starting\n"; },
+                    .on_thread_stop_functor = [](size_t i)
+                    { std::cout << "io_scheduler::thread_pool worker " << i << " stopping\n"; },
+                },
+            .execution_strategy = coro::io_scheduler::execution_strategy_t::process_tasks_on_thread_pool});
 
     auto make_server_task = [](std::unique_ptr<coro::io_scheduler>& scheduler) -> coro::task<void>
     {
@@ -1269,7 +1270,7 @@ int main()
 
         // Wait for an incoming connection and accept it.
         auto poll_status = co_await server.poll();
-        if (poll_status != coro::poll_status::event)
+        if (poll_status != coro::poll_status::read)
         {
             co_return; // Handle error, see poll_status for detailed error states.
         }
@@ -1286,7 +1287,7 @@ int main()
         // Now wait for the client message, this message is small enough it should always arrive
         // with a single recv() call.
         poll_status = co_await client.poll(coro::poll_op::read);
-        if (poll_status != coro::poll_status::event)
+        if (poll_status != coro::poll_status::read)
         {
             co_return; // Handle error.
         }
@@ -1306,7 +1307,7 @@ int main()
 
         // Make sure the client socket can be written to.
         poll_status = co_await client.poll(coro::poll_op::write);
-        if (poll_status != coro::poll_status::event)
+        if (poll_status != coro::poll_status::write)
         {
             co_return; // Handle error.
         }
@@ -1335,7 +1336,7 @@ int main()
             // able to be written to again.
             remaining    = r;
             auto pstatus = co_await client.poll(coro::poll_op::write);
-            if (pstatus != coro::poll_status::event)
+            if (pstatus != coro::poll_status::write)
             {
                 co_return; // Handle error.
             }

--- a/include/coro/generator.hpp
+++ b/include/coro/generator.hpp
@@ -28,7 +28,10 @@ public:
 
     auto initial_suspend() const { return std::suspend_always{}; }
 
-    auto final_suspend() const noexcept(true) { return std::suspend_always{}; }
+    auto final_suspend() const noexcept(true)
+    {
+        return std::suspend_always{};
+    }
 
     template<typename U = T, std::enable_if_t<!std::is_rvalue_reference<U>::value, int> = 0>
     auto yield_value(std::remove_reference_t<T>& value) noexcept
@@ -48,9 +51,6 @@ public:
     auto return_void() noexcept -> void {}
 
     auto value() const noexcept -> reference_type { return static_cast<reference_type>(*m_value); }
-
-    template<typename U>
-    auto await_transform(U&& value) -> std::suspend_never = delete;
 
     auto rethrow_if_exception() -> void
     {


### PR DESCRIPTION
* allows users to now use co_await of tasks inside a generator
* added test to verify generators throw exceptions correctly