### PR TITLE
Async Ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,9 +143,9 @@ set(LIBCORO_SOURCE_FILES
     include/coro/ranges/socket_stream.hpp # TODO: move to network sources
     include/coro/ranges/utils.hpp
     include/coro/ranges/take_until.hpp
-    include/coro/ranges/error_policy.hpp
     include/coro/ranges/to.hpp
     include/coro/ranges/join.hpp
+        include/coro/ranges/transform.hpp
 )
 
 if(LIBCORO_FEATURE_NETWORKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ set(LIBCORO_SOURCE_FILES
     include/coro/time.hpp
     include/coro/when_all.hpp
     include/coro/when_any.hpp
+
+    include/coro/ranges/socket_stream.hpp
 )
 
 if(LIBCORO_FEATURE_NETWORKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,12 +140,14 @@ set(LIBCORO_SOURCE_FILES
     include/coro/when_all.hpp
     include/coro/when_any.hpp
 
-    include/coro/ranges/socket_stream.hpp # TODO: move to network sources
     include/coro/ranges/utils.hpp
     include/coro/ranges/take_until.hpp
     include/coro/ranges/to.hpp
     include/coro/ranges/join.hpp
-        include/coro/ranges/transform.hpp
+    include/coro/ranges/transform.hpp
+    include/coro/ranges/await.hpp
+    include/coro/ranges/drain.hpp
+    include/coro/ranges/take.hpp
 )
 
 if(LIBCORO_FEATURE_NETWORKING)
@@ -158,6 +160,8 @@ if(LIBCORO_FEATURE_NETWORKING)
         include/coro/scheduler.hpp src/scheduler.cpp
         include/coro/io_notifier.hpp
         include/coro/poll.hpp src/poll.cpp
+
+        include/coro/ranges/socket_stream.hpp
     )
 
     if(LINUX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/ranges/await.hpp
     include/coro/ranges/drain.hpp
     include/coro/ranges/take.hpp
+    include/coro/ranges/filter.hpp
 )
 
 if(LIBCORO_FEATURE_NETWORKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,11 @@ set(LIBCORO_SOURCE_FILES
     include/coro/when_any.hpp
 
     include/coro/ranges/socket_stream.hpp
+    include/coro/ranges/socket_stream.hpp # TODO: move to network sources
+    include/coro/ranges/utils.hpp
+    include/coro/ranges/take_until.hpp
+    include/coro/ranges/to.hpp
+    include/coro/ranges/join.hpp
 )
 
 if(LIBCORO_FEATURE_NETWORKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,10 +140,10 @@ set(LIBCORO_SOURCE_FILES
     include/coro/when_all.hpp
     include/coro/when_any.hpp
 
-    include/coro/ranges/socket_stream.hpp
     include/coro/ranges/socket_stream.hpp # TODO: move to network sources
     include/coro/ranges/utils.hpp
     include/coro/ranges/take_until.hpp
+    include/coro/ranges/error_policy.hpp
     include/coro/ranges/to.hpp
     include/coro/ranges/join.hpp
 )

--- a/include/coro/ranges/await.hpp
+++ b/include/coro/ranges/await.hpp
@@ -1,0 +1,85 @@
+#pragma once
+#include "utils.hpp"
+#include <coro/task.hpp>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t, typename value_t>
+class await_view_base
+{
+protected:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+
+    previous_stream_t      m_prev_stream;
+    std::optional<value_t> m_value;
+
+public:
+    constexpr explicit await_view_base(previous_stream_t&& prev_stream)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
+    {
+    }
+
+    auto advance() -> coro::task<bool>
+    {
+        if (co_await m_prev_stream.advance())
+        {
+            m_value = co_await m_prev_stream.get_value();
+            co_return true;
+        }
+        co_return false;
+    }
+
+    auto get_value() noexcept -> value_t { return std::move(*m_value); }
+};
+
+template<concepts::async_streamable previous_stream_t>
+class await_view_base<previous_stream_t, void>
+{
+protected:
+    previous_stream_t m_prev_stream;
+
+public:
+    constexpr explicit await_view_base(previous_stream_t&& prev_stream)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
+    {
+    }
+
+    auto advance() -> coro::task<bool>
+    {
+        if (co_await m_prev_stream.advance())
+        {
+            co_await m_prev_stream.get_value();
+            co_return true;
+        }
+        co_return false;
+    }
+
+    void get_value() noexcept {}
+};
+
+template<concepts::async_streamable previous_stream_t>
+class await_view : public await_view_base<
+                       previous_stream_t,
+                       typename coro::concepts::awaitable_traits<
+                           concepts::async_stream_value_t<previous_stream_t>>::awaiter_return_type>
+{
+    using base_t = await_view_base<
+        previous_stream_t,
+        typename coro::concepts::awaitable_traits<
+            concepts::async_stream_value_t<previous_stream_t>>::awaiter_return_type>;
+
+public:
+    using base_t::base_t;
+};
+
+struct _await
+{
+    template<concepts::async_streamable Rng>
+    constexpr auto operator()(Rng&& rng)
+    {
+        return await_view<std::decay_t<Rng>>{std::forward<Rng>(rng)};
+    }
+};
+
+inline constexpr auto await = _partial<_await>{0};
+} // namespace coro::ranges

--- a/include/coro/ranges/await.hpp
+++ b/include/coro/ranges/await.hpp
@@ -10,63 +10,55 @@ class await_view_base
 protected:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
 
-    previous_stream_t      m_prev_stream;
-    std::optional<value_t> m_value;
+    previous_stream_t m_prev_stream;
 
 public:
-    constexpr explicit await_view_base(previous_stream_t&& prev_stream)
-        : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
-    {
-    }
+    constexpr explicit await_view_base(previous_stream_t prev_stream) : m_prev_stream(prev_stream) {}
 
-    auto advance() -> coro::task<bool>
+    auto next() -> awaiter_type
     {
-        if (co_await m_prev_stream.advance())
+        auto awaitable = co_await m_prev_stream.next();
+        if (awaitable)
         {
-            m_value = co_await m_prev_stream.get_value();
-            co_return true;
+            co_return co_await std::move(*awaitable);
         }
-        co_return false;
+        co_return std::nullopt;
     }
-
-    auto get_value() noexcept -> value_t { return std::move(*m_value); }
 };
 
 template<concepts::async_streamable previous_stream_t>
 class await_view_base<previous_stream_t, void>
 {
 protected:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+
     previous_stream_t m_prev_stream;
 
 public:
-    constexpr explicit await_view_base(previous_stream_t&& prev_stream)
+    constexpr explicit await_view_base(previous_stream_t prev_stream)
         : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
     {
     }
 
-    auto advance() -> coro::task<bool>
+    auto next() -> coro::task<std::optional<std::monostate>>
     {
-        if (co_await m_prev_stream.advance())
+        auto awaitable = co_await m_prev_stream.next();
+        if (awaitable)
         {
-            co_await m_prev_stream.get_value();
-            co_return true;
+            co_await *awaitable;
+            co_return std::monostate{};
         }
-        co_return false;
+        co_return std::nullopt;
     }
-
-    void get_value() noexcept {}
 };
 
-template<concepts::async_streamable previous_stream_t>
-class await_view : public await_view_base<
-                       previous_stream_t,
-                       typename coro::concepts::awaitable_traits<
-                           concepts::async_stream_value_t<previous_stream_t>>::awaiter_return_type>
+template<
+    concepts::async_streamable previous_stream_t,
+    typename value_t = typename coro::concepts::awaitable_traits<
+        concepts::async_stream_return_t<previous_stream_t>>::awaiter_return_type>
+class await_view : public await_view_base<previous_stream_t, value_t>
 {
-    using base_t = await_view_base<
-        previous_stream_t,
-        typename coro::concepts::awaitable_traits<
-            concepts::async_stream_value_t<previous_stream_t>>::awaiter_return_type>;
+    using base_t = await_view_base<previous_stream_t, value_t>;
 
 public:
     using base_t::base_t;

--- a/include/coro/ranges/await.hpp
+++ b/include/coro/ranges/await.hpp
@@ -15,7 +15,7 @@ protected:
 public:
     constexpr explicit await_view_base(previous_stream_t prev_stream) : m_prev_stream(prev_stream) {}
 
-    auto next() -> awaiter_type
+    auto next() -> coro::task<std::optional<std::remove_cvref_t<value_t>>>
     {
         auto awaitable = co_await m_prev_stream.next();
         if (awaitable)
@@ -54,11 +54,11 @@ public:
 
 template<
     concepts::async_streamable previous_stream_t,
-    typename value_t = typename coro::concepts::awaitable_traits<
+    typename value_type = typename coro::concepts::awaitable_traits<
         concepts::async_stream_return_t<previous_stream_t>>::awaiter_return_type>
-class await_view : public await_view_base<previous_stream_t, value_t>
+class await_view : public await_view_base<previous_stream_t, value_type>
 {
-    using base_t = await_view_base<previous_stream_t, value_t>;
+    using base_t = await_view_base<previous_stream_t, value_type>;
 
 public:
     using base_t::base_t;

--- a/include/coro/ranges/drain.hpp
+++ b/include/coro/ranges/drain.hpp
@@ -10,7 +10,7 @@ public:
     template<concepts::async_streamable Rng>
     auto operator()(Rng rng) const -> coro::task<void>
     {
-        while (co_await rng.advance()) {}
+        while (co_await rng.next()) {}
     }
 };
 

--- a/include/coro/ranges/drain.hpp
+++ b/include/coro/ranges/drain.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "coro/task.hpp"
+#include "utils.hpp"
+
+namespace coro::ranges
+{
+struct _drain : public concepts::_async_adaptor
+{
+public:
+    template<concepts::async_streamable Rng>
+    auto operator()(Rng rng) const -> coro::task<void>
+    {
+        while (co_await rng.advance()) {}
+    }
+};
+
+inline constexpr _drain drain;
+} // namespace coro::ranges

--- a/include/coro/ranges/filter.hpp
+++ b/include/coro/ranges/filter.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "utils.hpp"
+#include <optional>
+#include <utility>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t, class filter_fn>
+class filter_view
+{
+private:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+
+public:
+    constexpr filter_view(previous_stream_t prev_stream, filter_fn transform)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
+          m_filter(std::forward<filter_fn>(transform))
+    {
+    }
+
+    auto next() -> awaiter_type
+    {
+        while (true)
+        {
+            auto value = co_await m_prev_stream.next();
+            if (!value)
+            {
+                break;
+            }
+
+            if (m_filter(*value))
+            {
+                co_return std::forward<decltype(value)>(value);
+            }
+        }
+
+        co_return std::nullopt;
+    }
+
+private:
+    previous_stream_t m_prev_stream;
+    [[no_unique_address]]
+    filter_fn m_filter;
+};
+
+struct _filter
+{
+    template<concepts::async_streamable Rng, class Pred>
+    constexpr auto operator()(Rng&& rng, Pred&& pred) const
+    {
+        return filter_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
+    }
+
+    template<class Pred>
+    constexpr auto operator()(Pred&& pred) const
+    {
+        return _partial<_filter, Pred>{0, std::forward<Pred>(pred)};
+    }
+};
+
+inline constexpr _filter filter;
+} // namespace coro::ranges

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -11,7 +11,8 @@ class join_view
 private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
     using container_t  = concepts::async_stream_value_t<previous_stream_t>;
-    using value_t      = typename container_t::value_type;
+
+    using reference_t = decltype(std::declval<container_t&>()[0]);
 
     static_assert(std::ranges::sized_range<container_t>);
 
@@ -35,6 +36,7 @@ public:
             // Looping until it's not empty
             if (m_value->size() > 0)
             {
+                m_cursor = 0;
                 co_return true;
             }
         }
@@ -42,7 +44,7 @@ public:
         co_return false;
     }
 
-    auto get_value() noexcept -> value_t { return std::move((*m_value)[m_cursor]); }
+    auto get_value() noexcept -> reference_t { return std::move((*m_value)[m_cursor]); }
 
 private:
     previous_stream_t m_prev_stream;
@@ -58,9 +60,7 @@ struct _join
     {
         return join_view{std::forward<Rng>(rng)};
     }
-
-    constexpr auto operator()() const { return _partial<_join>{0}; }
 };
 
-inline constexpr _join join;
+inline constexpr auto join = _partial<_join>{0};
 } // namespace coro::ranges

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -42,7 +42,7 @@ public:
         co_return false;
     }
 
-    auto get_value() noexcept -> reference_t { return std::move((*m_value)[m_cursor]); }
+    auto get_value() noexcept -> reference_t { return (*m_value)[m_cursor]; }
 
 private:
     previous_stream_t m_prev_stream;

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -17,9 +17,7 @@ private:
     static_assert(std::ranges::sized_range<container_t>);
 
 public:
-    constexpr join_view(previous_stream_t&& prev_stream) : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
-    {
-    }
+    constexpr join_view(previous_stream_t prev_stream) : m_prev_stream(std::forward<previous_stream_t>(prev_stream)) {}
 
     auto advance() -> awaiter_type
     {

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -10,7 +10,7 @@ class join_view
 {
 private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
-    using container_t  = concepts::async_stream_value_t<previous_stream_t>;
+    using container_t  = std::remove_cvref_t<concepts::async_stream_value_t<previous_stream_t>>;
 
     using reference_t = decltype(std::declval<container_t&>()[0]);
 

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -30,14 +30,23 @@ public:
             co_return std::move((*m_value)[m_cursor]);
         }
 
-        m_value = co_await m_prev_stream.next();
-        if (m_value && m_value->size() > 0)
+        // Until we find non-empty chunk
+        while (true)
         {
-            m_cursor = 0;
-            co_return std::move((*m_value)[m_cursor]);
-        }
+            m_value = co_await m_prev_stream.next();
+            if (!m_value)
+            {
+                co_return std::nullopt; // source exhausted
+            }
 
-        co_return std::nullopt;
+            if (m_value->size() > 0)
+            {
+                m_cursor = 0;
+                co_return std::move((*m_value)[m_cursor]);
+            }
+
+            // get next chunk
+        }
     }
 
 private:

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -10,39 +10,35 @@ class join_view
 {
 private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
-    using container_t  = std::remove_cvref_t<concepts::async_stream_value_t<previous_stream_t>>;
+    using container_t  = std::remove_cvref_t<concepts::async_stream_return_t<previous_stream_t>>;
 
-    using reference_t = decltype(std::declval<container_t&>()[0]);
+    using value_type = std::ranges::range_value_t<container_t>;
 
     static_assert(std::ranges::sized_range<container_t>);
 
 public:
-    constexpr join_view(previous_stream_t prev_stream) : m_prev_stream(std::forward<previous_stream_t>(prev_stream)) {}
+    constexpr explicit join_view(previous_stream_t prev_stream)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
+    {
+    }
 
-    auto advance() -> awaiter_type
+    auto next() -> coro::task<std::optional<value_type>>
     {
         if (m_value && m_cursor + 1 < m_value->size())
         {
             m_cursor += 1;
-            co_return true;
+            co_return std::move((*m_value)[m_cursor]);
         }
 
-        while (co_await m_prev_stream.advance())
+        m_value = co_await m_prev_stream.next();
+        if (m_value && m_value->size() > 0)
         {
-            m_value = std::move(m_prev_stream.get_value());
-
-            // Looping until it's not empty
-            if (m_value->size() > 0)
-            {
-                m_cursor = 0;
-                co_return true;
-            }
+            m_cursor = 0;
+            co_return std::move((*m_value)[m_cursor]);
         }
 
-        co_return false;
+        co_return std::nullopt;
     }
-
-    auto get_value() noexcept -> reference_t { return (*m_value)[m_cursor]; }
 
 private:
     previous_stream_t m_prev_stream;

--- a/include/coro/ranges/join.hpp
+++ b/include/coro/ranges/join.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include "utils.hpp"
+#include <optional>
+#include <ranges>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t>
+class join_view
+{
+private:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+    using container_t  = concepts::async_stream_value_t<previous_stream_t>;
+    using value_t      = typename container_t::value_type;
+
+    static_assert(std::ranges::sized_range<container_t>);
+
+public:
+    constexpr join_view(previous_stream_t&& prev_stream) : m_prev_stream(std::forward<previous_stream_t>(prev_stream))
+    {
+    }
+
+    auto advance() -> awaiter_type
+    {
+        if (m_value && m_cursor + 1 < m_value->size())
+        {
+            m_cursor += 1;
+            co_return true;
+        }
+
+        while (co_await m_prev_stream.advance())
+        {
+            m_value = std::move(m_prev_stream.get_value());
+
+            // Looping until it's not empty
+            if (m_value->size() > 0)
+            {
+                co_return true;
+            }
+        }
+
+        co_return false;
+    }
+
+    auto get_value() noexcept -> value_t { return std::move((*m_value)[m_cursor]); }
+
+private:
+    previous_stream_t m_prev_stream;
+
+    std::optional<container_t> m_value;
+    std::size_t                m_cursor{};
+};
+
+struct _join
+{
+    template<concepts::async_streamable Rng>
+    constexpr auto operator()(Rng&& rng)
+    {
+        return join_view{std::forward<Rng>(rng)};
+    }
+
+    constexpr auto operator()() const { return _partial<_join>{0}; }
+};
+
+inline constexpr _join join;
+} // namespace coro::ranges

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -16,8 +16,12 @@ public:
     socket_stream(socket_stream&)            = delete;
     socket_stream& operator=(socket_stream&) = delete;
 
-    socket_stream(socket_stream&& other) : m_client(std::move(other.m_client)), m_buffer(std::move(other.m_buffer)) {}
-    socket_stream& operator=(socket_stream&& other)
+    socket_stream(socket_stream&& other) noexcept
+        : m_client(std::move(other.m_client)),
+          m_buffer(std::move(other.m_buffer))
+    {
+    }
+    socket_stream& operator=(socket_stream&& other) noexcept
     {
         if (std::addressof(other) != this)
         {
@@ -57,6 +61,7 @@ private:
 struct _with_buffer
 {
     template<class client_t>
+        requires std::is_same_v<std::remove_cvref_t<client_t>, coro::net::tcp::client>
     constexpr auto operator()(client_t&& client, std::size_t buffer_size = 4096) const
     {
         return socket_stream{std::forward<client_t>(client), std::vector<std::byte>{buffer_size}};
@@ -69,4 +74,10 @@ struct _with_buffer
 };
 
 inline constexpr _with_buffer with_buffer;
+
+template<class client_t>
+constexpr auto operator|(client_t&& client, _partial<_with_buffer, std::size_t>&& with_buf)
+{
+    return with_buf(client);
+}
 } // namespace coro::ranges

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -40,12 +40,13 @@ private:
     std::size_t             m_current_size{};
 };
 
-auto to_stream(coro::net::tcp::client& client, std::size_t buffer_size = 4096) -> socket_stream<std::vector<std::byte>>
+auto to_chunked_stream(coro::net::tcp::client& client, std::size_t buffer_size = 4096)
+    -> socket_stream<std::vector<std::byte>>
 {
     return socket_stream{client, std::vector<std::byte>{buffer_size}};
 }
 
-auto to_stream(coro::net::tcp::client& client, std::span<std::byte> external_buffer)
+auto to_chunked_stream(coro::net::tcp::client& client, std::span<std::byte> external_buffer)
     -> socket_stream<std::span<std::byte>>
 {
     return socket_stream{client, std::move(external_buffer)};

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -31,7 +31,9 @@ public:
         return *this;
     }
 
-    auto advance() -> coro::task<bool>
+    // Should be safe, because socket_stream gets moved
+    // into further pipe objects
+    auto next() -> coro::task<std::optional<std::span<const std::byte>>>
     {
         auto [status, read] = co_await m_client.read_some(m_buffer);
         m_current_size      = read.size();
@@ -41,16 +43,12 @@ public:
             if (status.is_closed())
             {
                 m_current_size = 0;
-                co_return false;
+                co_return std::nullopt;
             }
             throw std::runtime_error(status.message());
         }
-        co_return true;
+        co_return std::span{m_buffer}.subspan(0, m_current_size);
     }
-
-    // Should be safe, because socket_stream gets moved
-    // into further pipe objects
-    auto get_value() const noexcept -> std::span<const std::byte> { return {m_buffer.data(), m_current_size}; }
 
 private:
     client_t    m_client;

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -5,148 +5,49 @@
 
 namespace coro::ranges
 {
-template<typename T>
-struct async_stream_traits;
-
-template<typename T>
-    requires requires(T& t) { t.next(); }
-struct async_stream_traits<T>
-{
-    using value_type = typename decltype(std::declval<T&>().next())::return_type;
-};
-
-template<class T>
-using async_stream_value_t = typename async_stream_traits<T>::value_type;
-
-template<class T>
-concept async_streamable = requires(T& stream) {
-    { stream.next() } -> std::same_as<coro::task<async_stream_value_t<T>>>;
-};
-
+template<class buffer_t>
 class socket_stream
 {
 public:
-    explicit socket_stream(coro::net::tcp::client& client) : m_client(client) {};
+    explicit socket_stream(coro::net::tcp::client& client, buffer_t&& buffer)
+        : m_client(client),
+          m_buffer{std::move(buffer)} {};
 
-    auto next() -> coro::task<std::optional<std::byte>>
+    auto advance() -> coro::task<bool>
     {
-        std::byte b;
-        auto      span      = std::span{&b, 1};
-        auto [status, read] = co_await m_client.read_some(span);
+        auto [status, read] = co_await m_client.read_some(m_buffer);
+        m_current_size      = read.size();
 
         if (not status.is_ok())
         {
             if (status.is_closed())
             {
-                co_return std::nullopt;
+                m_current_size = 0;
+                co_return false;
             }
             throw std::runtime_error(status.message());
         }
-        co_return b;
+        co_return true;
     }
+
+    // Should be safe, because socket_stream gets moved
+    // into further pipe objects
+    auto get_value() const noexcept -> std::span<const std::byte> { return {m_buffer.data(), m_current_size}; }
 
 private:
     coro::net::tcp::client& m_client;
-    //    std::vector<std::byte>  m_buffer;
+    buffer_t                m_buffer;
+    std::size_t             m_current_size{};
 };
 
-template<async_streamable previous_stream_t, class Pred>
-class take_until_view
+auto to_stream(coro::net::tcp::client& client, std::size_t buffer_size = 4096) -> socket_stream<std::vector<std::byte>>
 {
-private:
-    using value_type = async_stream_value_t<previous_stream_t>;
-
-    previous_stream_t m_prev_stream;
-    Pred              m_pred;
-
-public:
-    constexpr take_until_view(previous_stream_t&& prev_stream, Pred&& pred)
-        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
-          m_pred(std::forward<Pred>(pred))
-    {
-    }
-
-    auto next() -> coro::task<value_type>
-    {
-        auto val = co_await m_prev_stream.next();
-        if (val and not m_pred(*val))
-        {
-            co_return std::move(val);
-        }
-        co_return std::nullopt;
-    }
-};
-
-template<typename Adaptor, typename... Args>
-struct _partial
-{
-    std::tuple<Args...> m_args;
-
-    constexpr _partial(int, Args&&... args) : m_args(std::forward<Args>(args)...) {}
-
-    template<async_streamable range_t>
-    constexpr auto operator()(range_t&& range) const&
-    {
-        auto forwarder = [&range](const auto&... args) { return Adaptor{}(std::forward<range_t>(range), args...); };
-        return std::apply(forwarder, m_args);
-    }
-
-    template<async_streamable range_t>
-    constexpr auto operator()(range_t&& range) &&
-    {
-        auto forwarder = [&range](auto&... args)
-        { return Adaptor{}(std::forward<range_t>(range), std::move(args)...); };
-        return std::apply(forwarder, m_args);
-    }
-
-    template<async_streamable range_t>
-    constexpr auto operator()(range_t&& range) const&& = delete;
-};
-
-template<class Partial, class Range>
-constexpr auto operator|(Range&& rng, Partial&& partial)
-{
-    return std::forward<Partial>(partial)(std::forward<Range>(rng));
+    return socket_stream{client, std::vector<std::byte>{buffer_size}};
 }
 
-struct _take_until
+auto to_stream(coro::net::tcp::client& client, std::span<std::byte> external_buffer)
+    -> socket_stream<std::span<std::byte>>
 {
-    template<async_streamable Rng, typename Pred>
-    constexpr auto operator()(Rng&& rng, Pred&& pred)
-    {
-        return take_until_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
-    }
-
-    template<typename Pred>
-    constexpr auto operator()(Pred&& pred) const
-    {
-        return _partial<_take_until, Pred>{0, std::forward<Pred>(pred)};
-    }
-};
-
-inline constexpr _take_until take_until;
-
-auto to_stream(coro::net::tcp::client& client) -> socket_stream
-{
-    return socket_stream{client};
+    return socket_stream{client, std::move(external_buffer)};
 }
-
-struct _to_vector
-{
-    template<async_streamable Rng>
-    auto operator()(Rng rng) const -> coro::task<std::vector<typename async_stream_value_t<Rng>::value_type>>
-    {
-        std::vector<typename async_stream_value_t<Rng>::value_type> result;
-        while (true)
-        {
-            auto val = co_await rng.next();
-            if (!val)
-                break;
-            result.push_back(std::move(*val));
-        }
-        co_return result;
-    }
-};
-
-inline constexpr _to_vector to_vector;
 } // namespace coro::ranges

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -9,9 +9,23 @@ template<class client_t, class buffer_t>
 class socket_stream
 {
 public:
-    explicit socket_stream(client_t&& client, buffer_t&& buffer)
+    explicit socket_stream(client_t client, buffer_t buffer)
         : m_client(std::forward<client_t>(client)),
           m_buffer{std::move(buffer)} {};
+
+    socket_stream(socket_stream&)            = delete;
+    socket_stream& operator=(socket_stream&) = delete;
+
+    socket_stream(socket_stream&& other) : m_client(std::move(other.m_client)), m_buffer(std::move(other.m_buffer)) {}
+    socket_stream& operator=(socket_stream&& other)
+    {
+        if (std::addressof(other) != this)
+        {
+            m_client = std::move(other.m_client);
+            m_buffer = std::move(other.m_buffer);
+        }
+        return *this;
+    }
 
     auto advance() -> coro::task<bool>
     {
@@ -40,28 +54,19 @@ private:
     std::size_t m_current_size{};
 };
 
-auto to_chunked_stream(coro::net::tcp::client& client, std::size_t buffer_size = 4096)
-    -> socket_stream<coro::net::tcp::client&, std::vector<std::byte>>
+struct _with_buffer
 {
-    return socket_stream<coro::net::tcp::client&, std::vector<std::byte>>{client, std::vector<std::byte>{buffer_size}};
-}
+    template<class client_t>
+    constexpr auto operator()(client_t&& client, std::size_t buffer_size = 4096) const
+    {
+        return socket_stream{std::forward<client_t>(client), std::vector<std::byte>{buffer_size}};
+    }
 
-auto to_chunked_stream(coro::net::tcp::client& client, std::span<std::byte> external_buffer)
-    -> socket_stream<coro::net::tcp::client&, std::span<std::byte>>
-{
-    return socket_stream<coro::net::tcp::client&, std::span<std::byte>>{client, std::move(external_buffer)};
-}
+    constexpr auto operator()(std::size_t buffer_size = 4096) const
+    {
+        return _partial<_with_buffer, std::size_t>{0, buffer_size};
+    }
+};
 
-auto to_chunked_stream(coro::net::tcp::client&& client, std::size_t buffer_size = 4096)
-    -> socket_stream<coro::net::tcp::client, std::vector<std::byte>>
-{
-    return socket_stream<coro::net::tcp::client, std::vector<std::byte>>{
-        std::move(client), std::vector<std::byte>{buffer_size}};
-}
-
-auto to_chunked_stream(coro::net::tcp::client&& client, std::span<std::byte> external_buffer)
-    -> socket_stream<coro::net::tcp::client, std::span<std::byte>>
-{
-    return socket_stream<coro::net::tcp::client, std::span<std::byte>>{std::move(client), std::move(external_buffer)};
-}
+inline constexpr _with_buffer with_buffer;
 } // namespace coro::ranges

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -17,11 +17,13 @@ public:
     socket_stream& operator=(socket_stream&) = delete;
 
     socket_stream(socket_stream&& other) noexcept
+        requires(!std::is_lvalue_reference_v<client_t>)
         : m_client(std::move(other.m_client)),
           m_buffer(std::move(other.m_buffer))
     {
     }
     socket_stream& operator=(socket_stream&& other) noexcept
+        requires(!std::is_lvalue_reference_v<client_t>)
     {
         if (std::addressof(other) != this)
         {
@@ -29,6 +31,13 @@ public:
             m_buffer = std::move(other.m_buffer);
         }
         return *this;
+    }
+
+    socket_stream(socket_stream&& other) noexcept
+        requires std::is_lvalue_reference_v<client_t>
+        : m_client(other.m_client),
+          m_buffer(std::move(other.m_buffer))
+    {
     }
 
     // Should be safe, because socket_stream gets moved
@@ -58,6 +67,7 @@ private:
 
 struct _with_buffer
 {
+    // Dynamic buffer (std::vector)
     template<class client_t>
         requires std::is_same_v<std::remove_cvref_t<client_t>, coro::net::tcp::client>
     constexpr auto operator()(client_t&& client, std::size_t buffer_size = 4096) const
@@ -65,16 +75,48 @@ struct _with_buffer
         return socket_stream{std::forward<client_t>(client), std::vector<std::byte>{buffer_size}};
     }
 
+    /**
+     * Dynamic buffer with size of 4 KiB by default.
+     * @example
+     * @code
+     * auto buffered_stream = client | coro::ranges::with_buffer(512);
+     * auto buffered_stream = coro::ranges::with_buffer(client, 512);
+     * @endcode
+     */
     constexpr auto operator()(std::size_t buffer_size = 4096) const
     {
         return _partial<_with_buffer, std::size_t>{0, buffer_size};
+    }
+
+    // Custom buffer (std::span)
+    template<class client_t>
+        requires std::is_same_v<std::remove_cvref_t<client_t>, coro::net::tcp::client>
+    constexpr auto operator()(client_t&& client, std::span<std::byte> buffer) const noexcept
+    {
+        // Making a copy of span, so socket_stream won't have lvalue ref accidentally
+        return socket_stream<client_t&&, std::span<std::byte>>{std::forward<client_t>(client), std::span{buffer}};
+    }
+
+    /**
+     * You can provide your own buffer using std::span
+     * @example
+     * @code
+     * std::array<char, 1024> static_array{};
+     *
+     * auto buffered_stream = client | coro::ranges::with_buffer(std::as_writable_bytes(static_array));
+     * auto buffered_stream = coro::ranges::with_buffer(client, std::as_writable_bytes(static_array));
+     * @endcode
+     */
+    constexpr auto operator()(std::span<std::byte> buffer) const noexcept
+    {
+        return _partial<_with_buffer, std::span<std::byte>>{0, std::span{buffer}};
     }
 };
 
 inline constexpr _with_buffer with_buffer;
 
-template<class client_t>
-constexpr auto operator|(client_t&& client, _partial<_with_buffer, std::size_t>&& with_buf)
+template<class client_t, class... args_t>
+constexpr auto operator|(client_t&& client, _partial<_with_buffer, args_t...>&& with_buf)
 {
     return with_buf(client);
 }

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -5,12 +5,12 @@
 
 namespace coro::ranges
 {
-template<class buffer_t>
+template<class client_t, class buffer_t>
 class socket_stream
 {
 public:
-    explicit socket_stream(coro::net::tcp::client& client, buffer_t&& buffer)
-        : m_client(client),
+    explicit socket_stream(client_t&& client, buffer_t&& buffer)
+        : m_client(std::forward<client_t>(client)),
           m_buffer{std::move(buffer)} {};
 
     auto advance() -> coro::task<bool>
@@ -35,20 +35,33 @@ public:
     auto get_value() const noexcept -> std::span<const std::byte> { return {m_buffer.data(), m_current_size}; }
 
 private:
-    coro::net::tcp::client& m_client;
-    buffer_t                m_buffer;
-    std::size_t             m_current_size{};
+    client_t    m_client;
+    buffer_t    m_buffer;
+    std::size_t m_current_size{};
 };
 
 auto to_chunked_stream(coro::net::tcp::client& client, std::size_t buffer_size = 4096)
-    -> socket_stream<std::vector<std::byte>>
+    -> socket_stream<coro::net::tcp::client&, std::vector<std::byte>>
 {
-    return socket_stream{client, std::vector<std::byte>{buffer_size}};
+    return socket_stream<coro::net::tcp::client&, std::vector<std::byte>>{client, std::vector<std::byte>{buffer_size}};
 }
 
 auto to_chunked_stream(coro::net::tcp::client& client, std::span<std::byte> external_buffer)
-    -> socket_stream<std::span<std::byte>>
+    -> socket_stream<coro::net::tcp::client&, std::span<std::byte>>
 {
-    return socket_stream{client, std::move(external_buffer)};
+    return socket_stream<coro::net::tcp::client&, std::span<std::byte>>{client, std::move(external_buffer)};
+}
+
+auto to_chunked_stream(coro::net::tcp::client&& client, std::size_t buffer_size = 4096)
+    -> socket_stream<coro::net::tcp::client, std::vector<std::byte>>
+{
+    return socket_stream<coro::net::tcp::client, std::vector<std::byte>>{
+        std::move(client), std::vector<std::byte>{buffer_size}};
+}
+
+auto to_chunked_stream(coro::net::tcp::client&& client, std::span<std::byte> external_buffer)
+    -> socket_stream<coro::net::tcp::client, std::span<std::byte>>
+{
+    return socket_stream<coro::net::tcp::client, std::span<std::byte>>{std::move(client), std::move(external_buffer)};
 }
 } // namespace coro::ranges

--- a/include/coro/ranges/socket_stream.hpp
+++ b/include/coro/ranges/socket_stream.hpp
@@ -1,0 +1,152 @@
+#pragma once
+#include "coro/net/tcp/client.hpp"
+#include "coro/task.hpp"
+#include <vector>
+
+namespace coro::ranges
+{
+template<typename T>
+struct async_stream_traits;
+
+template<typename T>
+    requires requires(T& t) { t.next(); }
+struct async_stream_traits<T>
+{
+    using value_type = typename decltype(std::declval<T&>().next())::return_type;
+};
+
+template<class T>
+using async_stream_value_t = typename async_stream_traits<T>::value_type;
+
+template<class T>
+concept async_streamable = requires(T& stream) {
+    { stream.next() } -> std::same_as<coro::task<async_stream_value_t<T>>>;
+};
+
+class socket_stream
+{
+public:
+    explicit socket_stream(coro::net::tcp::client& client) : m_client(client) {};
+
+    auto next() -> coro::task<std::optional<std::byte>>
+    {
+        std::byte b;
+        auto      span      = std::span{&b, 1};
+        auto [status, read] = co_await m_client.read_some(span);
+
+        if (not status.is_ok())
+        {
+            if (status.is_closed())
+            {
+                co_return std::nullopt;
+            }
+            throw std::runtime_error(status.message());
+        }
+        co_return b;
+    }
+
+private:
+    coro::net::tcp::client& m_client;
+    //    std::vector<std::byte>  m_buffer;
+};
+
+template<async_streamable previous_stream_t, class Pred>
+class take_until_view
+{
+private:
+    using value_type = async_stream_value_t<previous_stream_t>;
+
+    previous_stream_t m_prev_stream;
+    Pred              m_pred;
+
+public:
+    constexpr take_until_view(previous_stream_t&& prev_stream, Pred&& pred)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
+          m_pred(std::forward<Pred>(pred))
+    {
+    }
+
+    auto next() -> coro::task<value_type>
+    {
+        auto val = co_await m_prev_stream.next();
+        if (val and not m_pred(*val))
+        {
+            co_return std::move(val);
+        }
+        co_return std::nullopt;
+    }
+};
+
+template<typename Adaptor, typename... Args>
+struct _partial
+{
+    std::tuple<Args...> m_args;
+
+    constexpr _partial(int, Args&&... args) : m_args(std::forward<Args>(args)...) {}
+
+    template<async_streamable range_t>
+    constexpr auto operator()(range_t&& range) const&
+    {
+        auto forwarder = [&range](const auto&... args) { return Adaptor{}(std::forward<range_t>(range), args...); };
+        return std::apply(forwarder, m_args);
+    }
+
+    template<async_streamable range_t>
+    constexpr auto operator()(range_t&& range) &&
+    {
+        auto forwarder = [&range](auto&... args)
+        { return Adaptor{}(std::forward<range_t>(range), std::move(args)...); };
+        return std::apply(forwarder, m_args);
+    }
+
+    template<async_streamable range_t>
+    constexpr auto operator()(range_t&& range) const&& = delete;
+};
+
+template<class Partial, class Range>
+constexpr auto operator|(Range&& rng, Partial&& partial)
+{
+    return std::forward<Partial>(partial)(std::forward<Range>(rng));
+}
+
+struct _take_until
+{
+    template<async_streamable Rng, typename Pred>
+    constexpr auto operator()(Rng&& rng, Pred&& pred)
+    {
+        return take_until_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
+    }
+
+    template<typename Pred>
+    constexpr auto operator()(Pred&& pred) const
+    {
+        return _partial<_take_until, Pred>{0, std::forward<Pred>(pred)};
+    }
+};
+
+inline constexpr _take_until take_until;
+
+auto to_stream(coro::net::tcp::client& client) -> socket_stream
+{
+    return socket_stream{client};
+}
+
+struct _to_vector
+{
+    template<async_streamable Rng>
+    auto operator()(Rng rng) const -> coro::task<std::vector<typename async_stream_value_t<Rng>::value_type>>
+    {
+        std::vector<typename async_stream_value_t<Rng>::value_type> result;
+        while (true)
+        {
+            auto val = co_await rng.next();
+            if (!val)
+                break;
+            result.push_back(std::move(*val));
+        }
+        co_return result;
+    }
+};
+
+inline constexpr _to_vector to_vector;
+} // namespace coro::ranges

--- a/include/coro/ranges/take.hpp
+++ b/include/coro/ranges/take.hpp
@@ -18,7 +18,7 @@ public:
 
     auto next() -> awaiter_type
     {
-        if (m_current + 1 < m_count)
+        if (m_current < m_count)
         {
             m_current += 1;
             co_return co_await m_prev_stream.next();
@@ -35,12 +35,12 @@ private:
 struct _take
 {
     template<concepts::async_streamable Rng>
-    constexpr auto operator()(Rng&& rng, std::size_t N)
+    constexpr auto operator()(Rng&& rng, std::size_t N) const
     {
         return take_view{std::forward<Rng>(rng), N};
     }
 
-    constexpr auto operator()(std::size_t N) { return _partial<_take, std::size_t>{0, N}; }
+    constexpr auto operator()(std::size_t N) const { return _partial<_take, std::size_t>{0, N}; }
 };
 
 inline constexpr _take take;

--- a/include/coro/ranges/take.hpp
+++ b/include/coro/ranges/take.hpp
@@ -9,27 +9,21 @@ class take_view
 {
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
 
-    // std::optional doesn't support reference
-    using value_type = std::remove_reference_t<concepts::async_stream_value_t<previous_stream_t>>;
-
 public:
-    constexpr take_view(previous_stream_t prev_stream, std::size_t count) : m_prev_stream(prev_stream), m_count(count)
+    constexpr take_view(previous_stream_t prev_stream, std::size_t count)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
+          m_count(count)
     {
     }
 
-    auto advance() -> awaiter_type
+    auto next() -> awaiter_type
     {
         if (m_current + 1 < m_count)
         {
             m_current += 1;
-            co_return co_await m_prev_stream.advance();
+            co_return co_await m_prev_stream.next();
         }
-        co_return false;
-    }
-
-    auto get_value() noexcept(noexcept(m_prev_stream.get_value())) -> decltype(auto)
-    {
-        return m_prev_stream.get_value();
+        co_return std::nullopt;
     }
 
 private:

--- a/include/coro/ranges/take.hpp
+++ b/include/coro/ranges/take.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include "utils.hpp"
+#include <cstdint>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t>
+class take_view
+{
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+
+    // std::optional doesn't support reference
+    using value_type = std::remove_reference_t<concepts::async_stream_value_t<previous_stream_t>>;
+
+public:
+    constexpr take_view(previous_stream_t prev_stream, std::size_t count) : m_prev_stream(prev_stream), m_count(count)
+    {
+    }
+
+    auto advance() -> awaiter_type
+    {
+        if (m_current + 1 < m_count)
+        {
+            m_current += 1;
+            co_return co_await m_prev_stream.advance();
+        }
+        co_return false;
+    }
+
+    auto get_value() noexcept(noexcept(m_prev_stream.get_value())) -> decltype(auto)
+    {
+        return m_prev_stream.get_value();
+    }
+
+private:
+    previous_stream_t m_prev_stream;
+    std::size_t       m_current{};
+    const std::size_t m_count{};
+};
+
+struct _take
+{
+    template<concepts::async_streamable Rng>
+    constexpr auto operator()(Rng&& rng, std::size_t N)
+    {
+        return take_view{std::forward<Rng>(rng), N};
+    }
+
+    constexpr auto operator()(std::size_t N) { return _partial<_take, std::size_t>{0, N}; }
+};
+
+inline constexpr _take take;
+} // namespace coro::ranges

--- a/include/coro/ranges/take_until.hpp
+++ b/include/coro/ranges/take_until.hpp
@@ -1,0 +1,70 @@
+#pragma once
+#include "utils.hpp"
+#include <optional>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t, class Pred>
+class take_until_view
+{
+private:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+    using value_type   = concepts::async_stream_value_t<previous_stream_t>;
+
+public:
+    constexpr take_until_view(previous_stream_t&& prev_stream, Pred&& pred)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
+          m_pred(std::forward<Pred>(pred))
+    {
+    }
+
+    auto advance() -> awaiter_type
+    {
+        // Got the next value from the stream
+        auto has_value = co_await m_prev_stream.advance();
+        if (!has_value)
+        {
+            co_return false;
+        }
+
+        // Save it
+        m_value.emplace(std::move(m_prev_stream.get_value()));
+
+        // Check it. true means stop
+        if (m_pred(*m_value))
+        {
+            m_value.reset();
+            co_return false;
+        }
+
+        co_return true;
+    }
+
+    auto get_value() const& noexcept -> const value_type& { return *m_value; }
+    auto get_value() & noexcept -> value_type& { return *m_value; }
+
+    auto get_value() && noexcept -> value_type { return std::move(*m_value); }
+
+private:
+    previous_stream_t         m_prev_stream;
+    Pred                      m_pred;
+    std::optional<value_type> m_value;
+};
+
+struct _take_until
+{
+    template<concepts::async_streamable Rng, typename Pred>
+    constexpr auto operator()(Rng&& rng, Pred&& pred)
+    {
+        return take_until_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
+    }
+
+    template<typename Pred>
+    constexpr auto operator()(Pred&& pred) const
+    {
+        return _partial<_take_until, Pred>{0, std::forward<Pred>(pred)};
+    }
+};
+
+inline constexpr _take_until take_until;
+} // namespace coro::ranges

--- a/include/coro/ranges/take_until.hpp
+++ b/include/coro/ranges/take_until.hpp
@@ -10,9 +10,6 @@ class take_until_view
 private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
 
-    // std::optional doesn't support reference
-    using value_type = std::remove_reference_t<concepts::async_stream_value_t<previous_stream_t>>;
-
 public:
     constexpr take_until_view(previous_stream_t prev_stream, Pred pred)
         : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
@@ -20,37 +17,19 @@ public:
     {
     }
 
-    auto advance() -> awaiter_type
+    auto next() -> awaiter_type
     {
-        // Got the next value from the stream
-        auto has_value = co_await m_prev_stream.advance();
-        if (!has_value)
+        auto value = co_await m_prev_stream.next();
+        if (value && !m_pred(*value))
         {
-            co_return false;
+            co_return std::move(value);
         }
-
-        // Save it
-        m_value.emplace(std::move(m_prev_stream.get_value()));
-
-        // Check it. true means stop
-        if (m_pred(*m_value))
-        {
-            m_value.reset();
-            co_return false;
-        }
-
-        co_return true;
+        co_return std::nullopt;
     }
 
-    auto get_value() const& noexcept -> const value_type& { return *m_value; }
-    auto get_value() & noexcept -> value_type& { return *m_value; }
-
-    auto get_value() && noexcept -> value_type { return std::move(*m_value); }
-
 private:
-    previous_stream_t         m_prev_stream;
-    Pred                      m_pred;
-    std::optional<value_type> m_value;
+    previous_stream_t          m_prev_stream;
+    [[no_unique_address]] Pred m_pred;
 };
 
 struct _take_until

--- a/include/coro/ranges/take_until.hpp
+++ b/include/coro/ranges/take_until.hpp
@@ -14,7 +14,7 @@ private:
     using value_type = std::remove_reference_t<concepts::async_stream_value_t<previous_stream_t>>;
 
 public:
-    constexpr take_until_view(previous_stream_t&& prev_stream, Pred&& pred)
+    constexpr take_until_view(previous_stream_t prev_stream, Pred pred)
         : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
           m_pred(std::forward<Pred>(pred))
     {

--- a/include/coro/ranges/take_until.hpp
+++ b/include/coro/ranges/take_until.hpp
@@ -9,7 +9,9 @@ class take_until_view
 {
 private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
-    using value_type   = concepts::async_stream_value_t<previous_stream_t>;
+
+    // std::optional doesn't support reference
+    using value_type = std::remove_reference_t<concepts::async_stream_value_t<previous_stream_t>>;
 
 public:
     constexpr take_until_view(previous_stream_t&& prev_stream, Pred&& pred)
@@ -54,7 +56,7 @@ private:
 struct _take_until
 {
     template<concepts::async_streamable Rng, typename Pred>
-    constexpr auto operator()(Rng&& rng, Pred&& pred)
+    constexpr auto operator()(Rng&& rng, Pred&& pred) const
     {
         return take_until_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
     }

--- a/include/coro/ranges/take_until.hpp
+++ b/include/coro/ranges/take_until.hpp
@@ -28,8 +28,9 @@ public:
     }
 
 private:
-    previous_stream_t          m_prev_stream;
-    [[no_unique_address]] Pred m_pred;
+    previous_stream_t m_prev_stream;
+    [[no_unique_address]]
+    Pred m_pred;
 };
 
 struct _take_until

--- a/include/coro/ranges/to.hpp
+++ b/include/coro/ranges/to.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include "coro/task.hpp"
+#include "utils.hpp"
+
+namespace coro::ranges
+{
+template<class container_t>
+struct _to : public concepts::_async_adaptor
+{
+public:
+    template<concepts::async_streamable Rng>
+    auto operator()(Rng rng) const -> coro::task<container_t>
+    {
+        container_t result;
+        while (co_await rng.advance())
+        {
+            result.emplace_back(std::move(rng.get_value()));
+        }
+        co_return result;
+    }
+
+private:
+};
+
+template<class container_t>
+inline constexpr _to<container_t> to;
+} // namespace coro::ranges

--- a/include/coro/ranges/to.hpp
+++ b/include/coro/ranges/to.hpp
@@ -22,6 +22,26 @@ public:
 private:
 };
 
+template<class char_t, class traits, class alloc_t>
+struct _to<std::basic_string<char_t, traits, alloc_t>> : public concepts::_async_adaptor
+{
+    using container_t = std::basic_string<char_t, traits, alloc_t>;
+
+public:
+    template<concepts::async_streamable Rng>
+    auto operator()(Rng rng) const -> coro::task<container_t>
+    {
+        container_t result;
+        while (co_await rng.advance())
+        {
+            result.push_back(std::move(rng.get_value()));
+        }
+        co_return result;
+    }
+
+private:
+};
+
 template<class container_t>
 inline constexpr _to<container_t> to;
 } // namespace coro::ranges

--- a/include/coro/ranges/to.hpp
+++ b/include/coro/ranges/to.hpp
@@ -12,9 +12,17 @@ public:
     auto operator()(Rng rng) const -> coro::task<container_t>
     {
         container_t result;
-        while (co_await rng.advance())
+        while (true)
         {
-            result.emplace_back(std::move(rng.get_value()));
+            auto value = co_await rng.advance();
+            if (value)
+            {
+                result.emplace_back(std::move(*value));
+            }
+            else
+            {
+                break;
+            }
         }
         co_return result;
     }
@@ -32,9 +40,17 @@ public:
     auto operator()(Rng rng) const -> coro::task<container_t>
     {
         container_t result;
-        while (co_await rng.advance())
+        while (true)
         {
-            result.push_back(std::move(rng.get_value()));
+            auto value = co_await rng.next();
+            if (value)
+            {
+                result.push_back(std::move(*value));
+            }
+            else
+            {
+                break;
+            }
         }
         co_return result;
     }

--- a/include/coro/ranges/to.hpp
+++ b/include/coro/ranges/to.hpp
@@ -14,7 +14,7 @@ public:
         container_t result;
         while (true)
         {
-            auto value = co_await rng.advance();
+            auto value = co_await rng.next();
             if (value)
             {
                 result.emplace_back(std::move(*value));

--- a/include/coro/ranges/transform.hpp
+++ b/include/coro/ranges/transform.hpp
@@ -12,7 +12,7 @@ private:
     using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
 
 public:
-    constexpr transform_view(previous_stream_t&& prev_stream, transform_fn&& transform)
+    constexpr transform_view(previous_stream_t prev_stream, transform_fn transform)
         : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
           m_transform(std::forward<transform_fn>(transform))
     {

--- a/include/coro/ranges/transform.hpp
+++ b/include/coro/ranges/transform.hpp
@@ -11,8 +11,8 @@ class transform_view
 private:
     using awaiter_type        = concepts::async_stream_awaiter_t<previous_stream_t>;
     using awaiter_return_type = concepts::async_stream_return_t<previous_stream_t>;
-    using return_type         = wrap_return_value_for_optional_t<decltype(std::declval<transform_fn&>()(
-        unwrap_return_value(std::declval<awaiter_return_type>())))>;
+    using return_type         = concepts::wrap_return_value_for_optional_t<decltype(std::declval<transform_fn&>()(
+        concepts::unwrap_return_value(std::declval<awaiter_return_type>())))>;
 
 public:
     constexpr transform_view(previous_stream_t prev_stream, transform_fn transform)
@@ -26,7 +26,7 @@ public:
         auto value = co_await m_prev_stream.next();
         if (value)
         {
-            auto result = m_transform(unwrap_return_value(*value));
+            auto result = m_transform(concepts::unwrap_return_value(*value));
             co_return std::forward<decltype(result)>(result);
         }
         co_return std::nullopt;

--- a/include/coro/ranges/transform.hpp
+++ b/include/coro/ranges/transform.hpp
@@ -9,7 +9,10 @@ template<concepts::async_streamable previous_stream_t, class transform_fn>
 class transform_view
 {
 private:
-    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+    using awaiter_type        = concepts::async_stream_awaiter_t<previous_stream_t>;
+    using awaiter_return_type = concepts::async_stream_return_t<previous_stream_t>;
+    using return_type         = wrap_return_value_for_optional_t<decltype(std::declval<transform_fn&>()(
+        unwrap_return_value(std::declval<awaiter_return_type>())))>;
 
 public:
     constexpr transform_view(previous_stream_t prev_stream, transform_fn transform)
@@ -18,16 +21,21 @@ public:
     {
     }
 
-    auto advance() -> awaiter_type { co_return co_await m_prev_stream.advance(); }
-
-    auto get_value() noexcept(noexcept(m_transform(m_prev_stream.get_value()))) -> decltype(auto)
+    auto next() -> coro::task<std::optional<return_type>>
     {
-        return m_transform(m_prev_stream.get_value());
+        auto value = co_await m_prev_stream.next();
+        if (value)
+        {
+            auto result = m_transform(unwrap_return_value(*value));
+            co_return std::forward<decltype(result)>(result);
+        }
+        co_return std::nullopt;
     }
 
 private:
     previous_stream_t m_prev_stream;
-    transform_fn      m_transform;
+    [[no_unique_address]]
+    transform_fn m_transform;
 };
 
 struct _transform

--- a/include/coro/ranges/transform.hpp
+++ b/include/coro/ranges/transform.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include "utils.hpp"
+#include <optional>
+#include <utility>
+
+namespace coro::ranges
+{
+template<concepts::async_streamable previous_stream_t, class transform_fn>
+class transform_view
+{
+private:
+    using awaiter_type = concepts::async_stream_awaiter_t<previous_stream_t>;
+
+public:
+    constexpr transform_view(previous_stream_t&& prev_stream, transform_fn&& transform)
+        : m_prev_stream(std::forward<previous_stream_t>(prev_stream)),
+          m_transform(std::forward<transform_fn>(transform))
+    {
+    }
+
+    auto advance() -> awaiter_type { co_return co_await m_prev_stream.advance(); }
+
+    auto get_value() noexcept(noexcept(m_transform(m_prev_stream.get_value()))) -> decltype(auto)
+    {
+        return m_transform(m_prev_stream.get_value());
+    }
+
+private:
+    previous_stream_t m_prev_stream;
+    transform_fn      m_transform;
+};
+
+struct _transform
+{
+    template<concepts::async_streamable Rng, class Pred>
+    constexpr auto operator()(Rng&& rng, Pred&& pred) const
+    {
+        return transform_view{std::forward<Rng>(rng), std::forward<Pred>(pred)};
+    }
+
+    template<class Pred>
+    constexpr auto operator()(Pred&& pred) const
+    {
+        return _partial<_transform, Pred>{0, std::forward<Pred>(pred)};
+    }
+};
+
+inline constexpr _transform transform;
+} // namespace coro::ranges

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "coro/concepts/awaitable.hpp"
 #include "coro/task.hpp"
+#include <optional>
 #include <ranges>
 #include <tuple>
 #include <type_traits>
@@ -40,6 +41,34 @@ template<class T>
 concept async_streamable = requires(T& stream) {
     { stream.next() } -> coro::concepts::awaitable;
 };
+
+namespace detail
+{
+template<class T>
+struct _wrap_return_value_for_optional
+{
+    using type = T;
+};
+template<class T>
+struct _wrap_return_value_for_optional<T&>
+{
+    using type = std::reference_wrapper<T>;
+};
+
+} // namespace detail
+template<class T>
+using wrap_return_value_for_optional_t = typename detail::_wrap_return_value_for_optional<T>::type;
+
+template<class T>
+constexpr auto unwrap_return_value(T&& value) noexcept -> decltype(auto)
+{
+    return std::forward<T>(value);
+}
+template<class T>
+constexpr auto unwrap_return_value(std::reference_wrapper<T> value) noexcept -> T&
+{
+    return value.get();
+}
 
 // Concept for piping
 struct _async_adaptor
@@ -123,63 +152,40 @@ struct _partial : public concepts::_async_adaptor
     constexpr auto operator()(range_t&& range) const&& = delete;
 };
 
-template<std::ranges::viewable_range Range>
+template<std::ranges::viewable_range range_type>
 class sync_stream
 {
 public:
-    using value_type = std::ranges::range_value_t<Range>;
+    using value_type  = std::ranges::range_value_t<range_type>;
+    using return_type = value_type;
 
-    explicit constexpr sync_stream(Range range) : m_range(std::forward<Range>(range)), m_it(std::begin(m_range)) {}
+    explicit constexpr sync_stream(range_type range)
+        : m_range(std::forward<range_type>(range)),
+          m_it(std::begin(m_range))
+    {
+    }
 
-    auto next() -> coro::task<std::optional<value_type>>
+    auto next() -> coro::task<std::optional<return_type>>
     {
         if (m_it == std::end(m_range))
         {
             co_return std::nullopt;
         }
 
-        value_type current = *m_it;
+        value_type& current = *m_it;
         ++m_it;
         co_return std::move(current);
     }
 
 private:
-    Range                          m_range;
-    std::ranges::iterator_t<Range> m_it;
+    range_type                          m_range;
+    std::ranges::iterator_t<range_type> m_it;
 };
 
 // Sync range overload
 template<std::ranges::viewable_range Range, concepts::async_adaptor Adaptor>
 constexpr auto operator|(Range&& rng, Adaptor&& partial)
 {
-    return std::forward<Adaptor>(partial)(sync_stream{std::forward<Range>(rng)});
-}
-
-namespace detail
-{
-template<class T>
-struct _wrap_return_value_for_optional
-{
-    using type = T;
-};
-template<class T>
-struct _wrap_return_value_for_optional<T&>
-{
-    using type = std::reference_wrapper<T>;
-};
-
-} // namespace detail
-template<class T>
-using wrap_return_value_for_optional_t = typename detail::_wrap_return_value_for_optional<T>::type;
-
-template<class T>
-constexpr auto unwrap_return_value(T&& value) noexcept -> decltype(auto)
-{
-    return std::forward<T>(value);
-}
-template<class T>
-constexpr auto unwrap_return_value(std::reference_wrapper<T> value) noexcept -> T&
-{
-    return value.get();
+    return std::forward<Adaptor>(partial)(sync_stream<Range>{std::forward<Range>(rng)});
 }
 } // namespace coro::ranges

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -123,7 +123,7 @@ struct _partial : public concepts::_async_adaptor
     constexpr auto operator()(range_t&& range) &&
     {
         auto forwarder = [&range](auto&... args)
-        { return Adaptor{}(std::forward<range_t>(range), std::move(args)...); };
+        { return Adaptor{}(std::forward<range_t>(range), std::forward<decltype(args)>(args)...); };
         return std::apply(forwarder, m_args);
     }
 

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -22,25 +22,23 @@ template<typename T>
 struct async_stream_traits;
 
 template<typename T>
-    requires requires(T& t) {
-        t.advance();
-        t.get_value();
-    }
+    requires requires(T& t) { t.next(); }
 struct async_stream_traits<T>
 {
-    using awaiter_type = decltype(std::declval<T>().advance());
-    using value_type   = decltype(std::declval<T>().get_value());
+    using awaiter_type = decltype(std::declval<T>().next());
+    using optional_type =
+        std::remove_cvref_t<typename coro::concepts::awaitable_traits<awaiter_type>::awaiter_return_type>;
+    using return_type = typename optional_type::value_type;
 };
 
 template<class T>
-using async_stream_value_t = typename async_stream_traits<T>::value_type;
+using async_stream_return_t = typename async_stream_traits<T>::return_type;
 template<class T>
 using async_stream_awaiter_t = typename async_stream_traits<T>::awaiter_type;
 
 template<class T>
 concept async_streamable = requires(T& stream) {
-    { stream.advance() } -> coro::concepts::awaitable;
-    { stream.get_value() };
+    { stream.next() } -> coro::concepts::awaitable;
 };
 
 // Concept for piping
@@ -60,13 +58,7 @@ public:
     constexpr explicit ref_view(Stream& stream) noexcept : m_stream(stream) {}
 
     LIBCORO_ALWAYS_INLINE
-    auto advance() noexcept(noexcept(m_stream.advance())) -> concepts::async_stream_awaiter_t<Stream>
-    {
-        return m_stream.advance();
-    }
-
-    LIBCORO_ALWAYS_INLINE
-    auto get_value() noexcept(noexcept(m_stream.get_value())) -> decltype(auto) { return m_stream.get_value(); }
+    auto next() -> concepts::async_stream_awaiter_t<Stream> { return m_stream.next(); }
 
 private:
     Stream& m_stream;
@@ -135,28 +127,25 @@ template<std::ranges::viewable_range Range>
 class sync_stream
 {
 public:
+    using value_type = std::ranges::range_value_t<Range>;
+
     explicit constexpr sync_stream(Range range) : m_range(std::forward<Range>(range)), m_it(std::begin(m_range)) {}
 
-    auto advance() -> coro::task<bool>
+    auto next() -> coro::task<std::optional<value_type>>
     {
         if (m_it == std::end(m_range))
         {
-            co_return false;
+            co_return std::nullopt;
         }
-        if (!m_first)
-        {
-            ++m_it;
-        }
-        m_first = false;
-        co_return m_it != std::end(m_range);
-    }
 
-    auto get_value() noexcept -> decltype(auto) { return *m_it; }
+        value_type current = *m_it;
+        ++m_it;
+        co_return std::move(current);
+    }
 
 private:
     Range                          m_range;
     std::ranges::iterator_t<Range> m_it;
-    bool                           m_first{true};
 };
 
 // Sync range overload
@@ -164,5 +153,33 @@ template<std::ranges::viewable_range Range, concepts::async_adaptor Adaptor>
 constexpr auto operator|(Range&& rng, Adaptor&& partial)
 {
     return std::forward<Adaptor>(partial)(sync_stream{std::forward<Range>(rng)});
+}
+
+namespace detail
+{
+template<class T>
+struct _wrap_return_value_for_optional
+{
+    using type = T;
+};
+template<class T>
+struct _wrap_return_value_for_optional<T&>
+{
+    using type = std::reference_wrapper<T>;
+};
+
+} // namespace detail
+template<class T>
+using wrap_return_value_for_optional_t = typename detail::_wrap_return_value_for_optional<T>::type;
+
+template<class T>
+constexpr auto unwrap_return_value(T&& value) noexcept -> decltype(auto)
+{
+    return std::forward<T>(value);
+}
+template<class T>
+constexpr auto unwrap_return_value(std::reference_wrapper<T> value) noexcept -> T&
+{
+    return value.get();
 }
 } // namespace coro::ranges

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "coro/concepts/awaitable.hpp"
+#include "coro/task.hpp"
+#include <ranges>
 #include <tuple>
 #include <type_traits>
 
@@ -46,16 +48,19 @@ struct _partial : public concepts::_async_adaptor
 {
     std::tuple<Args...> m_args;
 
-    constexpr _partial(int, Args&&... args) : m_args(std::forward<Args>(args)...) {}
+    template<typename... ConstructorArgs>
+    constexpr explicit _partial(int, ConstructorArgs&&... args) : m_args(std::forward<ConstructorArgs>(args)...)
+    {
+    }
 
-    template<concepts::async_streamable range_t>
+    template<class range_t>
     constexpr auto operator()(range_t&& range) const&
     {
         auto forwarder = [&range](const auto&... args) { return Adaptor{}(std::forward<range_t>(range), args...); };
         return std::apply(forwarder, m_args);
     }
 
-    template<concepts::async_streamable range_t>
+    template<class range_t>
     constexpr auto operator()(range_t&& range) &&
     {
         auto forwarder = [&range](auto&... args)
@@ -63,13 +68,53 @@ struct _partial : public concepts::_async_adaptor
         return std::apply(forwarder, m_args);
     }
 
-    template<concepts::async_streamable range_t>
+    template<class range_t>
     constexpr auto operator()(range_t&& range) const&& = delete;
 };
 
-template<concepts::async_adaptor Adaptor, class Range>
+template<class Range, concepts::async_adaptor Adaptor>
 constexpr auto operator|(Range&& rng, Adaptor&& partial)
 {
     return std::forward<Adaptor>(partial)(std::forward<Range>(rng));
+}
+
+template<class Range, concepts::async_adaptor Adaptor>
+constexpr auto operator|(const Range& rng, Adaptor&& partial)
+{
+    return std::forward<Adaptor>(partial)(rng);
+}
+
+template<std::ranges::range Range>
+class sync_stream
+{
+public:
+    explicit constexpr sync_stream(Range range) : m_range(std::forward<Range>(range)), m_it(std::begin(m_range)) {}
+
+    auto advance() -> coro::task<bool>
+    {
+        if (m_it == std::end(m_range))
+        {
+            co_return false;
+        }
+        if (!m_first)
+        {
+            ++m_it;
+        }
+        m_first = false;
+        co_return m_it != std::end(m_range);
+    }
+
+    auto get_value() noexcept -> decltype(auto) { return *m_it; }
+
+private:
+    Range                          m_range;
+    std::ranges::iterator_t<Range> m_it;
+    bool                           m_first{true};
+};
+
+template<std::ranges::range Range, concepts::async_adaptor Adaptor>
+constexpr auto operator|(Range&& rng, Adaptor&& partial)
+{
+    return std::forward<Adaptor>(partial)(sync_stream{std::forward<Range>(rng)});
 }
 } // namespace coro::ranges

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -43,6 +43,52 @@ template<class T>
 concept async_adaptor = std::derived_from<std::decay_t<T>, _async_adaptor>;
 } // namespace concepts
 
+// This lets a named lvalue stream  be reused
+// without being moved-from. Exactly how std::ranges::ref_view works.
+template<concepts::async_streamable Stream>
+class ref_view
+{
+public:
+    explicit ref_view(Stream& stream) noexcept : m_stream(std::addressof(stream)) {}
+
+    auto advance() -> concepts::async_stream_awaiter_t<Stream> { return m_stream->advance(); }
+
+    auto get_value() noexcept(noexcept(m_stream->get_value())) -> decltype(auto) { return m_stream->get_value(); }
+
+private:
+    Stream* m_stream;
+};
+
+// template<concepts::async_streamable Stream>
+// struct concepts::async_stream_traits<ref_view<Stream>>
+//     : concepts::async_stream_traits<Stream> {};
+
+// struct _ref
+//{
+//     template<concepts::async_streamable Rng>
+//     constexpr auto operator()(Rng& rng) const noexcept
+//     {
+//         return ref_view<Rng>{rng};
+//     }
+// };
+// inline constexpr _ref ref{};
+
+template<class Rng, concepts::async_adaptor Adaptor>
+    requires concepts::async_streamable<std::remove_cvref_t<Rng>>
+constexpr auto operator|(Rng&& rng, Adaptor&& partial)
+{
+    // lvalue -> wrap in ref_view
+    // rvalue -> move ownership
+    if constexpr (std::is_lvalue_reference_v<decltype(rng)>)
+    {
+        return std::forward<Adaptor>(partial)(ref_view<std::remove_cvref_t<decltype(rng)>>{rng});
+    }
+    else
+    {
+        return std::forward<Adaptor>(partial)(std::forward<Rng>(rng));
+    }
+}
+
 template<typename Adaptor, typename... Args>
 struct _partial : public concepts::_async_adaptor
 {
@@ -72,18 +118,7 @@ struct _partial : public concepts::_async_adaptor
     constexpr auto operator()(range_t&& range) const&& = delete;
 };
 
-template<class Range, concepts::async_adaptor Adaptor>
-constexpr auto operator|(Range&& rng, Adaptor&& partial)
-{
-    return std::forward<Adaptor>(partial)(std::forward<Range>(rng));
-}
-
-template<class Range, concepts::async_adaptor Adaptor>
-constexpr auto operator|(const Range& rng, Adaptor&& partial)
-{
-    return std::forward<Adaptor>(partial)(rng);
-}
-
+// sync_stream (unchanged - already at the bottom of your file)
 template<std::ranges::range Range>
 class sync_stream
 {
@@ -112,6 +147,7 @@ private:
     bool                           m_first{true};
 };
 
+// Sync range overload
 template<std::ranges::range Range, concepts::async_adaptor Adaptor>
 constexpr auto operator|(Range&& rng, Adaptor&& partial)
 {

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -5,7 +5,13 @@
 #include <tuple>
 #include <type_traits>
 
-#define LIBCORO_ALWAYS_INLINE [[gnu::always_inline]]
+#if defined(_MSC_VER)
+    #define LIBCORO_ALWAYS_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+    #define LIBCORO_ALWAYS_INLINE [[gnu::always_inline]] inline
+#else
+    #define LIBCORO_ALWAYS_INLINE inline
+#endif
 
 namespace coro::ranges
 {
@@ -125,8 +131,7 @@ struct _partial : public concepts::_async_adaptor
     constexpr auto operator()(range_t&& range) const&& = delete;
 };
 
-// sync_stream (unchanged - already at the bottom of your file)
-template<std::ranges::range Range>
+template<std::ranges::viewable_range Range>
 class sync_stream
 {
 public:
@@ -155,7 +160,7 @@ private:
 };
 
 // Sync range overload
-template<std::ranges::range Range, concepts::async_adaptor Adaptor>
+template<std::ranges::viewable_range Range, concepts::async_adaptor Adaptor>
 constexpr auto operator|(Range&& rng, Adaptor&& partial)
 {
     return std::forward<Adaptor>(partial)(sync_stream{std::forward<Range>(rng)});

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -5,6 +5,8 @@
 #include <tuple>
 #include <type_traits>
 
+#define LIBCORO_ALWAYS_INLINE [[gnu::always_inline]]
+
 namespace coro::ranges
 {
 namespace concepts
@@ -49,14 +51,19 @@ template<concepts::async_streamable Stream>
 class ref_view
 {
 public:
-    explicit ref_view(Stream& stream) noexcept : m_stream(std::addressof(stream)) {}
+    constexpr explicit ref_view(Stream& stream) noexcept : m_stream(stream) {}
 
-    auto advance() -> concepts::async_stream_awaiter_t<Stream> { return m_stream->advance(); }
+    LIBCORO_ALWAYS_INLINE
+    auto advance() noexcept(noexcept(m_stream.advance())) -> concepts::async_stream_awaiter_t<Stream>
+    {
+        return m_stream.advance();
+    }
 
-    auto get_value() noexcept(noexcept(m_stream->get_value())) -> decltype(auto) { return m_stream->get_value(); }
+    LIBCORO_ALWAYS_INLINE
+    auto get_value() noexcept(noexcept(m_stream.get_value())) -> decltype(auto) { return m_stream.get_value(); }
 
 private:
-    Stream* m_stream;
+    Stream& m_stream;
 };
 
 // template<concepts::async_streamable Stream>

--- a/include/coro/ranges/utils.hpp
+++ b/include/coro/ranges/utils.hpp
@@ -1,0 +1,75 @@
+#pragma once
+#include "coro/concepts/awaitable.hpp"
+#include <tuple>
+#include <type_traits>
+
+namespace coro::ranges
+{
+namespace concepts
+{
+
+template<typename T>
+struct async_stream_traits;
+
+template<typename T>
+    requires requires(T& t) {
+        t.advance();
+        t.get_value();
+    }
+struct async_stream_traits<T>
+{
+    using awaiter_type = decltype(std::declval<T>().advance());
+    using value_type   = decltype(std::declval<T>().get_value());
+};
+
+template<class T>
+using async_stream_value_t = typename async_stream_traits<T>::value_type;
+template<class T>
+using async_stream_awaiter_t = typename async_stream_traits<T>::awaiter_type;
+
+template<class T>
+concept async_streamable = requires(T& stream) {
+    { stream.advance() } -> coro::concepts::awaitable;
+    { stream.get_value() };
+};
+
+// Concept for piping
+struct _async_adaptor
+{
+};
+template<class T>
+concept async_adaptor = std::derived_from<std::decay_t<T>, _async_adaptor>;
+} // namespace concepts
+
+template<typename Adaptor, typename... Args>
+struct _partial : public concepts::_async_adaptor
+{
+    std::tuple<Args...> m_args;
+
+    constexpr _partial(int, Args&&... args) : m_args(std::forward<Args>(args)...) {}
+
+    template<concepts::async_streamable range_t>
+    constexpr auto operator()(range_t&& range) const&
+    {
+        auto forwarder = [&range](const auto&... args) { return Adaptor{}(std::forward<range_t>(range), args...); };
+        return std::apply(forwarder, m_args);
+    }
+
+    template<concepts::async_streamable range_t>
+    constexpr auto operator()(range_t&& range) &&
+    {
+        auto forwarder = [&range](auto&... args)
+        { return Adaptor{}(std::forward<range_t>(range), std::move(args)...); };
+        return std::apply(forwarder, m_args);
+    }
+
+    template<concepts::async_streamable range_t>
+    constexpr auto operator()(range_t&& range) const&& = delete;
+};
+
+template<concepts::async_adaptor Adaptor, class Range>
+constexpr auto operator|(Range&& rng, Adaptor&& partial)
+{
+    return std::forward<Adaptor>(partial)(std::forward<Range>(rng));
+}
+} // namespace coro::ranges

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -72,9 +72,9 @@ public:
     using coroutine_handle                         = std::coroutine_handle<promise<return_type>>;
     static constexpr bool return_type_is_reference = std::is_reference_v<return_type>;
     using stored_type                              = std::conditional_t<
-        return_type_is_reference,
-        std::remove_reference_t<return_type>*,
-        std::remove_const_t<return_type>>;
+                                     return_type_is_reference,
+                                     std::remove_reference_t<return_type>*,
+                                     std::remove_const_t<return_type>>;
     using variant_type = std::variant<unset_return_value, stored_type, std::exception_ptr>;
 
     promise() noexcept {}
@@ -87,9 +87,9 @@ public:
     auto get_return_object() noexcept -> task_type;
 
     template<typename value_type>
-    requires(return_type_is_reference and std::is_constructible_v<return_type, value_type&&>) or
-        (not return_type_is_reference and
-         std::is_constructible_v<stored_type, value_type&&>) auto return_value(value_type&& value) -> void
+        requires(return_type_is_reference and std::is_constructible_v<return_type, value_type &&>) or
+                (not return_type_is_reference and std::is_constructible_v<stored_type, value_type &&>)
+    auto return_value(value_type&& value) -> void
     {
         if constexpr (return_type_is_reference)
         {
@@ -102,7 +102,8 @@ public:
         }
     }
 
-    auto return_value(stored_type&& value) -> void requires(not return_type_is_reference)
+    auto return_value(stored_type&& value) -> void
+        requires(not return_type_is_reference)
     {
         if constexpr (std::is_move_constructible_v<stored_type>)
         {
@@ -229,10 +230,11 @@ private:
 
 } // namespace detail
 
-template<typename return_type>
+template<typename return_type_>
 class [[nodiscard]] task
 {
 public:
+    using return_type      = return_type_;
     using task_type        = task<return_type>;
     using promise_type     = detail::promise<return_type>;
     using coroutine_handle = std::coroutine_handle<promise_type>;

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -230,11 +230,10 @@ private:
 
 } // namespace detail
 
-template<typename return_type_>
+template<typename return_type>
 class [[nodiscard]] task
 {
 public:
-    using return_type      = return_type_;
     using task_type        = task<return_type>;
     using promise_type     = detail::promise<return_type>;
     using coroutine_handle = std::coroutine_handle<promise_type>;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIBCORO_TEST_SOURCE_FILES
         test_task_group.cpp
         test_thread_pool.cpp
         test_when_all.cpp
+        test_ranges.cpp
 
         catch_amalgamated.hpp catch_amalgamated.cpp
         catch_extensions.hpp catch_extensions.cpp
@@ -45,8 +46,6 @@ if (LIBCORO_FEATURE_NETWORKING)
             net/test_tcp_server.cpp
             net/test_tls_server.cpp
             net/test_udp_peers.cpp
-
-            test_ranges.cpp
     )
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBCORO_TEST_SOURCE_FILES
 
         catch_amalgamated.hpp catch_amalgamated.cpp
         catch_extensions.hpp catch_extensions.cpp
+        test_ranges.cpp
 )
 
 if (NOT EMSCRIPTEN)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,6 @@ set(LIBCORO_TEST_SOURCE_FILES
 
         catch_amalgamated.hpp catch_amalgamated.cpp
         catch_extensions.hpp catch_extensions.cpp
-        test_ranges.cpp
 )
 
 if (NOT EMSCRIPTEN)
@@ -46,6 +45,8 @@ if (LIBCORO_FEATURE_NETWORKING)
             net/test_tcp_server.cpp
             net/test_tls_server.cpp
             net/test_udp_peers.cpp
+
+            test_ranges.cpp
     )
 endif ()
 

--- a/test/catch_extensions.hpp
+++ b/test/catch_extensions.hpp
@@ -5,3 +5,5 @@
 extern std::mutex g_catch2_thread_safe_mutex;
 #define REQUIRE_THREAD_SAFE(expr) {std::lock_guard<std::mutex> lock_guard{g_catch2_thread_safe_mutex}; REQUIRE(expr);}
 #define REQUIRE_THAT_THREAD_SAFE(expr, that) {std::lock_guard<std::mutex> lock_guard{g_catch2_thread_safe_mutex}; REQUIRE_THAT(expr, that);}
+
+#define CHECK_THREAD_SAFE(expr) {std::lock_guard<std::mutex> lock_guard{g_catch2_thread_safe_mutex}; CHECK(expr);}

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,6 +1,9 @@
+#include "coro/ranges/join.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
 #include <coro/ranges/socket_stream.hpp>
+#include <coro/ranges/take_until.hpp>
+#include <coro/ranges/to.hpp>
 #include <iostream>
 
 TEST_CASE("", "[async_ranges]")
@@ -34,14 +37,18 @@ TEST_CASE("", "[async_ranges]")
         co_await client.connect();
         std::cerr << "client: connected\n";
 
-        auto data_task = coro::ranges::to_stream(client) |
-                         coro::ranges::take_until([](auto f) -> bool { return static_cast<int>(f) == 0; }) |
-                         coro::ranges::to_vector;
+        auto data_task = coro::ranges::to_stream(client) | coro::ranges::join() |
+                         coro::ranges::take_until([](auto f) -> bool { return false; }) |
+                         coro::ranges::to<std::vector<std::byte>>;
 
         auto data = co_await data_task;
         std::cerr << "client: received data\n";
 
         std::cerr << "Size: " << data.size() << '\n';
+
+        //        auto custom_socket = coro::ranges::to_stream(client1)
+        //                             | coro::ranges::transform(some_encryption_func)
+        //                             | coro::ranges::to_socket();
 
         for (auto&& b : data)
         {

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -56,45 +56,45 @@ constexpr auto only_upper =
 TEST_CASE("Stream to string", "[async_ranges]")
 {
     // clang-format off
-    auto [name, message, expected, pipeline_func] = GENERATE(
-        table<
-            std::string_view,
-            std::string_view,
-            std::string_view,
-            std::function<coro::task<std::string>(socket_stream ss)>>(
-            {
-                {"Simple pipe",
-                 "Hello world!",
-                 "Hello world!",
-                 [](auto ss) -> coro::task<std::string>
-                 { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+     auto [name, message, expected, pipeline_func] = GENERATE(
+         table<
+             std::string_view,
+             std::string_view,
+             std::string_view,
+             std::function<coro::task<std::string>(socket_stream ss)>>(
+             {
+                 {"Simple pipe",
+                  "Hello world!",
+                  "Hello world!",
+                  [](auto ss) -> coro::task<std::string>
+                  { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
 
-                {"Empty stream",
-                 "",
-                 "",
-                 [](auto ss) -> coro::task<std::string>
-                 { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+                 {"Empty stream",
+                  "",
+                  "",
+                  [](auto ss) -> coro::task<std::string>
+                  { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
 
-                {"Stop at null",
-                 "Part 1\0Part 2",
-                 "Part 1",
-                 [](auto ss) -> coro::task<std::string>
-                 {
-                     return std::move(ss) | coro::ranges::join | as_chars
-                            | until_zero
-                            | coro::ranges::to<std::string>;
-                 }},
+                 {"Stop at null",
+                  "Part 1\0Part 2",
+                  "Part 1",
+                  [](auto ss) -> coro::task<std::string>
+                  {
+                      return std::move(ss) | coro::ranges::join | as_chars
+                             | until_zero
+                             | coro::ranges::to<std::string>;
+                  }},
 
-                {"Transformation (Uppercase)",
-                 "libcoro",
-                 "LIBCORO",
-                 [](auto ss) -> coro::task<std::string>
-                 {
-                     return std::move(ss) | coro::ranges::join | as_chars
-                            | only_upper
-                            | coro::ranges::to<std::string>;
-                 }}
-            }));
+                 {"Transformation (Uppercase)",
+                  "libcoro",
+                  "LIBCORO",
+                  [](auto ss) -> coro::task<std::string>
+                  {
+                      return std::move(ss) | coro::ranges::join | as_chars
+                             | only_upper
+                             | coro::ranges::to<std::string>;
+                  }}
+             }));
     // clang-format on
 
     auto scheduler = coro::scheduler::make_unique();
@@ -134,14 +134,14 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         REQUIRE(client);
 
         // clang-format off
-        co_await (
-            msgs
-            | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
-                                          co_await client->write_all(msg);
-                                      })
-            | coro::ranges::await
-            | coro::ranges::drain
-        );
+         co_await (
+             msgs
+             | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
+                                           co_await client->write_all(msg);
+                                       })
+             | coro::ranges::await
+             | coro::ranges::drain
+         );
         // clang-format on
     }(scheduler, messages);
 
@@ -154,13 +154,13 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         REQUIRE(connect_status == coro::net::connect_status::connected);
 
         // clang-format off
-        std::string result = co_await (
-            client
-            | coro::ranges::with_buffer()
-            | coro::ranges::join
-            | as_chars
-            | coro::ranges::to<std::string>
-        );
+         std::string result = co_await (
+             client
+             | coro::ranges::with_buffer()
+             | coro::ranges::join
+             | as_chars
+             | coro::ranges::to<std::string>
+         );
         // clang-format on
 
         CHECK(result == "Helloworld!");
@@ -169,65 +169,70 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
     coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
 }
 
-// TEST_CASE("Partial reading", "[async_ranges]")
-//{
-//     auto                          scheduler = coro::scheduler::make_unique();
-//
-//     char msg1[] {"Hello"};
-//     char msg2[] {"world!"};
-//
-//     std::vector<std::span<char>> messages {std::span{msg1}, std::span{msg2}};
-//
-//     auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler,
-//                           std::span<std::span<char>>       msgs) -> coro::task<void>
-//     {
-//         co_await scheduler->schedule();
-//
-//         coro::net::tcp::server server{scheduler, local_address};
-//         auto                   client = co_await server.accept();
-//
-//         REQUIRE(client);
-//
-//         // clang-format off
-//         co_await (
-//             msgs
-//             | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
-//                                           co_await client->write_all(msg);
-//                                       })
-//             | coro::ranges::await
-//             | coro::ranges::drain
-//         );
-//         // clang-format on
-//     }(scheduler, messages);
-//
-//     auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
-//     {
-//         co_await scheduler->schedule();
-//
-//         coro::net::tcp::client client{scheduler, local_address};
-//         auto                   connect_status = co_await client.connect();
-//         REQUIRE(connect_status == coro::net::connect_status::connected);
-//
-//         auto buffered_stream = client | coro::ranges::with_buffer() | coro::ranges::join;
-//
-//         // clang-format off
-//         std::string hello = co_await (
-//             buffered_stream
-//             | as_chars | until_zero
-//             | coro::ranges::to<std::string>
-//         );
-//         CHECK(hello == "Hello");
-//
-//         std::string world = co_await (
-//             buffered_stream
-//             | as_chars | until_zero
-//             | coro::ranges::to<std::string>
-//         );
-//         CHECK(world == "world!");
-//
-//         std::cout << "client: got " << hello << world << '\n';
-//         // clang-format on
-//     }(scheduler);
-//
-//     coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
-// }
+TEST_CASE("Partial reading", "[async_ranges]")
+{
+    auto scheduler = coro::scheduler::make_unique();
+
+    char msg1[]{"Hello"};
+    char msg2[]{"world!"};
+
+    std::vector<std::span<char>> messages{std::span{msg1}, std::span{msg2}};
+
+    auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler,
+                          std::span<std::span<char>>        msgs) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        coro::net::tcp::server server{scheduler, local_address};
+        auto                   client = co_await server.accept();
+
+        REQUIRE(client);
+
+        // clang-format off
+         co_await (
+             msgs
+             | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
+                                           co_await client->write_all(msg);
+                                       })
+             | coro::ranges::await
+             | coro::ranges::drain
+         );
+        // clang-format on
+    }(scheduler, messages);
+
+    auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        coro::net::tcp::client client{scheduler, local_address};
+        auto                   connect_status = co_await client.connect();
+        REQUIRE(connect_status == coro::net::connect_status::connected);
+
+        // clang-format off
+        auto buffered_stream =
+            client // tcp::client
+            | coro::ranges::with_buffer(4096) // buffered reading
+            | coro::ranges::join; // byte by byte
+
+         std::string hello = co_await (
+             buffered_stream
+             | as_chars
+             | until_zero
+             | coro::ranges::to<std::string>
+         );
+         CHECK(hello == "Hello");
+
+         std::string world = co_await (
+             buffered_stream
+             | as_chars
+             | until_zero
+             | coro::ranges::to<std::string>
+         );
+         CHECK(world == "world!");
+
+         std::cout << "client: got " << hello << ' ' << world << '\n';
+        // clang-format on
+    }(scheduler);
+
+    coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
+}

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -12,10 +12,8 @@
 #include <iostream>
 
 auto make_server_task(
-    std::unique_ptr<coro::scheduler>& scheduler,
-    const coro::net::socket_address&  address,
-    std::string_view                  message,
-    coro::latch&                      latch) -> coro::task<void>
+    std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address, std::string_view message)
+    -> coro::task<void>
 {
     co_await scheduler->schedule();
 
@@ -29,7 +27,7 @@ auto make_server_task(
     REQUIRE_THAT_THREAD_SAFE(wstatus, IsOk());
     std::cerr << "server: sent message\n";
 
-    co_await scheduler->yield_for(std::chrono::milliseconds(20)); // wait a bit until client reads data
+    co_await scheduler->yield_for(std::chrono::milliseconds(50)); // wait a bit until client reads data
 }
 
 using socket_stream = coro::ranges::socket_stream<coro::net::tcp::client, std::vector<std::byte>>;
@@ -105,11 +103,10 @@ TEST_CASE("Stream to string", "[async_ranges]")
 
     DYNAMIC_SECTION(name)
     {
-        coro::latch l{2};
         std::cerr << "--- starting " << name << " ---\n";
-        auto server = make_server_task(scheduler, local_address, message, l);
+        auto server = make_server_task(scheduler, local_address, message);
 
-        auto client = [](auto&& sched, auto&& pipe, auto&& expectd, auto&& latch) -> coro::task<void>
+        auto client = [](auto&& sched, auto&& pipe, auto&& expectd) -> coro::task<void>
         {
             co_await sched->schedule();
 
@@ -118,7 +115,7 @@ TEST_CASE("Stream to string", "[async_ranges]")
             std::string result = co_await pipe(std::move(stream));
 
             CHECK_THREAD_SAFE(result == expectd);
-        }(scheduler, pipeline_func, expected, l);
+        }(scheduler, pipeline_func, expected);
 
         coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
         std::cerr << "--- ending " << name << " ---\n";

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -12,8 +12,10 @@
 #include <iostream>
 
 auto make_server_task(
-    std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address, std::string_view message)
-    -> coro::task<void>
+    std::unique_ptr<coro::scheduler>& scheduler,
+    const coro::net::socket_address&  address,
+    std::string_view                  message,
+    coro::latch&                      latch) -> coro::task<void>
 {
     co_await scheduler->schedule();
 
@@ -26,6 +28,8 @@ auto make_server_task(
     auto [wstatus, written] = co_await client->write_all(message);
     REQUIRE_THAT_THREAD_SAFE(wstatus, IsOk());
     std::cerr << "server: sent message\n";
+
+    co_await scheduler->yield_for(std::chrono::milliseconds(20)); // wait a bit until client reads data
 }
 
 using socket_stream = coro::ranges::socket_stream<coro::net::tcp::client, std::vector<std::byte>>;
@@ -56,54 +60,56 @@ constexpr auto only_upper =
 TEST_CASE("Stream to string", "[async_ranges]")
 {
     // clang-format off
-     auto [name, message, expected, pipeline_func] = GENERATE(
-         table<
-             std::string_view,
-             std::string_view,
-             std::string_view,
-             std::function<coro::task<std::string>(socket_stream ss)>>(
-             {
-                 {"Simple pipe",
-                  "Hello world!",
-                  "Hello world!",
-                  [](auto ss) -> coro::task<std::string>
-                  { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+      auto [name, message, expected, pipeline_func] = GENERATE(
+          table<
+              std::string_view,
+              std::string_view,
+              std::string_view,
+              std::function<coro::task<std::string>(socket_stream ss)>>(
+              {
+                  {"Simple pipe",
+                   "Hello world!",
+                   "Hello world!",
+                   [](auto ss) -> coro::task<std::string>
+                   { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
 
-                 {"Empty stream",
-                  "",
-                  "",
-                  [](auto ss) -> coro::task<std::string>
-                  { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+                  {"Empty stream",
+                   "",
+                   "",
+                   [](auto ss) -> coro::task<std::string>
+                   { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
 
-                 {"Stop at null",
-                  "Part 1\0Part 2",
-                  "Part 1",
-                  [](auto ss) -> coro::task<std::string>
-                  {
-                      return std::move(ss) | coro::ranges::join | as_chars
-                             | until_zero
-                             | coro::ranges::to<std::string>;
-                  }},
+                  {"Stop at null",
+                   "Part 1\0Part 2",
+                   "Part 1",
+                   [](auto ss) -> coro::task<std::string>
+                   {
+                       return std::move(ss) | coro::ranges::join | as_chars
+                              | until_zero
+                              | coro::ranges::to<std::string>;
+                   }},
 
-                 {"Transformation (Uppercase)",
-                  "libcoro",
-                  "LIBCORO",
-                  [](auto ss) -> coro::task<std::string>
-                  {
-                      return std::move(ss) | coro::ranges::join | as_chars
-                             | only_upper
-                             | coro::ranges::to<std::string>;
-                  }}
-             }));
+                  {"Transformation (Uppercase)",
+                   "libcoro",
+                   "LIBCORO",
+                   [](auto ss) -> coro::task<std::string>
+                   {
+                       return std::move(ss) | coro::ranges::join | as_chars
+                              | only_upper
+                              | coro::ranges::to<std::string>;
+                   }}
+              }));
     // clang-format on
 
     auto scheduler = coro::scheduler::make_unique();
 
     DYNAMIC_SECTION(name)
     {
-        auto server = make_server_task(scheduler, local_address, message);
+        coro::latch l{2};
+        std::cerr << "--- starting " << name << " ---\n";
+        auto server = make_server_task(scheduler, local_address, message, l);
 
-        auto client = [](auto&& sched, auto&& pipe, auto&& expectd) -> coro::task<void>
+        auto client = [](auto&& sched, auto&& pipe, auto&& expectd, auto&& latch) -> coro::task<void>
         {
             co_await sched->schedule();
 
@@ -112,9 +118,10 @@ TEST_CASE("Stream to string", "[async_ranges]")
             std::string result = co_await pipe(std::move(stream));
 
             CHECK_THREAD_SAFE(result == expectd);
-        }(scheduler, pipeline_func, expected);
+        }(scheduler, pipeline_func, expected, l);
 
         coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
+        std::cerr << "--- ending " << name << " ---\n";
     }
 }
 
@@ -134,14 +141,14 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         REQUIRE(client);
 
         // clang-format off
-         co_await (
-             msgs
-             | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
-                                           co_await client->write_all(msg);
-                                       })
-             | coro::ranges::await
-             | coro::ranges::drain
-         );
+          co_await (
+              msgs
+              | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
+                                            co_await client->write_all(msg);
+                                        })
+              | coro::ranges::await
+              | coro::ranges::drain
+          );
         // clang-format on
     }(scheduler, messages);
 
@@ -154,13 +161,13 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         REQUIRE(connect_status == coro::net::connect_status::connected);
 
         // clang-format off
-         std::string result = co_await (
-             client
-             | coro::ranges::with_buffer()
-             | coro::ranges::join
-             | as_chars
-             | coro::ranges::to<std::string>
-         );
+          std::string result = co_await (
+              client
+              | coro::ranges::with_buffer()
+              | coro::ranges::join
+              | as_chars
+              | coro::ranges::to<std::string>
+          );
         // clang-format on
 
         CHECK(result == "Helloworld!");

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,3 +1,5 @@
+#include "coro/ranges/await.hpp"
+#include "coro/ranges/drain.hpp"
 #include "coro/ranges/join.hpp"
 #include "coro/ranges/take_until.hpp"
 #include "coro/ranges/transform.hpp"
@@ -37,8 +39,10 @@ auto make_client_stream(std::unique_ptr<coro::scheduler>& scheduler, const coro:
     REQUIRE(cstatus == coro::net::connect_status::connected);
     std::cerr << "client: connected\n";
 
-    co_return coro::ranges::to_chunked_stream(std::move(client));
+    co_return std::move(client) | coro::ranges::with_buffer();
 }
+
+static auto local_address = coro::net::socket_address{"127.0.0.1", 8080};
 
 // Helper adaptors
 constexpr auto as_chars   = coro::ranges::transform([](auto byte) { return static_cast<char>(byte); });
@@ -48,8 +52,6 @@ constexpr auto only_upper =
 
 TEST_CASE("Stream to string", "[async_ranges]")
 {
-    static auto address = coro::net::socket_address{"127.0.0.1", 8080};
-
     // clang-format off
     auto [name, message, expected, pipeline_func] = GENERATE(
         table<
@@ -96,13 +98,13 @@ TEST_CASE("Stream to string", "[async_ranges]")
 
     DYNAMIC_SECTION(name)
     {
-        auto server = make_server_task(scheduler, address, message);
+        auto server = make_server_task(scheduler, local_address, message);
 
         auto client = [&](std::unique_ptr<coro::scheduler>& sched) -> coro::task<void>
         {
             co_await sched->schedule();
 
-            auto stream = co_await make_client_stream(sched, address);
+            auto stream = co_await make_client_stream(sched, local_address);
 
             std::string result = co_await pipeline_func(std::move(stream));
 
@@ -112,3 +114,117 @@ TEST_CASE("Stream to string", "[async_ranges]")
         coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
     }
 }
+
+TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
+{
+    auto                          scheduler = coro::scheduler::make_unique();
+    std::vector<std::string_view> messages  = {"Hello", "world!"};
+
+    auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler,
+                          std::span<std::string_view>       msgs) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        coro::net::tcp::server server{scheduler, local_address};
+        auto                   client = co_await server.accept();
+
+        REQUIRE(client);
+
+        // clang-format off
+        co_await (
+            msgs
+            | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
+                                          co_await client->write_all(msg);
+                                      })
+            | coro::ranges::await
+            | coro::ranges::drain
+        );
+        // clang-format on
+    }(scheduler, messages);
+
+    auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        coro::net::tcp::client client{scheduler, local_address};
+        auto                   connect_status = co_await client.connect();
+        REQUIRE(connect_status == coro::net::connect_status::connected);
+
+        // clang-format off
+        std::string result = co_await (
+            client
+            | coro::ranges::with_buffer()
+            | coro::ranges::join
+            | as_chars
+            | coro::ranges::to<std::string>
+        );
+        // clang-format on
+
+        CHECK(result == "Helloworld!");
+    }(scheduler);
+
+    coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
+}
+
+// TEST_CASE("Partial reading", "[async_ranges]")
+//{
+//     auto                          scheduler = coro::scheduler::make_unique();
+//
+//     char msg1[] {"Hello"};
+//     char msg2[] {"world!"};
+//
+//     std::vector<std::span<char>> messages {std::span{msg1}, std::span{msg2}};
+//
+//     auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler,
+//                           std::span<std::span<char>>       msgs) -> coro::task<void>
+//     {
+//         co_await scheduler->schedule();
+//
+//         coro::net::tcp::server server{scheduler, local_address};
+//         auto                   client = co_await server.accept();
+//
+//         REQUIRE(client);
+//
+//         // clang-format off
+//         co_await (
+//             msgs
+//             | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
+//                                           co_await client->write_all(msg);
+//                                       })
+//             | coro::ranges::await
+//             | coro::ranges::drain
+//         );
+//         // clang-format on
+//     }(scheduler, messages);
+//
+//     auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+//     {
+//         co_await scheduler->schedule();
+//
+//         coro::net::tcp::client client{scheduler, local_address};
+//         auto                   connect_status = co_await client.connect();
+//         REQUIRE(connect_status == coro::net::connect_status::connected);
+//
+//         auto buffered_stream = client | coro::ranges::with_buffer() | coro::ranges::join;
+//
+//         // clang-format off
+//         std::string hello = co_await (
+//             buffered_stream
+//             | as_chars | until_zero
+//             | coro::ranges::to<std::string>
+//         );
+//         CHECK(hello == "Hello");
+//
+//         std::string world = co_await (
+//             buffered_stream
+//             | as_chars | until_zero
+//             | coro::ranges::to<std::string>
+//         );
+//         CHECK(world == "world!");
+//
+//         std::cout << "client: got " << hello << world << '\n';
+//         // clang-format on
+//     }(scheduler);
+//
+//     coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
+// }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,0 +1,53 @@
+#include <catch_amalgamated.hpp>
+#include <coro/coro.hpp>
+#include <coro/ranges/socket_stream.hpp>
+#include <iostream>
+
+TEST_CASE("", "[async_ranges]")
+{
+    auto scheduler = coro::scheduler::make_unique();
+
+    auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        auto server = coro::net::tcp::server{scheduler, {"127.0.0.1", 8080}};
+
+        auto client = co_await server.accept();
+        std::cerr << "server: accepted client\n";
+
+        if (not client)
+        {
+            throw std::runtime_error(client.error().message());
+        }
+
+        std::string data{"Hello!"};
+        co_await client->write_all(data);
+        std::cerr << "server: sent message\n";
+    };
+    auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+    {
+        co_await scheduler->schedule();
+
+        auto client = coro::net::tcp::client{scheduler, {"127.0.0.1", 8080}};
+
+        co_await client.connect();
+        std::cerr << "client: connected\n";
+
+        auto data_task = coro::ranges::to_stream(client) |
+                         coro::ranges::take_until([](auto f) -> bool { return static_cast<int>(f) == 0; }) |
+                         coro::ranges::to_vector;
+
+        auto data = co_await data_task;
+        std::cerr << "client: received data\n";
+
+        std::cerr << "Size: " << data.size() << '\n';
+
+        for (auto&& b : data)
+        {
+            std::cerr << static_cast<int>(b) << ' ';
+        }
+    };
+
+    coro::sync_wait(coro::when_all(server_task(scheduler), client_task(scheduler)));
+}

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,3 +1,4 @@
+#include "catch_extensions.hpp"
 #include "coro/ranges/await.hpp"
 #include "coro/ranges/drain.hpp"
 #include "coro/ranges/join.hpp"
@@ -19,11 +20,11 @@ auto make_server_task(
     auto server = coro::net::tcp::server(scheduler, address);
 
     auto client = co_await server.accept();
-    REQUIRE(client);
+    REQUIRE_THREAD_SAFE(client);
     std::cerr << "server: accepted\n";
 
     auto [wstatus, written] = co_await client->write_all(message);
-    REQUIRE_THAT(wstatus, IsOk());
+    REQUIRE_THAT_THREAD_SAFE(wstatus, IsOk());
     std::cerr << "server: sent message\n";
 }
 
@@ -35,8 +36,10 @@ auto make_client_stream(std::unique_ptr<coro::scheduler>& scheduler, const coro:
     co_await scheduler->schedule();
     auto client = coro::net::tcp::client{scheduler, address};
 
+    co_await scheduler->yield_for(std::chrono::milliseconds(20)); // wait a bit until server wakes up
+
     auto cstatus = co_await client.connect();
-    REQUIRE(cstatus == coro::net::connect_status::connected);
+    REQUIRE_THREAD_SAFE(cstatus == coro::net::connect_status::connected);
     std::cerr << "client: connected\n";
 
     co_return std::move(client) | coro::ranges::with_buffer();
@@ -100,16 +103,16 @@ TEST_CASE("Stream to string", "[async_ranges]")
     {
         auto server = make_server_task(scheduler, local_address, message);
 
-        auto client = [&](std::unique_ptr<coro::scheduler>& sched) -> coro::task<void>
+        auto client = [](auto&& sched, auto&& pipe, auto&& expectd) -> coro::task<void>
         {
             co_await sched->schedule();
 
             auto stream = co_await make_client_stream(sched, local_address);
 
-            std::string result = co_await pipeline_func(std::move(stream));
+            std::string result = co_await pipe(std::move(stream));
 
-            CHECK(result == expected);
-        }(scheduler);
+            CHECK_THREAD_SAFE(result == expectd);
+        }(scheduler, pipeline_func, expected);
 
         coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
     }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,4 +1,5 @@
 #include "coro/ranges/join.hpp"
+#include "coro/ranges/transform.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
 #include <coro/ranges/socket_stream.hpp>
@@ -38,16 +39,14 @@ TEST_CASE("", "[async_ranges]")
         std::cerr << "client: connected\n";
 
         auto result = co_await (
-            coro::ranges::to_chunked_stream(client) | coro::ranges::join() |
-            coro::ranges::take_until([](auto f) -> bool { return static_cast<char>(f) == '0'; }) |
-            coro::ranges::to<std::vector<std::byte>>);
+            coro::ranges::to_chunked_stream(client) | coro::ranges::join |
+            coro::ranges::transform([](auto f) { return static_cast<char>(f); }) |
+            coro::ranges::take_until([](auto f) { return static_cast<char>(f) == '0'; }) |
+            coro::ranges::to<std::string>);
 
         std::cerr << "client: received data\n";
 
-        for (auto&& b : result)
-        {
-            std::cerr << static_cast<int>(b) << ' ';
-        }
+        std::cerr << result << ' ';
     };
 
     coro::sync_wait(coro::when_all(server_task(scheduler), client_task(scheduler)));

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,5 +1,6 @@
 #include "coro/ranges/join.hpp"
 #include "coro/ranges/transform.hpp"
+#include "net/catch_net_extensions.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
 #include <coro/ranges/socket_stream.hpp>
@@ -7,47 +8,58 @@
 #include <coro/ranges/to.hpp>
 #include <iostream>
 
-TEST_CASE("", "[async_ranges]")
+auto make_server_task(
+    std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address, std::string_view message)
+    -> coro::task<void>
 {
+    co_await scheduler->schedule();
+
+    auto server = coro::net::tcp::server(scheduler, address);
+
+    auto client = co_await server.accept();
+    REQUIRE(client);
+    std::cerr << "server: accepted\n";
+
+    auto [wstatus, written] = co_await client->write_all(message);
+    REQUIRE_THAT(wstatus, IsOk());
+    std::cerr << "server: sent message\n";
+}
+
+auto make_client_stream(std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address)
+    -> coro::task<coro::ranges::socket_stream<coro::net::tcp::client, std::vector<std::byte>>>
+{
+    co_await scheduler->schedule();
+    auto client = coro::net::tcp::client{scheduler, address};
+
+    auto cstatus = co_await client.connect();
+    REQUIRE(cstatus == coro::net::connect_status::connected);
+    std::cerr << "client: connected\n";
+
+    co_return coro::ranges::to_chunked_stream(std::move(client));
+}
+
+TEST_CASE("Stream to string", "[async_ranges]")
+{
+    static auto address = coro::net::socket_address{"127.0.0.1", 8080};
+
+    auto [message, expected] = GENERATE(table<std::string_view, std::string_view>({{"Hello world!", "Hello world!"}}));
+
     auto scheduler = coro::scheduler::make_unique();
 
-    auto server_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
+    auto server = make_server_task(scheduler, address, message);
+
+    auto client = [](std::unique_ptr<coro::scheduler>& scheduler, std::string_view message) -> coro::task<void>
     {
         co_await scheduler->schedule();
+        auto stream = co_await make_client_stream(scheduler, address);
 
-        auto server = coro::net::tcp::server{scheduler, {"127.0.0.1", 8080}};
+        auto pipeline = std::move(stream) | coro::ranges::join |
+                        coro::ranges::transform([](auto byte) { return static_cast<char>(byte); }) |
+                        coro::ranges::to<std::string>;
 
-        auto client = co_await server.accept();
-        std::cerr << "server: accepted client\n";
+        auto result = co_await pipeline;
+        CHECK(result == message);
+    }(scheduler, expected);
 
-        if (not client)
-        {
-            throw std::runtime_error(client.error().message());
-        }
-
-        std::string data{"Hello!\0 Hidden"};
-        co_await client->write_all(data);
-        std::cerr << "server: sent message\n";
-    };
-    auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
-    {
-        co_await scheduler->schedule();
-
-        auto client = coro::net::tcp::client{scheduler, {"127.0.0.1", 8080}};
-
-        co_await client.connect();
-        std::cerr << "client: connected\n";
-
-        auto result = co_await (
-            coro::ranges::to_chunked_stream(client) | coro::ranges::join |
-            coro::ranges::transform([](auto f) { return static_cast<char>(f); }) |
-            coro::ranges::take_until([](auto f) { return static_cast<char>(f) == '0'; }) |
-            coro::ranges::to<std::string>);
-
-        std::cerr << "client: received data\n";
-
-        std::cerr << result << ' ';
-    };
-
-    coro::sync_wait(coro::when_all(server_task(scheduler), client_task(scheduler)));
+    coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
 }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -24,7 +24,7 @@ TEST_CASE("", "[async_ranges]")
             throw std::runtime_error(client.error().message());
         }
 
-        std::string data{"Hello!"};
+        std::string data{"Hello!\0 Hidden"};
         co_await client->write_all(data);
         std::cerr << "server: sent message\n";
     };
@@ -37,20 +37,14 @@ TEST_CASE("", "[async_ranges]")
         co_await client.connect();
         std::cerr << "client: connected\n";
 
-        auto data_task = coro::ranges::to_stream(client) | coro::ranges::join() |
-                         coro::ranges::take_until([](auto f) -> bool { return false; }) |
-                         coro::ranges::to<std::vector<std::byte>>;
+        auto result = co_await (
+            coro::ranges::to_chunked_stream(client) | coro::ranges::join() |
+            coro::ranges::take_until([](auto f) -> bool { return static_cast<char>(f) == '0'; }) |
+            coro::ranges::to<std::vector<std::byte>>);
 
-        auto data = co_await data_task;
         std::cerr << "client: received data\n";
 
-        std::cerr << "Size: " << data.size() << '\n';
-
-        //        auto custom_socket = coro::ranges::to_stream(client1)
-        //                             | coro::ranges::transform(some_encryption_func)
-        //                             | coro::ranges::to_socket();
-
-        for (auto&& b : data)
+        for (auto&& b : result)
         {
             std::cerr << static_cast<int>(b) << ' ';
         }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -4,14 +4,15 @@
 #include "coro/ranges/join.hpp"
 #include "coro/ranges/take_until.hpp"
 #include "coro/ranges/transform.hpp"
-#include "net/catch_net_extensions.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
-#include <coro/ranges/socket_stream.hpp>
 #include <coro/ranges/to.hpp>
 #include <iostream>
 
 #ifdef LIBCORO_FEATURE_NETWORKING
+    #include "net/catch_net_extensions.hpp"
+    #include <coro/ranges/socket_stream.hpp>
+
 auto make_server_task(
     std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address, std::string_view message)
     -> coro::task<void>

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,10 +1,10 @@
 #include "coro/ranges/join.hpp"
+#include "coro/ranges/take_until.hpp"
 #include "coro/ranges/transform.hpp"
 #include "net/catch_net_extensions.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
 #include <coro/ranges/socket_stream.hpp>
-#include <coro/ranges/take_until.hpp>
 #include <coro/ranges/to.hpp>
 #include <iostream>
 
@@ -25,8 +25,10 @@ auto make_server_task(
     std::cerr << "server: sent message\n";
 }
 
+using socket_stream = coro::ranges::socket_stream<coro::net::tcp::client, std::vector<std::byte>>;
+
 auto make_client_stream(std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address)
-    -> coro::task<coro::ranges::socket_stream<coro::net::tcp::client, std::vector<std::byte>>>
+    -> coro::task<socket_stream>
 {
     co_await scheduler->schedule();
     auto client = coro::net::tcp::client{scheduler, address};
@@ -38,28 +40,75 @@ auto make_client_stream(std::unique_ptr<coro::scheduler>& scheduler, const coro:
     co_return coro::ranges::to_chunked_stream(std::move(client));
 }
 
+// Helper adaptors
+constexpr auto as_chars   = coro::ranges::transform([](auto byte) { return static_cast<char>(byte); });
+constexpr auto until_zero = coro::ranges::take_until([](auto byte) { return static_cast<int>(byte) == 0; });
+constexpr auto only_upper =
+    coro::ranges::transform([](char c) { return (c >= 'a' && c <= 'z') ? static_cast<char>(c - 32) : c; });
+
 TEST_CASE("Stream to string", "[async_ranges]")
 {
     static auto address = coro::net::socket_address{"127.0.0.1", 8080};
 
-    auto [message, expected] = GENERATE(table<std::string_view, std::string_view>({{"Hello world!", "Hello world!"}}));
+    // clang-format off
+    auto [name, message, expected, pipeline_func] = GENERATE(
+        table<
+            std::string_view,
+            std::string_view,
+            std::string_view,
+            std::function<coro::task<std::string>(socket_stream ss)>>(
+            {
+                {"Simple pipe",
+                 "Hello world!",
+                 "Hello world!",
+                 [](auto ss) -> coro::task<std::string>
+                 { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+
+                {"Empty stream",
+                 "",
+                 "",
+                 [](auto ss) -> coro::task<std::string>
+                 { return std::move(ss) | coro::ranges::join | as_chars | coro::ranges::to<std::string>; }},
+
+                {"Stop at null",
+                 "Part 1\0Part 2",
+                 "Part 1",
+                 [](auto ss) -> coro::task<std::string>
+                 {
+                     return std::move(ss) | coro::ranges::join | as_chars
+                            | until_zero
+                            | coro::ranges::to<std::string>;
+                 }},
+
+                {"Transformation (Uppercase)",
+                 "libcoro",
+                 "LIBCORO",
+                 [](auto ss) -> coro::task<std::string>
+                 {
+                     return std::move(ss) | coro::ranges::join | as_chars
+                            | only_upper
+                            | coro::ranges::to<std::string>;
+                 }}
+            }));
+    // clang-format on
 
     auto scheduler = coro::scheduler::make_unique();
 
-    auto server = make_server_task(scheduler, address, message);
-
-    auto client = [](std::unique_ptr<coro::scheduler>& scheduler, std::string_view message) -> coro::task<void>
+    DYNAMIC_SECTION(name)
     {
-        co_await scheduler->schedule();
-        auto stream = co_await make_client_stream(scheduler, address);
+        auto server = make_server_task(scheduler, address, message);
 
-        auto pipeline = std::move(stream) | coro::ranges::join |
-                        coro::ranges::transform([](auto byte) { return static_cast<char>(byte); }) |
-                        coro::ranges::to<std::string>;
+        auto client = [&](std::unique_ptr<coro::scheduler>& sched) -> coro::task<void>
+        {
+            co_await sched->schedule();
 
-        auto result = co_await pipeline;
-        CHECK(result == message);
-    }(scheduler, expected);
+            auto stream = co_await make_client_stream(sched, address);
 
-    coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
+            std::string result = co_await pipeline_func(std::move(stream));
+
+            CHECK(result == expected);
+        }(scheduler);
+
+        coro::sync_wait(coro::when_all(std::move(server), std::move(client)));
+    }
 }

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -11,6 +11,7 @@
 #include <coro/ranges/to.hpp>
 #include <iostream>
 
+#ifdef LIBCORO_FEATURE_NETWORKING
 auto make_server_task(
     std::unique_ptr<coro::scheduler>& scheduler, const coro::net::socket_address& address, std::string_view message)
     -> coro::task<void>
@@ -138,15 +139,18 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         REQUIRE(client);
 
         // clang-format off
-          co_await (
-              msgs
-              | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
+        co_await (
+            msgs // Sync stream
+            | coro::ranges::transform([&](std::string_view msg) -> coro::task<void> {
                                             co_await client->write_all(msg);
-                                        })
-              | coro::ranges::await
-              | coro::ranges::drain
-          );
+                                        }) // Creating tasks
+            | coro::ranges::await // co_awaiting them
+            | coro::ranges::drain // Making the whole pipe a single task
+        );
         // clang-format on
+
+        // let the client catch up (BSD only)
+        co_await scheduler->yield_for(std::chrono::milliseconds{40});
     }(scheduler, messages);
 
     auto client_task = [](std::unique_ptr<coro::scheduler>& scheduler) -> coro::task<void>
@@ -157,15 +161,34 @@ TEST_CASE("Sync stream to TCP pipeline", "[async_ranges]")
         auto                   connect_status = co_await client.connect();
         REQUIRE(connect_status == coro::net::connect_status::connected);
 
-        // clang-format off
-          std::string result = co_await (
-              client
-              | coro::ranges::with_buffer()
-              | coro::ranges::join
-              | as_chars
-              | coro::ranges::to<std::string>
-          );
-        // clang-format on
+        std::string result;
+
+        SECTION("Dynamic buffer")
+        {
+            // clang-format off
+            result = co_await (
+                client
+                | coro::ranges::with_buffer()
+                | coro::ranges::join
+                | as_chars
+                | coro::ranges::to<std::string>
+            );
+            // clang-format on
+        }
+
+        SECTION("Custom buffer")
+        {
+            std::array<char, 4096> buffer{};
+            // clang-format off
+            result = co_await (
+                client
+                | coro::ranges::with_buffer(std::as_writable_bytes(std::span{buffer}))
+                | coro::ranges::join
+                | as_chars
+                | coro::ranges::to<std::string>
+            );
+            // clang-format on
+        }
 
         CHECK(result == "Helloworld!");
     }(scheduler);
@@ -234,3 +257,5 @@ TEST_CASE("Partial reading", "[async_ranges]")
 
     coro::sync_wait(coro::when_all(std::move(server_task), std::move(client_task)));
 }
+
+#endif

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -1,13 +1,236 @@
 #include "catch_extensions.hpp"
 #include "coro/ranges/await.hpp"
 #include "coro/ranges/drain.hpp"
+#include "coro/ranges/filter.hpp"
 #include "coro/ranges/join.hpp"
+#include "coro/ranges/take.hpp"
 #include "coro/ranges/take_until.hpp"
 #include "coro/ranges/transform.hpp"
 #include <catch_amalgamated.hpp>
 #include <coro/coro.hpp>
 #include <coro/ranges/to.hpp>
 #include <iostream>
+
+TEST_CASE("coro::ranges::take_until basic", "[async_ranges]")
+{
+    std::vector<int> input = {1, 2, 3, 4, 5, 6};
+
+    // Take until we hit 4
+    // 4 should be excluded
+    auto task = input | coro::ranges::take_until([](int i) { return i == 4; }) | coro::ranges::to<std::vector<int>>;
+
+    auto result = coro::sync_wait(task);
+
+    CHECK(result == std::vector{1, 2, 3});
+}
+
+TEST_CASE("coro::ranges::take basic", "[async_ranges]")
+{
+    std::vector<int>  input = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    const std::size_t limit = 4;
+
+    auto task = input | coro::ranges::take(limit) | coro::ranges::to<std::vector<int>>;
+
+    auto result = coro::sync_wait(task);
+
+    CHECK(result.size() == limit);
+    CHECK(result == std::vector{1, 2, 3, 4});
+}
+
+TEST_CASE("coro::ranges::take boundary conditions", "[async_ranges]")
+{
+    std::vector<int> input = {1, 2, 3};
+
+    auto [name, n, expected_size] = GENERATE(
+        table<std::string, std::size_t, std::size_t>(
+            {{"take zero", 0, 0}, {"take exact", 3, 3}, {"take more", 5, 3}, {"take one", 1, 1}}));
+
+    DYNAMIC_SECTION("Testing: " << name)
+    {
+        auto task = input | coro::ranges::take(n) | coro::ranges::to<std::vector<int>>;
+
+        auto result = coro::sync_wait(task);
+        CHECK(result.size() == expected_size);
+    }
+}
+
+TEST_CASE("coro::ranges::transform basic", "[async_ranges]")
+{
+    std::vector<int> input = {1, 2, 3, 4, 5};
+
+    auto task = input | coro::ranges::transform([](int i) { return i * 2; }) | coro::ranges::to<std::vector<int>>;
+
+    auto result = coro::sync_wait(task);
+
+    CHECK(result == std::vector{2, 4, 6, 8, 10});
+}
+
+TEST_CASE("coro::ranges::transform", "[async_ranges]")
+{
+    auto [name, input, expected] = GENERATE(
+        table<std::string, std::vector<int>, std::vector<std::string>>(
+            {{"multiple elements", {1, 2, 3}, {"1", "2", "3"}},
+             {"empty stream", {}, {}},
+             {"single element", {42}, {"42"}}}));
+
+    DYNAMIC_SECTION("Testing: " << name)
+    {
+        auto task = input | coro::ranges::transform([](int i) { return std::to_string(i); }) |
+                    coro::ranges::to<std::vector<std::string>>;
+
+        auto result = coro::sync_wait(task);
+        CHECK(result == expected);
+    }
+}
+
+TEST_CASE("coro::ranges::transform with capture", "[async_ranges]")
+{
+    std::vector<int> input       = {10, 10, 10};
+    int              running_sum = 0;
+
+    auto task = input |
+                coro::ranges::transform(
+                    [&running_sum](int i)
+                    {
+                        running_sum += i;
+                        return running_sum;
+                    }) |
+                coro::ranges::to<std::vector<int>>;
+
+    auto result = coro::sync_wait(task);
+
+    CHECK(result == std::vector{10, 20, 30});
+    CHECK(running_sum == 30);
+}
+
+// TEST_CASE("coro::ranges::transform returning references", "[async_ranges]") {
+//     struct Point { int x; int y; };
+//     std::vector<Point> points = {{1, 2}, {3, 4}};
+//
+//     auto task = points
+//                 | coro::ranges::transform([](Point& p) -> int& { return p.x; })
+//                 | coro::ranges::transform([](int& x) { x += 1; });
+//
+//     coro::sync_wait(task | coro::ranges::drain);
+//
+//     CHECK(points[0].x == 2);
+//     CHECK(points[1].x == 4);
+// }
+
+TEST_CASE("coro::ranges::await with value tasks", "[async_ranges]")
+{
+    // A simple function that returns a task
+    auto make_task = [](int val) -> coro::task<int> { co_return val * 2; };
+
+    std::vector<int> inputs = {1, 2, 3};
+
+    auto task_stream = inputs | coro::ranges::transform(make_task);
+
+    auto result_task = task_stream | coro::ranges::await | coro::ranges::to<std::vector<int>>;
+
+    auto results = coro::sync_wait(result_task);
+
+    std::vector<int> expected = {2, 4, 6};
+    CHECK(results == expected);
+}
+
+TEST_CASE("coro::ranges::await with void tasks", "[async_ranges]")
+{
+    int execution_count = 0;
+
+    auto make_void_task = [&](int) -> coro::task<void>
+    {
+        execution_count++;
+        co_return;
+    };
+
+    std::vector<int> inputs = {1, 2, 3, 4, 5};
+
+    auto pipeline = inputs | coro::ranges::transform(make_void_task) | coro::ranges::await;
+
+    coro::sync_wait(pipeline | coro::ranges::drain);
+
+    CHECK(execution_count == 5);
+}
+
+TEST_CASE("coro::ranges::await empty stream", "[async_ranges]")
+{
+    std::vector<coro::task<int>> empty_input;
+
+    auto result_task = empty_input | coro::ranges::await | coro::ranges::to<std::vector<int>>;
+
+    auto results = coro::sync_wait(result_task);
+
+    CHECK(results.empty());
+}
+
+TEST_CASE("coro::ranges::drain", "[async_ranges]")
+{
+    // To verify how many elements were processed
+    std::size_t processed_count = 0;
+
+    auto [name, input_size] =
+        GENERATE(table<std::string, size_t>({{"empty stream", 0}, {"small stream", 5}, {"large stream", 100}}));
+
+    DYNAMIC_SECTION("Draining a " << name)
+    {
+        std::vector<int> data(input_size, 1);
+
+        auto stream = data | coro::ranges::transform(
+                                 [&](int)
+                                 {
+                                     processed_count++;
+                                     return 0; // dummy value
+                                 });
+
+        coro::sync_wait(stream | coro::ranges::drain);
+
+        CHECK(processed_count == input_size);
+    }
+}
+
+TEST_CASE("coro::ranges::join", "[async_ranges]")
+{
+    using TestData = std::vector<std::vector<int>>;
+
+    auto [name, input_chunks, expected] = GENERATE(
+        table<std::string, TestData, std::vector<int>>(
+            {{"standard chunks", {{1, 2}, {3, 4}, {5}}, {1, 2, 3, 4, 5}},
+             {"empty chunks in between", {{1}, {}, {2, 3}, {}, {4}}, {1, 2, 3, 4}},
+             {"all empty chunks", {{}, {}, {}}, {}},
+             {"single large chunk", {{10, 20, 30, 40}}, {10, 20, 30, 40}}}));
+
+    DYNAMIC_SECTION("Joining " << name)
+    {
+        auto joined_task = input_chunks | coro::ranges::join | coro::ranges::to<std::vector<int>>;
+
+        auto result = coro::sync_wait(joined_task);
+        CHECK(result == expected);
+    }
+}
+
+TEST_CASE("coro::ranges::filter", "[async_ranges]")
+{
+    std::vector input = {1, 2, 3, 4, 5, 6, 7, 8};
+
+    auto [name, predicate] = GENERATE(
+        table<std::string, std::function<bool(int)>>(
+            {{"even numbers", [](int i) { return i % 2 == 0; }},
+             {"odd numbers", [](int i) { return i % 2 != 0; }},
+             {"greater than 5", [](int i) { return i > 5; }}}));
+
+    DYNAMIC_SECTION("Filtering for " << name)
+    {
+        auto             expected_view = input | std::views::filter(predicate);
+        std::vector<int> expected(expected_view.begin(), expected_view.end());
+
+        auto task = input | coro::ranges::filter(predicate) | coro::ranges::to<std::vector<int>>;
+
+        auto result = coro::sync_wait(task);
+
+        CHECK(std::ranges::equal(expected, result));
+    }
+}
 
 #ifdef LIBCORO_FEATURE_NETWORKING
     #include "net/catch_net_extensions.hpp"
@@ -218,7 +441,7 @@ TEST_CASE("Partial reading", "[async_ranges]")
 
         // clang-format off
         auto pipe = msgs
-            | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
+            | coro::ranges::transform([&](auto msg) -> coro::task<void> {
                                           co_await client->write_all(msg);
                                       })
             | coro::ranges::await

--- a/test/test_ranges.cpp
+++ b/test/test_ranges.cpp
@@ -193,14 +193,14 @@ TEST_CASE("Partial reading", "[async_ranges]")
         REQUIRE(client);
 
         // clang-format off
-         co_await (
-             msgs
-             | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
-                                           co_await client->write_all(msg);
-                                       })
-             | coro::ranges::await
-             | coro::ranges::drain
-         );
+        auto pipe = msgs
+            | coro::ranges::transform([&](auto &&msg) -> coro::task<void> {
+                                          co_await client->write_all(msg);
+                                      })
+            | coro::ranges::await
+            | coro::ranges::drain;
+
+        co_await std::move(pipe);
         // clang-format on
     }(scheduler, messages);
 
@@ -218,20 +218,14 @@ TEST_CASE("Partial reading", "[async_ranges]")
             | coro::ranges::with_buffer(4096) // buffered reading
             | coro::ranges::join; // byte by byte
 
-         std::string hello = co_await (
-             buffered_stream
-             | as_chars
-             | until_zero
-             | coro::ranges::to<std::string>
-         );
+        auto get_word = buffered_stream
+            | as_chars
+            | until_zero;
+
+         std::string hello = co_await (get_word | coro::ranges::to<std::string>);
          CHECK(hello == "Hello");
 
-         std::string world = co_await (
-             buffered_stream
-             | as_chars
-             | until_zero
-             | coro::ranges::to<std::string>
-         );
+         std::string world = co_await (get_word | coro::ranges::to<std::string>);
          CHECK(world == "world!");
 
          std::cout << "client: got " << hello << ' ' << world << '\n';


### PR DESCRIPTION
While working with std::ranges, I've got this idea. We already have nice coroutine primitives and networking API in libcoro, but when it comes to stream-style processing, everything still ends up as manual while (co_await ...) loops. It works, but it’s not composable, and it doesn’t scale nicely once you add filtering, logging, etc.

So I experimented with a small async range layer built on top of existing coroutine primitives.

## Idea
An async stream is just a type that provides:

```cpp
// std::nullopt means the end of stream
auto next() -> awaitable<std::optional<value_type>>;
```

How it looks:
```cpp
auto result = co_await (
    client
    | coro::ranges::with_buffer(1024)
    | coro::ranges::join() // we flatten chunks of data into a stream of bytes
    | coro::ranges::take_until([](auto f) -> bool { return static_cast<char>(f) == '0'; }) // we take them until 0
    | coro::ranges::to<std::vector<std::byte>> // and save to a container
);

// Executing a bunch of tasks
auto task_stream = inputs | coro::ranges::transform(make_task);

auto result_task = task_stream | coro::ranges::await | coro::ranges::to<std::vector<int>>;
```

Everything remains fully lazy and very nice to use with coroutines.

Everything gets completely **inlined** with no overhead (checked on clang).

---

My PR is a very early draft, because I just wanted to show this idea.

Idk if this idea makes sense, so I need feedback on the overall direction before taking this further, so I didn't focus on buffering, error handling and cancellation semantics yet

## How could it look (when finished)

```cpp
// Proxying from one client to another
auto redirect_task = client1
    | coro::ranges::with_buffer(64_KiB)
    | coro::ranges::take(1024 * 1024) // Limit to 1 MiB
    | coro::ranges::inspect([&](auto& b) { 
        bytes_transferred++; // Logging transferred bytes
    })
    | coro::ranges::to(client2);


auto task = client
    | coro::ranges::with_buffer() 
    | coro::ranges::inspect([](auto byte) { std::cout << (int)byte; }) // sideeffect
    | coro::ranges::to(...);
    
// Ratelimiting
auto throttled_task = co_await (
    client
    | coro::ranges::with_buffer(1024)
    | coro::ranges::throttle(100ms)   // one chunk per 100 ms
    | coro::ranges::to(file)
);

// Partial reads
auto buffered_stream = client | std::ranges::with_buffer(512) | std::ranges::join;

auto header = buffered_stream
    | as_chars
    | std::ranges::take_until("\r\n\r\n")
    | std::ranges::split("\r\n")
    | std::ranges::transform(parse_header)
    | std::ranges::to<std::vector<std::string>>();

auto body = buffered_stream
    | coro::ranges::to<std::vector<std::byte>>();

// Calculating simple XOR checksum on fly
uint8_t checksum = 0;
auto processing_task = client
    | coro::ranges::with_buffer()
    | coro::ranges::inspect([&](std::byte b) {
          checksum ^= static_cast<uint8_t>(b);
      })
    | coro::ranges::to<std::vector>();
    
// Imagine reading a stream of URLs from a socket and fetching them concurrently
auto fetch_results = co_await (
    url_client
    | coro::ranges::with_buffer()
    | coro::ranges::split_by("\n")
    // Launch up to 4 concurrent coroutines to fetch data
    | coro::ranges::flat_map_concurrent(4, [](std::string_view url) -> coro::task<Result> {
        auto response = co_await http::get(url);
        co_return parse(response);
    })
    | coro::ranges::to<std::vector>()
);

// Download a large payload via HTTP and stream it directly to a file
auto download_task = co_await (
    http_client
    | coro::ranges::with_buffer()
    | coro::ranges::join // by byte
    // Skip data until we find the end of the HTTP headers (\r\n\r\n)
    | coro::ranges::drop_until(is_start_of_body) 
    | coro::ranges::chunk(4096) 
    | coro::ranges::to(coro::ranges::write_to_file("cat.jpeg"))
);

// Simple teeing
auto stream = client | coro::ranges::with_buffer();

auto [logger, processor] = stream | coro::ranges::tee();

auto log_task = logger
    | coro::ranges::inspect([](auto b) { log_byte(b); })
    | coro::ranges::drain();

auto process_task = processor
    | coro::ranges::chunk(1024)
    | coro::ranges::to(coro::ranges::write_to(file));

co_await when_all(log_task, process_task);

// How to handle errors?
auto result = co_await (
    client
    | coro::ranges::with_buffer(1024)
    | coro::ranges::on_error([](auto const& err) {
          std::cerr << "stream error: " << err.message() << "\n";
      })
    | coro::ranges::to<std::vector>()
);

// How could cancellation work?
cancellation_source cancel;

auto task = co_await (
    client
    | coro::ranges::with_buffer(4096)
    | coro::ranges::with_cancellation(cancel.token())
    | coro::ranges::to(coro::ranges::write_to(file))
);

// somewhere else
cancel.request_cancellation();
```