### PR TITLE
coro::thread_pool_ws (work stealing)

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -608,9 +608,9 @@ If you require TLS, provide OpenSSL for the target ABI (static or shared) and se
 
 ### Requirements
     C++20 Compiler with coroutine support
-        g++ [11, 12, 13]
-        clang++ [16, 17]
-        MSVC Windows 2022 CL
+        g++ [11, 12, 13, 14, 15]
+        clang++ with coroutine support [clang-21 is CI tested]
+        MSVC Windows 2022, 2025 CL
             Does not currently support:
                 `LIBCORO_FEATURE_NETWORKING`
                 `LIBCORO_FEATURE_TLS`

--- a/.github/workflows/ci-cpu-usage.yml
+++ b/.github/workflows/ci-cpu-usage.yml
@@ -63,12 +63,12 @@ jobs:
               exit 1
             fi
   ci-cpu-usage-macos:
-    name: macos-15
+    name: ci-cpu-usage-macos-15-clang-21
     runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        clang_version: [ 20 ]
+        clang_version: [ 21 ]
         cxx_standard: [ 20 ]
         libcoro_feature_networking:
           [
@@ -104,13 +104,15 @@ jobs:
               -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
               -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
               -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
+              -DLIBCORO_MACOS_LLVM_VERSION=${{ matrix.clang_version }} \
               ..
           cmake --build . --config Release
       - name: Test CPU Usage
         run: |
           cd Release
           ./examples/coro_http_200_ok_server &
-          CPU_USAGE=top -d 1 -b -n 5 -p $(pgrep coro_http) | egrep -v "top|Tasks|%Cpu|MiB|PID|$^" | awk '{ sum += $9 } END { print sum }'
+          CPU_USAGE=$(top -d 1 -b -n 5 -p $(pgrep coro_http) | egrep -v "top|Tasks|%Cpu|MiB|PID|$^" | awk '{ sum += $9 } END { print sum }')
+          #CPU_USAGE=$(top -l 2 -s 5 -pid $(pgrep coro_http) | tail -n 1 | awk '{ sum += $3 } END { print sum }')
           if [[ $CPU_USAGE -gt "5" ]]; then
             exit 1
           fi

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Test
         run: |
           cd RelWithDebInfo
-          lldb  -b --one-line-on-crash 'thread backtrace all' -o r -- ctest --build-config RelWithDebInfo -VV
-          # ctest --build-config RelWithDebInfo -VV
+          # lldb  -b --one-line-on-crash 'thread backtrace all' -o r -- ctest --build-config RelWithDebInfo -VV
+          ctest --build-config RelWithDebInfo -VV

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -32,12 +32,12 @@ jobs:
           fetch-tags: true
       - name: Mark repository as safe
         run: git config --global --add safe.directory "*"
-      - name: Release
+      - name: RelWithDebInfo
         run: |
           brew --prefix llvm@${{ matrix.clang_version }}
           ls $(brew --prefix llvm@${{ matrix.clang_version }})/bin
-          mkdir Release
-          cd Release
+          mkdir RelWithDebInfo
+          cd RelWithDebInfo
           cmake \
               -GNinja \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -48,9 +48,9 @@ jobs:
               -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
               -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
               ..
-          cmake --build . --config Release
+          cmake --build . --config RelWithDebInfo
       - name: Test
         run: |
-          cd Release
-          lldb -b -o r -- ctest --build-config RelWithDebInfo -VV
-          ctest --build-config Release -VV
+          cd RelWithDebInfo
+          lldb  -b --one-line-on-crash 'thread backtrace all' -o r -- ctest --build-config RelWithDebInfo -VV
+          # ctest --build-config RelWithDebInfo -VV

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -53,4 +53,4 @@ jobs:
         run: |
           cd Release
           lldb -b -o r -- ctest --build-config RelWithDebInfo -VV
-          # ctest --build-config Release -VV
+          ctest --build-config Release -VV

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -4,12 +4,12 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   macos:
-    name: macos-15
+    name: macos-15-${{ matrix.clang_version }}-${{ matrix.cxx_standard }}-${{ matrix.libcoro_feature_networking.enabled }}-${{ matrix.libcoro_feature_networking.tls }}-${{ matrix.libcoro_build_shared_libs }}
     runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
-        clang_version: [20]
+        clang_version: [21]
         cxx_standard: [20, 23]
         libcoro_feature_networking:
           [
@@ -32,26 +32,39 @@ jobs:
           fetch-tags: true
       - name: Mark repository as safe
         run: git config --global --add safe.directory "*"
-      - name: RelWithDebInfo
+      - name: Release build clang
         run: |
           brew --prefix llvm@${{ matrix.clang_version }}
-          ls $(brew --prefix llvm@${{ matrix.clang_version }})/bin
-          mkdir RelWithDebInfo
-          cd RelWithDebInfo
+
+          mkdir Release
+          cd Release
           cmake \
               -GNinja \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
               -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
               -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
               -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
               -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
-              -DLIBCORO_ENABLE_ASAN=ON \
+              -DLIBCORO_MACOS_LLVM_VERSION=${{ matrix.clang_version }} \
               ..
-          cmake --build . --config RelWithDebInfo
-      - name: Test
+          cmake --build . --config Release
+      - name: Test clang
         run: |
-          cd RelWithDebInfo
-          # lldb  -b --one-line-on-crash 'thread backtrace all' -o r -- ctest --build-config RelWithDebInfo -VV
-          ctest --build-config RelWithDebInfo -VV
+          cd Release
+          ctest --build-config Release -VV
+
+          # Run in lldb and capture the backtrace on crash.
+          #lldb  -b --one-line-on-crash 'thread backtrace all' -o r -- ctest --build-config Release -VV
+
+          # Run, crash, and then backtrace the core file.
+          #sudo chmod 1777 /cores
+          #sudo sysctl kern.coredump=1
+          #cd Release/test
+          #/usr/libexec/PlistBuddy -c "Add :com.apple.security.get-task-allow bool true" debug.entitlements
+          #codesign -s - -f --entitlements debug.entitlements ./libcoro_test
+          #ulimit -c unlimited
+          #./libcoro_test "[thread_pool_ws]" || true
+          #ls -lha /cores
+          #lldb -b -o "bt all" -c /cores/core* -- ./libcoro_test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -47,6 +47,7 @@ jobs:
               -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
               -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
               -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
+              -DLIBCORO_ENABLE_ASAN=ON \
               ..
           cmake --build . --config RelWithDebInfo
       - name: Test

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -40,7 +40,7 @@ jobs:
           cd Release
           cmake \
               -GNinja \
-              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DCMAKE_C_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
               -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@${{ matrix.clang_version }})/bin/clang-${{ matrix.clang_version }} \
               -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -52,5 +52,5 @@ jobs:
       - name: Test
         run: |
           cd Release
-          # lldb -b -o r -- ctest --build-config Release -VV
-          ctest --build-config Release -VV
+          lldb -b -o r -- ctest --build-config RelWithDebInfo -VV
+          # ctest --build-config Release -VV

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -31,7 +31,8 @@ jobs:
                         git \
                         ninja-build \
                         g++-${{ matrix.gplusplus_version }} \
-                        libssl-dev
+                        libssl-dev \
+                        gdb
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:
@@ -46,7 +47,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -58,7 +59,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
+                    # ctest -VV
+                    gdb -ex run ./test/libcoro_test
     ci-ubuntu-24-04-gplusplus:
         name: ci-ubuntu-24.04-g++
         runs-on: ubuntu-latest
@@ -86,7 +88,8 @@ jobs:
                         git \
                         ninja-build \
                         g++-${{ matrix.gplusplus_version }} \
-                        libssl-dev
+                        libssl-dev \
+                        gdb
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:
@@ -101,7 +104,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -112,7 +115,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
+                    # ctest -VV
+                    gdb -ex run ./test/libcoro_test
     ci-ubuntu-22-04-clang:
         name: ci-ubuntu-22.04-clang
         runs-on: ubuntu-latest
@@ -139,7 +143,8 @@ jobs:
                         cmake \
                         git \
                         ninja-build \
-                        libssl-dev
+                        libssl-dev \
+                        gdb
             -   name: install-clang
                 run: |
                     wget https://apt.llvm.org/llvm.sh
@@ -159,7 +164,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -170,4 +175,5 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest --build-config Release -VV
+                    # ctest --build-config Release -VV
+                    gdb -ex run ./test/libcoro_test

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -5,28 +5,23 @@ on: [pull_request, workflow_dispatch]
 jobs:
     ci-ubuntu-22-04-gplusplus:
         name: ci-ubuntu-22.04-g++-${{ matrix.gplusplus_version }}-networking-${{ matrix.libcoro_feature_networking.enabled }}-tls-${{ matrix.libcoro_feature_networking.tls }}
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 gplusplus_version: [11]
                 cxx_standard: [20]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON}, {enabled: ON, tls: OFF}, {enabled: OFF, tls: OFF} ]
                 libcoro_build_shared_libs: [OFF, ON]
-        container:
-            image: ubuntu:22.04
-            env:
-                TZ: America/New_York
-                DEBIAN_FRONTEND: noninteractive
         steps:
             -   name: Install Dependencies
                 run: |
-                    apt-get clean
-                    apt-get update
-                    apt install -y \
+                    sudo apt-get clean
+                    sudo apt-get update
+                    sudo apt install -y \
                         build-essential \
                         software-properties-common
-                    add-apt-repository ppa:ubuntu-toolchain-r/test
-                    apt-get install -y \
+                    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+                    sudo apt-get install -y \
                         cmake \
                         git \
                         ninja-build \
@@ -54,37 +49,30 @@ jobs:
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
-                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    # gdb -ex run -ex "bt" ./test/libcoro_test
                     ctest --build-config Release -VV
     ci-ubuntu-24-04-gplusplus:
         name: ci-ubuntu-24.04-g++
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
-                gplusplus_version: [11, 12, 13]
+                gplusplus_version: [11, 12, 13, 14, 15]
                 cxx_standard: [20, 23]
-                libcoro_feature_networking: [ {enabled: ON, tls: ON}]
-        container:
-            image: ubuntu:24.04
-            env:
-                TZ: America/New_York
-                DEBIAN_FRONTEND: noninteractive
+                libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
         steps:
             -   name: Install Dependencies
                 run: |
-                    apt-get clean
-                    apt-get update
-                    apt install -y --no-install-recommends \
+                    sudo apt-get clean
+                    sudo apt-get update
+                    sudo apt install -y --no-install-recommends \
                         build-essential \
                         software-properties-common
-                    add-apt-repository ppa:ubuntu-toolchain-r/test
-                    apt-get install -y --no-install-recommends \
+                    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+                    sudo apt-get install -y --no-install-recommends \
                         cmake \
                         git \
                         ninja-build \
@@ -111,47 +99,41 @@ jobs:
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
-                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
-                    ninja
+                    cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    # gdb -ex run -ex "bt" ./test/libcoro_test
                     ctest --build-config Release -VV
     ci-ubuntu-22-04-clang:
         name: ci-ubuntu-22.04-clang
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
-                clang_version: [16, 17]
+                clang_version: [21]
                 cxx_standard: [20, 23]
                 libcoro_feature_networking: [ {enabled: ON, tls: ON}]
-        container:
-            image: ubuntu:22.04
-            env:
-                TZ: America/New_York
-                DEBIAN_FRONTEND: noninteractive
         steps:
             -   name: Install Dependencies
                 run: |
-                    apt-get clean
-                    apt-get update
-                    apt-get install -y --no-install-recommends \
+                    sudo apt-get clean
+                    sudo apt-get update
+                    sudo apt-get install -y --no-install-recommends \
                         build-essential \
                         software-properties-common
-                    apt-get install -y --no-install-recommends \
+                    sudo apt-get install -y --no-install-recommends \
                         wget \
                         cmake \
                         git \
                         ninja-build \
                         libssl-dev \
-                        gdb
+                        gdb \
+                        systemd-coredump
             -   name: install-clang
                 run: |
                     wget https://apt.llvm.org/llvm.sh
                     chmod +x llvm.sh
-                    ./llvm.sh ${{ matrix.clang_version }}
+                    sudo ./llvm.sh ${{ matrix.clang_version }}
             -   name: Checkout
                 uses: actions/checkout@v4
                 with:
@@ -172,11 +154,65 @@ jobs:
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
-                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
                     cmake --build . --config Release
             -   name: Test
                 run: |
                     cd Release
-                    # gdb -ex run -ex "bt" ./test/libcoro_test
+                    ctest --build-config Release -VV
+
+    ci-ubuntu-24-04-clang:
+        name: ci-ubuntu-24.04-clang
+        runs-on: ubuntu-24.04
+        strategy:
+            matrix:
+                clang_version: [21]
+                cxx_standard: [20, 23]
+                libcoro_feature_networking: [ {enabled: ON, tls: ON} ]
+        steps:
+            -   name: Install Dependencies
+                run: |
+                    sudo apt-get clean
+                    sudo apt-get update
+                    sudo apt-get install -y --no-install-recommends \
+                        build-essential \
+                        software-properties-common
+                    sudo apt-get install -y --no-install-recommends \
+                        wget \
+                        cmake \
+                        git \
+                        ninja-build \
+                        libssl-dev \
+                        gdb \
+                        systemd-coredump
+            -   name: install-clang
+                run: |
+                    wget https://apt.llvm.org/llvm.sh
+                    chmod +x llvm.sh
+                    sudo ./llvm.sh ${{ matrix.clang_version }}
+            -   name: Checkout
+                uses: actions/checkout@v4
+                with:
+                    submodules: recursive
+                    fetch-depth: 0
+                    fetch-tags: true
+            -   name: Mark repository as safe
+                run: git config --global --add safe.directory "*"
+            -   name: Build
+                run: |
+                    mkdir Release
+                    cd Release
+                    cmake \
+                        -GNinja \
+                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
+                        -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
+                        -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+                        -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
+                        -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+                        ..
+                    cmake --build . --config Release
+            -   name: Test
+                run: |
+                    cd Release
                     ctest --build-config Release -VV

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -144,22 +144,27 @@ jobs:
                 run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
-                    mkdir Release
-                    cd Release
+                    mkdir RelWithDebInfo
+                    cd RelWithDebInfo
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         ..
-                    cmake --build . --config Release
+                    cmake --build . --config RelWithDebInfo
             -   name: Test
                 run: |
-                    cd Release
-                    ctest --build-config Release -VV
+                    cd RelWithDebInfo
+                    sudo sysctl -w kernel.core_pattern=core.%p.%e
+                    ulimit -c unlimited
+                    ./test/libcoro_test
+                    gdb ./test/libcoro_test core* -ex "thread apply all bt" -ex "quit"
+                    #gdb -ex run -ex bt -ex q --args ./test/libcoro_test
+                    #ctest --build-config RelWithDebInfo -VV
 
     ci-ubuntu-24-04-clang:
         name: ci-ubuntu-24.04-clang
@@ -200,19 +205,24 @@ jobs:
                 run: git config --global --add safe.directory "*"
             -   name: Build
                 run: |
-                    mkdir Release
-                    cd Release
+                    mkdir RelWithDebInfo
+                    cd RelWithDebInfo
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=Release \
+                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                         -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         ..
-                    cmake --build . --config Release
+                    cmake --build . --config RelWithDebInfo
             -   name: Test
                 run: |
-                    cd Release
-                    ctest --build-config Release -VV
+                    cd RelWithDebInfo
+                    sudo sysctl -w kernel.core_pattern=core.%p.%e
+                    ulimit -c unlimited
+                    ./test/libcoro_test
+                    gdb ./test/libcoro_test core* -ex "thread apply all bt" -ex "quit"
+                    #gdb -ex run -ex bt -ex q --args ./test/libcoro_test
+                    #ctest --build-config Release -VV

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -47,7 +47,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                        -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -59,8 +59,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    gdb -ex run -ex "bt" ./test/libcoro_test
-                    # ctest -VV
+                    # gdb -ex run -ex "bt" ./test/libcoro_test
+                    ctest --build-config Release -VV
     ci-ubuntu-24-04-gplusplus:
         name: ci-ubuntu-24.04-g++
         runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                        -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=gcc-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_COMPILER=g++-${{ matrix.gplusplus_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -115,8 +115,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    gdb -ex run -ex "bt" ./test/libcoro_test
-                    # ctest -VV
+                    # gdb -ex run -ex "bt" ./test/libcoro_test
+                    ctest --build-config Release -VV
     ci-ubuntu-22-04-clang:
         name: ci-ubuntu-22.04-clang
         runs-on: ubuntu-latest
@@ -164,7 +164,7 @@ jobs:
                     cd Release
                     cmake \
                         -GNinja \
-                        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                        -DCMAKE_BUILD_TYPE=Release \
                         -DCMAKE_C_COMPILER=clang-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_COMPILER=clang++-${{ matrix.clang_version }} \
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
@@ -175,5 +175,5 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    gdb -ex run -ex "bt" ./test/libcoro_test
-                    # ctest --build-config Release -VV
+                    # gdb -ex run -ex "bt" ./test/libcoro_test
+                    ctest --build-config Release -VV

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -59,8 +59,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
-                    gdb -ex run ./test/libcoro_test
+                    gdb -ex run -ex "bt" ./test/libcoro_test
+                    # ctest -VV
     ci-ubuntu-24-04-gplusplus:
         name: ci-ubuntu-24.04-g++
         runs-on: ubuntu-latest
@@ -115,8 +115,8 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest -VV
-                    gdb -ex run ./test/libcoro_test
+                    gdb -ex run -ex "bt" ./test/libcoro_test
+                    # ctest -VV
     ci-ubuntu-22-04-clang:
         name: ci-ubuntu-22.04-clang
         runs-on: ubuntu-latest
@@ -175,5 +175,5 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    ctest --build-config Release -VV
-                    gdb -ex run ./test/libcoro_test
+                    gdb -ex run -ex "bt" ./test/libcoro_test
+                    # ctest --build-config Release -VV

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -54,6 +54,7 @@ jobs:
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
                         -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} \
+                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
                     ninja
             -   name: Test
@@ -110,6 +111,7 @@ jobs:
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
                     ninja
             -   name: Test
@@ -170,6 +172,7 @@ jobs:
                         -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
                         -DLIBCORO_FEATURE_NETWORKING=${{ matrix.libcoro_feature_networking.enabled }} \
                         -DLIBCORO_FEATURE_TLS=${{ matrix.libcoro_feature_networking.tls }} \
+                        -DLIBCORO_ENABLE_ASAN=ON \
                         ..
                     cmake --build . --config Release
             -   name: Test

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -59,7 +59,7 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    # ctest -VV
+                    ctest -VV
                     gdb -ex run ./test/libcoro_test
     ci-ubuntu-24-04-gplusplus:
         name: ci-ubuntu-24.04-g++
@@ -115,7 +115,7 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    # ctest -VV
+                    ctest -VV
                     gdb -ex run ./test/libcoro_test
     ci-ubuntu-22-04-clang:
         name: ci-ubuntu-22.04-clang
@@ -175,5 +175,5 @@ jobs:
             -   name: Test
                 run: |
                     cd Release
-                    # ctest --build-config Release -VV
+                    ctest --build-config Release -VV
                     gdb -ex run ./test/libcoro_test

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -5,7 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
     ci-windows-2022:
         name: windows-2022
-        runs-on: windows-latest
+        runs-on: windows-2022
         strategy:
             matrix:
                 cxx_standard: [20, 23]

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,3 +29,30 @@ jobs:
                 run: |
                     cd Release
                     ctest --build-config Release -VV
+    ci-windows-2025:
+        name: windows-2025
+        runs-on: windows-2025
+        strategy:
+            matrix:
+                cxx_standard: [ 20, 23 ]
+                libcoro_build_shared_libs: [ OFF, ON ]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+                  fetch-depth: 0
+                  fetch-tags: true
+            - name: Mark repository as safe
+              run: git config --global --add safe.directory "*"
+            - name: Build
+              run: |
+                  mkdir Release
+                  cd Release
+                  cmake -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} -DLIBCORO_BUILD_SHARED_LIBS=${{ matrix.libcoro_build_shared_libs }} ..
+                  cmake --build . --config Release
+            - name: Test
+              run: |
+                  cd Release
+                  ctest --build-config Release -VV
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,31 @@ project(libcoro
 
 message(STATUS "${PROJECT_NAME} version: ${PROJECT_VERSION}")
 
+set(LIBCORO_MACOS_LLVM_VERSION ${LIBCORO_MACOS_LLVM_VERSION} CACHE INTERNAL "21")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX TRUE)
-    # We need to build with clang >= 17, assuming its installed by
-    # brew. We also need to force linking to libc++.a
-    add_link_options(-L/usr/local/opt/llvm/lib)
-    link_libraries(-lc++)
+
+    # Dynamically determine where llvm was installed based on the brew --prefix.
+    execute_process(
+        COMMAND brew --prefix llvm@${LIBCORO_MACOS_LLVM_VERSION}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE LIBCORO_MACOS_BREW_LLVM_PREFIX_RESULT
+        OUTPUT_VARIABLE LIBCORO_MACOS_BREW_LLVM_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    message("LIBCORO_MACOS_BREW_LLVM_PREFIX = ${LIBCORO_MACOS_BREW_LLVM_PREFIX}")
+    include_directories(BEFORE SYSTEM ${LIBCORO_MACOS_BREW_LLVM_PREFIX}/include)
+#    include_directories(BEFORE SYSTEM /opt/homebrew/opt/llvm@21/include)
+    link_directories(AFTER ${LIBCORO_MACOS_BREW_LLVM_PREFIX}/lib ${LIBCORO_MACOS_BREW_LLVM_PREFIX}/lib/c++ ${LIBCORO_MACOS_BREW_LLVM_PREFIX}/lib/unwind)
+#    link_directories(AFTER /opt/homebrew/opt/llvm@21/lib /opt/homebrew/opt/llvm@21/lib/c++ /opt/homebrew/opt/llvm@21/lib/unwind)
+    link_libraries(c++ unwind)
+
+    # Required for the macos system clang to be ignored.
+    add_compile_definitions(_LIBCPP_DISABLE_AVAILABILITY)
+
+    # Uncomment to show all linked libraries the binaries will require.
+    # add_link_options(-Wl,-t)
 endif()
 
 if(UNIX AND NOT APPLE)
@@ -47,7 +66,6 @@ endif()
 include(GNUInstallDirs)
 include(GenerateExportHeader)
 include(cmake/CPM.cmake)
-# CPMAddPackage("gh:ConorWilliams/ConcurrentDeque#v2.0.0")
 
 if (NOT "$ENV{version}" STREQUAL "")
     set(PROJECT_VERSION "$ENV{version}" CACHE INTERNAL "Copied from environment variable")
@@ -214,11 +232,17 @@ if(DEFINED EMSCRIPTEN)
     add_link_options(-sEXIT_RUNTIME)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+# Global compiler options to apply across all of libcoro.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     add_compile_options(
         $<$<COMPILE_LANGUAGE:CXX>:-Wall>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-interference-size>
+    )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
     )
 elseif(MSVC)
     add_compile_options(
@@ -228,7 +252,6 @@ endif()
 
 add_library(${PROJECT_NAME} ${LIBCORO_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX PREFIX "" VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-# target_link_libraries(${PROJECT_NAME} PUBLIC RiftenDeque::RiftenDeque)
 
 if(LIBCORO_ENABLE_ASAN)
     add_compile_options(-g -O0 -fno-omit-frame-pointer -fsanitize=address)
@@ -241,7 +264,9 @@ if(LIBCORO_ENABLE_MSAN)
 endif()
 
 if(LIBCORO_ENABLE_TSAN)
-    add_compile_options(-g -O0 -fno-omit-frame-pointer -fsanitize=thread)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=thread)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE LIBCORO_TSAN)
+    set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE FALSE)
     add_link_options(-fsanitize=thread)
 endif()
 
@@ -269,8 +294,8 @@ if(LIBCORO_FEATURE_NETWORKING)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.2.0")
-        message(FATAL_ERROR "g++ version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 10.2.0")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0")
+        message(FATAL_ERROR "g++ version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 11.0")
     endif()
 
     target_compile_options(${PROJECT_NAME} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ endif()
 
 include(GNUInstallDirs)
 include(GenerateExportHeader)
+include(cmake/CPM.cmake)
+CPMAddPackage("gh:ConorWilliams/ConcurrentDeque#v2.0.0")
 
 if (NOT "$ENV{version}" STREQUAL "")
     set(PROJECT_VERSION "$ENV{version}" CACHE INTERNAL "Copied from environment variable")
@@ -135,6 +137,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/sync_wait.hpp src/sync_wait.cpp
     include/coro/task.hpp
     include/coro/task_group.hpp
+    include/coro/thread_pool_ws.hpp src/thread_pool_ws.cpp
     include/coro/thread_pool.hpp src/thread_pool.cpp
     include/coro/time.hpp
     include/coro/when_all.hpp
@@ -220,6 +223,7 @@ endif()
 
 add_library(${PROJECT_NAME} ${LIBCORO_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX PREFIX "" VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+target_link_libraries(${PROJECT_NAME} PUBLIC RiftenDeque::RiftenDeque)
 
 if(LIBCORO_ENABLE_ASAN)
     add_compile_options(-g -O0 -fno-omit-frame-pointer -fsanitize=address)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,9 @@ if(LIBCORO_FEATURE_NETWORKING)
 endif()
 
 if(DEFINED EMSCRIPTEN)
+    # For WebAssembly, set a compatible cache line size that's a power of 2
+    add_compile_definitions(RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE=64)
+
     add_compile_options(-fwasm-exceptions)
     add_compile_options(-pthread)
     add_compile_options(-matomics)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(
         $<$<COMPILE_LANGUAGE:CXX>:-Wall>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-interference-size>
     )
 elseif(MSVC)
     add_compile_options(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 include(GNUInstallDirs)
 include(GenerateExportHeader)
 include(cmake/CPM.cmake)
-CPMAddPackage("gh:ConorWilliams/ConcurrentDeque#v2.0.0")
+# CPMAddPackage("gh:ConorWilliams/ConcurrentDeque#v2.0.0")
 
 if (NOT "$ENV{version}" STREQUAL "")
     set(PROJECT_VERSION "$ENV{version}" CACHE INTERNAL "Copied from environment variable")
@@ -118,6 +118,7 @@ set(LIBCORO_SOURCE_FILES
     include/coro/concepts/range_of.hpp
 
     include/coro/detail/awaiter_list.hpp
+    include/coro/detail/riften_deque.hpp
     include/coro/detail/task_self_deleting.hpp src/detail/task_self_deleting.cpp
     include/coro/detail/void_value.hpp
 
@@ -226,7 +227,7 @@ endif()
 
 add_library(${PROJECT_NAME} ${LIBCORO_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX PREFIX "" VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-target_link_libraries(${PROJECT_NAME} PUBLIC RiftenDeque::RiftenDeque)
+# target_link_libraries(${PROJECT_NAME} PUBLIC RiftenDeque::RiftenDeque)
 
 if(LIBCORO_ENABLE_ASAN)
     add_compile_options(-g -O0 -fno-omit-frame-pointer -fsanitize=address)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,21 @@
+set(CPM_DOWNLOAD_VERSION 0.42.1)
+
+if(CPM_SOURCE_CACHE)
+  # Expand relative path. This is important if the provided path contains a tilde (~)
+  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD
+       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION}
+  )
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/include/coro/concepts/awaitable.hpp
+++ b/include/coro/concepts/awaitable.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <coroutine>
 #include <type_traits>
@@ -110,7 +111,7 @@ concept awaiter_forward_list_entry = requires(entry_type* e)
     /// The next awaiter in the list.
     { std::same_as<entry_type*, decltype(e->m_next)> };
     /// The awaiting coroutine for this entry.
-    { std::same_as<std::coroutine_handle<>, decltype(e->m_awaiting_coroutine)> };
+    { std::same_as<std::atomic<std::coroutine_handle<>>, decltype(e->m_awaiting_coroutine)> };
 };
 
 } // namespace detail

--- a/include/coro/condition_variable.hpp
+++ b/include/coro/condition_variable.hpp
@@ -18,11 +18,11 @@
     #include <stop_token>
 #endif
 
-// latest gcc versions > 13 are incorrectly reporting the std::optional<std::function<bool>()> = std::nullopt as the internal
-// std::function being uninitialized, it is but that is expected since its wrapped in an nullopt optional.
+// latest gcc versions > 13 are incorrectly reporting the std::optional<std::function<bool>()> = std::nullopt as the
+// internal std::function being uninitialized, it is but that is expected since its wrapped in an nullopt optional.
 #if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 namespace coro
@@ -57,7 +57,7 @@ private:
         /// @brief The next waiting awaiter.
         awaiter_base* m_next{nullptr};
         /// @brief The coroutine to resume the waiter.
-        std::coroutine_handle<> m_awaiting_coroutine{nullptr};
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine{nullptr};
         /// @brief The condition variable this waiter is waiting on.
         coro::condition_variable& m_condition_variable;
         /// @brief The lock that the wait() was called with.
@@ -229,7 +229,7 @@ private:
             {
                 // The condition coroutine is resumed from here instead of the awaiter hook task to
                 // guarantee the controller is still alive until the caller's coroutine is completed.
-                m_awaiting_coroutine.resume();
+                m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             }
 
             // This was a timeout, do nothing but exit to let the controller task know it can safely exit now.
@@ -257,7 +257,7 @@ private:
                 // must be re-acquired.
                 co_await m_lock.m_mutex->lock();
                 m_predicate_result = data.m_predicate.has_value() ? data.m_predicate.value()() : true;
-                m_awaiting_coroutine.resume();
+                m_awaiting_coroutine.load(std::memory_order::acquire).resume();
                 co_return;
             }
 
@@ -304,7 +304,8 @@ private:
 
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
         {
-            m_awaiting_coroutine = awaiting_coroutine; // This is the real coroutine to resume.
+            m_awaiting_coroutine.store(
+                awaiting_coroutine, std::memory_order::release); // This is the real coroutine to resume.
 
             // Make the background controller which proxies between the notify task and the timeout task.
             auto controller = make_controller_task();
@@ -547,9 +548,8 @@ private:
     }
 };
 
-
 #if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
+    #pragma GCC diagnostic pop
 #endif
 
 } // namespace coro

--- a/include/coro/coro.hpp
+++ b/include/coro/coro.hpp
@@ -9,11 +9,11 @@
 #include "coro/expected.hpp"
 
 #ifdef LIBCORO_FEATURE_NETWORKING
-    #include "coro/scheduler.hpp"
     #include "coro/net/dns/resolver.hpp"
     #include "coro/net/tcp/client.hpp"
     #include "coro/net/tcp/server.hpp"
     #include "coro/poll.hpp"
+    #include "coro/scheduler.hpp"
     #ifdef LIBCORO_FEATURE_TLS
         #include "coro/net/tls/client.hpp"
         #include "coro/net/tls/connection_status.hpp"
@@ -22,8 +22,8 @@
     #endif
     #include "coro/net/connect.hpp"
     #include "coro/net/hostname.hpp"
-    #include "coro/net/ip_address.hpp"
     #include "coro/net/io_status.hpp"
+    #include "coro/net/ip_address.hpp"
     #include "coro/net/socket.hpp"
     #include "coro/net/udp/peer.hpp"
 #endif
@@ -43,6 +43,7 @@
 #include "coro/task.hpp"
 #include "coro/task_group.hpp"
 #include "coro/thread_pool.hpp"
+#include "coro/thread_pool_ws.hpp"
 #include "coro/time.hpp"
 #include "coro/when_all.hpp"
 #include "coro/when_any.hpp"

--- a/include/coro/detail/poll_info.hpp
+++ b/include/coro/detail/poll_info.hpp
@@ -53,8 +53,7 @@ struct poll_info
         auto await_ready() const noexcept -> bool { return false; }
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
         {
-            m_pi.m_awaiting_coroutine = awaiting_coroutine;
-            std::atomic_thread_fence(std::memory_order::release);
+            m_pi.m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
         }
         auto await_resume() noexcept -> coro::poll_status { return m_pi.m_poll_status; }
 
@@ -73,7 +72,7 @@ struct poll_info
     /// the timeout within epoll.
     std::optional<timed_events::iterator> m_timer_pos{std::nullopt};
     /// The awaiting coroutine for this poll info to resume upon event or timeout.
-    std::coroutine_handle<> m_awaiting_coroutine;
+    std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
     /// The status of the poll operation.
     coro::poll_status m_poll_status{coro::poll_status::error};
     /// Did the timeout and event trigger at the same time on the same epoll_wait call?

--- a/include/coro/detail/riften_deque.hpp
+++ b/include/coro/detail/riften_deque.hpp
@@ -73,20 +73,20 @@ private:
 } // namespace detail
 
 #ifdef RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
-inline constexpr std::size_t hardware_destructive_interference_size = RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
-#elifdef __cpp_lib_hardware_interference_size
+inline constexpr std::size_t hardware_destructive_interference_size = RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE;
+#elif defined(__cpp_lib_hardware_interference_size)
 using std::hardware_destructive_interference_size;
 #else
 // 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned │ ...
 inline constexpr std::size_t hardware_destructive_interference_size = 2 * sizeof(std::max_align_t);
 #endif
 
-    // Lock-free single-producer multiple-consumer deque. Only the deque owner can perform pop and push
-    // operations where the deque behaves like a stack. Others can (only) steal data from the deque, they see
-    // a FIFO queue. All threads must have finished using the deque before it is destructed. T must be
-    // default initializable, trivially destructible and have nothrow move constructor/assignment operators.
-    template<Simple T>
-    class Deque
+// Lock-free single-producer multiple-consumer deque. Only the deque owner can perform pop and push
+// operations where the deque behaves like a stack. Others can (only) steal data from the deque, they see
+// a FIFO queue. All threads must have finished using the deque before it is destructed. T must be
+// default initializable, trivially destructible and have nothrow move constructor/assignment operators.
+template<Simple T>
+class Deque
 {
 public:
     // Constructs the deque with a given capacity the capacity of the deque (must be power of 2)

--- a/include/coro/detail/riften_deque.hpp
+++ b/include/coro/detail/riften_deque.hpp
@@ -1,0 +1,268 @@
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// This (stand-alone) file implements the deque described in the papers, "Correct and Efficient
+// Work-Stealing for Weak Memory Models," and "Dynamic Circular Work-Stealing Deque". Both are
+// available in 'reference/'.
+
+namespace riften
+{
+
+template<typename T>
+concept Simple = std::default_initializable<T> && std::is_trivially_destructible_v<T>;
+
+namespace detail
+{
+
+// Basic wrapper around a c-style array of atomic objects that provides modulo load/stores. Capacity
+// must be a power of 2.
+template<Simple T>
+struct RingBuff
+{
+public:
+    explicit RingBuff(std::int64_t cap) : _cap{cap}, _mask{cap - 1}
+    {
+        assert(cap && (!(cap & (cap - 1))) && "Capacity must be buf power of 2!");
+    }
+
+    std::int64_t capacity() const noexcept { return _cap; }
+
+    // Store (copy) at modulo index
+    void store(std::int64_t i, T&& x) noexcept
+        requires std::is_nothrow_move_assignable_v<T>
+    {
+        _buff[i & _mask] = std::move(x);
+    }
+
+    // Load (copy) at modulo index
+    T load(std::int64_t i) const noexcept
+        requires std::is_nothrow_move_constructible_v<T>
+    {
+        return _buff[i & _mask];
+    }
+
+    // Allocates and returns a new ring buffer, copies elements in range [b, t) into the new buffer.
+    RingBuff<T>* resize(std::int64_t b, std::int64_t t) const
+    {
+        RingBuff<T>* ptr = new RingBuff{2 * _cap};
+        for (std::int64_t i = t; i != b; ++i)
+        {
+            ptr->store(i, load(i));
+        }
+        return ptr;
+    }
+
+private:
+    std::int64_t _cap;  // Capacity of the buffer
+    std::int64_t _mask; // Bit mask to perform modulo capacity operations
+
+    std::unique_ptr<T[]> _buff = std::make_unique_for_overwrite<T[]>(_cap);
+};
+
+} // namespace detail
+
+#ifdef RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
+inline constexpr std::size_t hardware_destructive_interference_size = RIFTEN_HARDWARE_DESTRUCTIVE_INTERFERENCE_SIZE
+#elifdef __cpp_lib_hardware_interference_size
+using std::hardware_destructive_interference_size;
+#else
+// 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned │ ...
+inline constexpr std::size_t hardware_destructive_interference_size = 2 * sizeof(std::max_align_t);
+#endif
+
+    // Lock-free single-producer multiple-consumer deque. Only the deque owner can perform pop and push
+    // operations where the deque behaves like a stack. Others can (only) steal data from the deque, they see
+    // a FIFO queue. All threads must have finished using the deque before it is destructed. T must be
+    // default initializable, trivially destructible and have nothrow move constructor/assignment operators.
+    template<Simple T>
+    class Deque
+{
+public:
+    // Constructs the deque with a given capacity the capacity of the deque (must be power of 2)
+    explicit Deque(std::int64_t cap = 1024);
+
+    // Move/Copy is not supported
+    Deque(Deque const& other)            = delete;
+    Deque& operator=(Deque const& other) = delete;
+
+    //  Query the size at instance of call
+    std::size_t size() const noexcept;
+
+    // Query the capacity at instance of call
+    int64_t capacity() const noexcept;
+
+    // Test if empty at instance of call
+    bool empty() const noexcept;
+
+    // Emplace an item to the deque. Only the owner thread can insert an item to the deque. The
+    // operation can trigger the deque to resize its cap if more space is required. Provides the
+    // strong exception guarantee.
+    template<typename... Args>
+    void emplace(Args&&... args);
+
+    // Pops out an item from the deque. Only the owner thread can pop out an item from the deque.
+    // The return can be a std::nullopt if this operation fails (empty deque).
+    std::optional<T> pop() noexcept;
+
+    // Steals an item from the deque Any threads can try to steal an item from the deque. The return
+    // can be a std::nullopt if this operation failed (not necessarily empty).
+    std::optional<T> steal() noexcept;
+
+    // Destruct the deque, all threads must have finished using the deque.
+    ~Deque() noexcept;
+
+private:
+    alignas(hardware_destructive_interference_size) std::atomic<std::int64_t> _top;
+    alignas(hardware_destructive_interference_size) std::atomic<std::int64_t> _bottom;
+    alignas(hardware_destructive_interference_size) std::atomic<detail::RingBuff<T>*> _buffer;
+
+    std::vector<std::unique_ptr<detail::RingBuff<T>>> _garbage; // Store old buffers here.
+
+    // Convenience aliases.
+    static constexpr std::memory_order relaxed = std::memory_order_relaxed;
+    static constexpr std::memory_order consume = std::memory_order_consume;
+    static constexpr std::memory_order acquire = std::memory_order_acquire;
+    static constexpr std::memory_order release = std::memory_order_release;
+    static constexpr std::memory_order seq_cst = std::memory_order_seq_cst;
+};
+
+template<Simple T>
+Deque<T>::Deque(std::int64_t cap) : _top(0),
+                                    _bottom(0),
+                                    _buffer(new detail::RingBuff<T>{cap})
+{
+    _garbage.reserve(32);
+}
+
+template<Simple T>
+std::size_t Deque<T>::size() const noexcept
+{
+    int64_t b = _bottom.load(relaxed);
+    int64_t t = _top.load(relaxed);
+    return static_cast<std::size_t>(b >= t ? b - t : 0);
+}
+
+template<Simple T>
+int64_t Deque<T>::capacity() const noexcept
+{
+    return _buffer.load(relaxed)->capacity();
+}
+
+template<Simple T>
+bool Deque<T>::empty() const noexcept
+{
+    return !size();
+}
+
+template<Simple T>
+template<typename... Args>
+void Deque<T>::emplace(Args&&... args)
+{
+    // Construct before acquiring slot in-case constructor throws
+    T object(std::forward<Args>(args)...);
+
+    std::int64_t         b   = _bottom.load(relaxed);
+    std::int64_t         t   = _top.load(acquire);
+    detail::RingBuff<T>* buf = _buffer.load(relaxed);
+
+    if (buf->capacity() < (b - t) + 1)
+    {
+        // Queue is full, build a new one
+        _garbage.emplace_back(std::exchange(buf, buf->resize(b, t)));
+        _buffer.store(buf, relaxed);
+    }
+
+    // Construct new object, this does not have to be atomic as no one can steal this item until after we
+    // store the new value of bottom, ordering is maintained by surrounding atomics.
+    buf->store(b, std::move(object));
+
+    std::atomic_thread_fence(release);
+    _bottom.store(b + 1, relaxed);
+}
+
+template<Simple T>
+std::optional<T> Deque<T>::pop() noexcept
+{
+    std::int64_t         b   = _bottom.load(relaxed) - 1;
+    detail::RingBuff<T>* buf = _buffer.load(relaxed);
+
+    _bottom.store(b, relaxed); // Stealers can no longer steal
+
+    std::atomic_thread_fence(seq_cst);
+    std::int64_t t = _top.load(relaxed);
+
+    if (t <= b)
+    {
+        // Non-empty deque
+        if (t == b)
+        {
+            // The last item could get stolen, by a stealer that loaded bottom before our write above
+            if (!_top.compare_exchange_strong(t, t + 1, seq_cst, relaxed))
+            {
+                // Failed race, thief got the last item.
+                _bottom.store(b + 1, relaxed);
+                return std::nullopt;
+            }
+            _bottom.store(b + 1, relaxed);
+        }
+
+        // Can delay load until after acquiring slot as only this thread can push(), this load is not
+        // required to be atomic as we are the exclusive writer.
+        return buf->load(b);
+    }
+    else
+    {
+        _bottom.store(b + 1, relaxed);
+        return std::nullopt;
+    }
+}
+
+template<Simple T>
+std::optional<T> Deque<T>::steal() noexcept
+{
+    std::int64_t t = _top.load(acquire);
+    std::atomic_thread_fence(seq_cst);
+    std::int64_t b = _bottom.load(acquire);
+
+    if (t < b)
+    {
+        // Must load *before* acquiring the slot as slot may be overwritten immediately after acquiring.
+        // This load is NOT required to be atomic even-though it may race with an overrite as we only
+        // return the value if we win the race below garanteeing we had no race during our read. If we
+        // loose the race then 'x' could be corrupt due to read-during-write race but as T is trivially
+        // destructible this does not matter.
+        T x = _buffer.load(consume)->load(t);
+
+        if (!_top.compare_exchange_strong(t, t + 1, seq_cst, relaxed))
+        {
+            // Failed race.
+            return std::nullopt;
+        }
+
+        return x;
+    }
+    else
+    {
+        // Empty deque.
+        return std::nullopt;
+    }
+}
+
+template<Simple T>
+Deque<T>::~Deque() noexcept
+{
+    delete _buffer.load();
+}
+
+} // namespace riften

--- a/include/coro/event.hpp
+++ b/include/coro/event.hpp
@@ -67,7 +67,7 @@ public:
         /// @brief The next awaiter in line for this event, nullptr if this is the end.
         awaiter* m_next{nullptr};
         /// @brief The awaiting continuation coroutine handle.
-        std::coroutine_handle<> m_awaiting_coroutine;
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
         /// Refernce to the event that this awaiter is waiting on.
         const event& m_event;
     };
@@ -119,7 +119,7 @@ public:
             while (waiters != nullptr)
             {
                 auto* next = waiters->m_next;
-                e->resume(waiters->m_awaiting_coroutine);
+                e->resume(waiters->m_awaiting_coroutine.load(std::memory_order::acquire));
                 waiters = next;
             }
         }

--- a/include/coro/mutex.hpp
+++ b/include/coro/mutex.hpp
@@ -7,6 +7,10 @@
 #include <mutex>
 #include <utility>
 
+#ifdef LIBCORO_TSAN
+#include <sanitizer/tsan_interface.h>
+#endif
+
 namespace coro
 {
 class mutex;
@@ -115,7 +119,13 @@ private:
 class mutex
 {
 public:
-    explicit mutex() noexcept : m_state(const_cast<void*>(unlocked_value())) {}
+    explicit mutex() noexcept
+        : m_state(const_cast<void*>(unlocked_value()))
+    {
+#ifdef LIBCORO_TSAN
+        __tsan_release(&m_state);
+#endif
+    }
     ~mutex() = default;
 
     mutex(const mutex&)                    = delete;

--- a/include/coro/mutex.hpp
+++ b/include/coro/mutex.hpp
@@ -21,21 +21,21 @@ struct lock_operation_base
     explicit lock_operation_base(coro::mutex& m) : m_mutex(m) {}
     virtual ~lock_operation_base() = default;
 
-    lock_operation_base(const lock_operation_base&) = delete;
-    lock_operation_base(lock_operation_base&&) = delete;
+    lock_operation_base(const lock_operation_base&)                    = delete;
+    lock_operation_base(lock_operation_base&&)                         = delete;
     auto operator=(const lock_operation_base&) -> lock_operation_base& = delete;
-    auto operator=(lock_operation_base&&) -> lock_operation_base& = delete;
+    auto operator=(lock_operation_base&&) -> lock_operation_base&      = delete;
 
     auto await_ready() const noexcept -> bool;
     auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool;
 
-    std::coroutine_handle<> m_awaiting_coroutine;
-    lock_operation_base*    m_next{nullptr};
+    lock_operation_base*                 m_next{nullptr};
+    std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
 
 protected:
     friend class coro::mutex;
 
-    coro::mutex&            m_mutex;
+    coro::mutex& m_mutex;
 };
 
 template<typename return_type>
@@ -44,10 +44,10 @@ struct lock_operation : public lock_operation_base
     explicit lock_operation(coro::mutex& m) : lock_operation_base(m) {}
     ~lock_operation() override = default;
 
-    lock_operation(const lock_operation&) = delete;
-    lock_operation(lock_operation&&) = delete;
+    lock_operation(const lock_operation&)                    = delete;
+    lock_operation(lock_operation&&)                         = delete;
     auto operator=(const lock_operation&) -> lock_operation& = delete;
-    auto operator=(lock_operation&&) -> lock_operation& = delete;
+    auto operator=(lock_operation&&) -> lock_operation&      = delete;
 
     auto await_resume() noexcept -> return_type
     {
@@ -92,8 +92,7 @@ public:
     ~scoped_lock();
 
     scoped_lock(const scoped_lock&) = delete;
-    scoped_lock(scoped_lock&& other) noexcept
-        : m_mutex(std::exchange(other.m_mutex, nullptr)) {}
+    scoped_lock(scoped_lock&& other) noexcept : m_mutex(std::exchange(other.m_mutex, nullptr)) {}
     auto operator=(const scoped_lock&) -> scoped_lock& = delete;
     auto operator=(scoped_lock&& other) noexcept -> scoped_lock&
     {
@@ -129,7 +128,10 @@ public:
      *        which will hold the mutex until the coro::scoped_lock destructs.
      * @return A co_await'able operation to acquire the mutex.
      */
-    [[nodiscard]] auto scoped_lock() -> detail::lock_operation<scoped_lock> { return detail::lock_operation<coro::scoped_lock>{*this}; }
+    [[nodiscard]] auto scoped_lock() -> detail::lock_operation<scoped_lock>
+    {
+        return detail::lock_operation<coro::scoped_lock>{*this};
+    }
 
     /**
      * @brief Locks the mutex.

--- a/include/coro/queue.hpp
+++ b/include/coro/queue.hpp
@@ -99,9 +99,9 @@ public:
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
         {
             // No element is ready, put ourselves on the waiter list and suspend.
-            this->m_next         = m_queue.m_waiters;
-            m_queue.m_waiters    = this;
-            m_awaiting_coroutine = awaiting_coroutine;
+            this->m_next      = m_queue.m_waiters;
+            m_queue.m_waiters = this;
+            m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
             m_queue.m_mutex.unlock();
             return true;
         }
@@ -126,17 +126,14 @@ public:
             }
         }
 
-        std::optional<element_type> m_element{std::nullopt};
-        queue&                      m_queue;
-        std::coroutine_handle<>     m_awaiting_coroutine{nullptr};
-        awaiter*                    m_next{nullptr};
+        std::optional<element_type>          m_element{std::nullopt};
+        queue&                               m_queue;
+        awaiter*                             m_next{nullptr};
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine{nullptr};
     };
 
     queue() {}
-    ~queue()
-    {
-        coro::sync_wait(shutdown());
-    }
+    ~queue() { coro::sync_wait(shutdown()); }
 
     queue(const queue&)  = delete;
     queue(queue&& other) = delete;
@@ -190,7 +187,7 @@ public:
 
             // Transfer the element directly to the awaiter.
             waiter->m_element = element;
-            waiter->m_awaiting_coroutine.resume();
+            waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         }
         else
         {
@@ -224,7 +221,7 @@ public:
 
             // Transfer the element directly to the awaiter.
             waiter->m_element = std::move(element);
-            waiter->m_awaiting_coroutine.resume();
+            waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         }
         else
         {
@@ -257,7 +254,7 @@ public:
             lock.unlock();
 
             waiter->m_element.emplace(std::forward<args_type>(args)...);
-            waiter->m_awaiting_coroutine.resume();
+            waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         }
         else
         {
@@ -348,12 +345,12 @@ public:
         }
 
         auto* waiters = m_waiters;
-        m_waiters = nullptr;
+        m_waiters     = nullptr;
         lk.unlock();
         while (waiters != nullptr)
         {
             auto* next = waiters->m_next;
-            waiters->m_awaiting_coroutine.resume();
+            waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             waiters = next;
         }
     }
@@ -370,7 +367,7 @@ public:
     template<coro::concepts::executor executor_type>
     auto shutdown_drain(std::unique_ptr<executor_type>& e) -> coro::task<void>
     {
-        auto lk = co_await m_mutex.scoped_lock();
+        auto lk       = co_await m_mutex.scoped_lock();
         auto expected = running_state_t::running;
         if (!m_running_state.compare_exchange_strong(
                 expected, running_state_t::draining, std::memory_order::acq_rel, std::memory_order::relaxed))
@@ -391,7 +388,10 @@ public:
      * Returns true if shutdown() or shutdown_drain() have been called on this coro::queue.
      * @return True if the coro::queue has been shutdown.
      */
-    [[nodiscard]] auto is_shutdown() const -> bool { return m_running_state.load(std::memory_order::acquire) != running_state_t::running; }
+    [[nodiscard]] auto is_shutdown() const -> bool
+    {
+        return m_running_state.load(std::memory_order::acquire) != running_state_t::running;
+    }
 
 private:
     friend awaiter;

--- a/include/coro/ring_buffer.hpp
+++ b/include/coro/ring_buffer.hpp
@@ -47,7 +47,8 @@ private:
         running,
         /// @brief The ring buffer is draining all elements, produce is no longer allowed.
         draining,
-        /// @brief The ring buffer is fully shutdown, all produce and consume tasks will be woken up with result::stopped.
+        /// @brief The ring buffer is fully shutdown, all produce and consume tasks will be woken up with
+        /// result::stopped.
         stopped,
     };
 
@@ -55,10 +56,7 @@ public:
     /**
      * static_assert If `num_elements` == 0.
      */
-    ring_buffer()
-    {
-        static_assert(num_elements != 0, "num_elements cannot be zero");
-    }
+    ring_buffer() { static_assert(num_elements != 0, "num_elements cannot be zero"); }
 
     ~ring_buffer()
     {
@@ -74,10 +72,7 @@ public:
 
     struct produce_operation
     {
-        produce_operation(ring_buffer<element, num_elements>& rb, element e)
-            : m_rb(rb),
-              m_e(std::move(e))
-        {}
+        produce_operation(ring_buffer<element, num_elements>& rb, element e) : m_rb(rb), m_e(std::move(e)) {}
 
         auto await_ready() noexcept -> bool
         {
@@ -94,7 +89,7 @@ public:
             if (m_rb.m_used.load(std::memory_order::acquire) < num_elements)
             {
                 // There is guaranteed space to store
-                auto slot = m_rb.m_front.fetch_add(1, std::memory_order::acq_rel) % num_elements;
+                auto slot             = m_rb.m_front.fetch_add(1, std::memory_order::acq_rel) % num_elements;
                 m_rb.m_elements[slot] = std::move(m_e);
                 m_rb.m_used.fetch_add(1, std::memory_order::release);
                 mutex.unlock();
@@ -106,7 +101,7 @@ public:
 
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
         {
-            m_awaiting_coroutine = awaiting_coroutine;
+            m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
             m_next = m_rb.m_produce_waiters.exchange(this, std::memory_order::acq_rel);
             m_rb.m_mutex.unlock();
             return true;
@@ -115,13 +110,10 @@ public:
         /**
          * @return produce_result
          */
-        auto await_resume() -> ring_buffer_result::produce
-        {
-            return m_result;
-        }
+        auto await_resume() -> ring_buffer_result::produce { return m_result; }
 
         /// If the operation needs to suspend, the coroutine to resume when the element can be produced.
-        std::coroutine_handle<> m_awaiting_coroutine;
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
         /// The result that should be returned when this coroutine resumes.
         ring_buffer_result::produce m_result{ring_buffer_result::produce::produced};
         /// Linked list of produce operations that are awaiting to produce their element.
@@ -139,9 +131,7 @@ public:
 
     struct consume_operation
     {
-        explicit consume_operation(ring_buffer<element, num_elements>& rb)
-            : m_rb(rb)
-        {}
+        explicit consume_operation(ring_buffer<element, num_elements>& rb) : m_rb(rb) {}
 
         auto await_ready() noexcept -> bool
         {
@@ -157,8 +147,8 @@ public:
 
             if (m_rb.m_used.load(std::memory_order::acquire) > 0)
             {
-                auto slot = m_rb.m_back.fetch_add(1, std::memory_order::acq_rel) % num_elements;
-                m_e = std::move(m_rb.m_elements[slot]);
+                auto slot             = m_rb.m_back.fetch_add(1, std::memory_order::acq_rel) % num_elements;
+                m_e                   = std::move(m_rb.m_elements[slot]);
                 m_rb.m_elements[slot] = std::nullopt;
                 m_rb.m_used.fetch_sub(1, std::memory_order::release);
                 mutex.unlock();
@@ -170,7 +160,7 @@ public:
 
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
         {
-            m_awaiting_coroutine = awaiting_coroutine;
+            m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
             m_next = m_rb.m_consume_waiters.exchange(this, std::memory_order::acq_rel);
             m_rb.m_mutex.unlock();
             return true;
@@ -192,7 +182,7 @@ public:
         }
 
         /// If the operation needs to suspend, the coroutine to resume when the element can be consumed.
-        std::coroutine_handle<> m_awaiting_coroutine;
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
         /// The unexpected result this should return on resume
         ring_buffer_result::consume m_result{ring_buffer_result::consume::stopped};
         /// Linked list of consume operations that are awaiting to consume an element.
@@ -236,18 +226,12 @@ public:
     /**
      * @return The maximum number of elements the ring buffer can hold.
      */
-    constexpr auto max_size() const noexcept -> size_t
-    {
-        return num_elements;
-    }
+    constexpr auto max_size() const noexcept -> size_t { return num_elements; }
 
     /**
      * @return The current number of elements contained in the ring buffer.
      */
-    auto size() const -> size_t
-    {
-        return m_used.load(std::memory_order::acquire);
-    }
+    auto size() const -> size_t { return m_used.load(std::memory_order::acquire); }
 
     /**
      * @return True if the ring buffer contains zero elements.
@@ -277,9 +261,9 @@ public:
 
         while (produce_waiters != nullptr)
         {
-            auto* next = produce_waiters->m_next;
+            auto* next                = produce_waiters->m_next;
             produce_waiters->m_result = ring_buffer_result::produce::notified;
-            produce_waiters->m_awaiting_coroutine.resume();
+            produce_waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             produce_waiters = next;
         }
 
@@ -304,9 +288,9 @@ public:
 
         while (consume_waiters != nullptr)
         {
-            auto* next = consume_waiters->m_next;
+            auto* next                = consume_waiters->m_next;
             consume_waiters->m_result = ring_buffer_result::consume::notified;
-            consume_waiters->m_awaiting_coroutine.resume();
+            consume_waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             consume_waiters = next;
         }
 
@@ -328,7 +312,8 @@ public:
 
         auto lk = co_await m_mutex.scoped_lock();
         // Only let one caller do the wake-ups, this can go from running or draining to stopped
-        if (!m_running_state.compare_exchange_strong(expected, running_state_t::stopped, std::memory_order::acq_rel, std::memory_order::relaxed))
+        if (!m_running_state.compare_exchange_strong(
+                expected, running_state_t::stopped, std::memory_order::acq_rel, std::memory_order::relaxed))
         {
             co_return;
         }
@@ -341,17 +326,17 @@ public:
 
         while (produce_waiters != nullptr)
         {
-            auto* next = produce_waiters->m_next;
+            auto* next                = produce_waiters->m_next;
             produce_waiters->m_result = ring_buffer_result::produce::stopped;
-            produce_waiters->m_awaiting_coroutine.resume();
+            produce_waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             produce_waiters = next;
         }
 
         while (consume_waiters != nullptr)
         {
-            auto* next = consume_waiters->m_next;
+            auto* next                = consume_waiters->m_next;
             consume_waiters->m_result = ring_buffer_result::consume::stopped;
-            consume_waiters->m_awaiting_coroutine.resume();
+            consume_waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             consume_waiters = next;
         }
 
@@ -364,7 +349,8 @@ public:
         auto lk = co_await m_mutex.scoped_lock();
         // Do not allow any more produces, the state must be in running to drain.
         auto expected = running_state_t::running;
-        if (!m_running_state.compare_exchange_strong(expected, running_state_t::draining, std::memory_order::acq_rel, std::memory_order::relaxed))
+        if (!m_running_state.compare_exchange_strong(
+                expected, running_state_t::draining, std::memory_order::acq_rel, std::memory_order::relaxed))
         {
             co_return;
         }
@@ -375,7 +361,7 @@ public:
         while (produce_waiters != nullptr)
         {
             auto* next = produce_waiters->m_next;
-            produce_waiters->m_awaiting_coroutine.resume();
+            produce_waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             produce_waiters = next;
         }
 
@@ -392,7 +378,10 @@ public:
      * Returns true if shutdown() or shutdown_drain() have been called on this coro::ring_buffer.
      * @return True if the coro::ring_buffer has been shutdown.
      */
-    [[nodiscard]] auto is_shutdown() const -> bool { return m_running_state.load(std::memory_order::acquire) != running_state_t::running; }
+    [[nodiscard]] auto is_shutdown() const -> bool
+    {
+        return m_running_state.load(std::memory_order::acquire) != running_state_t::running;
+    }
 
 private:
     friend produce_operation;
@@ -425,12 +414,12 @@ private:
                 auto* op = detail::awaiter_list_pop(m_produce_waiters);
                 if (op != nullptr)
                 {
-                    auto slot = m_front.fetch_add(1, std::memory_order::acq_rel) % num_elements;
+                    auto slot        = m_front.fetch_add(1, std::memory_order::acq_rel) % num_elements;
                     m_elements[slot] = std::move(op->m_e);
                     m_used.fetch_add(1, std::memory_order::release);
 
                     lk.unlock();
-                    op->m_awaiting_coroutine.resume();
+                    op->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
                     continue;
                 }
             }
@@ -448,13 +437,13 @@ private:
                 auto* op = detail::awaiter_list_pop(m_consume_waiters);
                 if (op != nullptr)
                 {
-                    auto slot = m_back.fetch_add(1, std::memory_order::acq_rel) % num_elements;
-                    op->m_e = std::move(m_elements[slot]);
+                    auto slot        = m_back.fetch_add(1, std::memory_order::acq_rel) % num_elements;
+                    op->m_e          = std::move(m_elements[slot]);
                     m_elements[slot] = std::nullopt;
                     m_used.fetch_sub(1, std::memory_order::release);
                     lk.unlock();
 
-                    op->m_awaiting_coroutine.resume();
+                    op->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
                     continue;
                 }
             }

--- a/include/coro/scheduler.hpp
+++ b/include/coro/scheduler.hpp
@@ -149,7 +149,7 @@ public:
             if (m_scheduler.m_opts.execution_strategy == execution_strategy_t::process_tasks_inline)
             {
                 m_scheduler.m_size.fetch_add(1, std::memory_order::release);
-                m_awaiting_coroutine = awaiting_coroutine;
+                m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
                 detail::awaiter_list_push(m_scheduler.m_scheduled_ops, this);
 
                 // Trigger the event to wake-up the scheduler if this event isn't currently triggered.
@@ -178,9 +178,9 @@ public:
          */
         auto await_resume() noexcept -> void {}
 
-        std::coroutine_handle<> m_awaiting_coroutine;
-        schedule_operation*     m_next{nullptr};
-        bool                    m_allocated{false};
+        schedule_operation*                  m_next{nullptr};
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
+        bool                                 m_allocated{false};
 
     private:
         /// The thread pool that this operation will execute on.

--- a/include/coro/semaphore.hpp
+++ b/include/coro/semaphore.hpp
@@ -37,11 +37,12 @@ template<std::ptrdiff_t max_value>
 class acquire_operation
 {
 public:
-    explicit acquire_operation(semaphore<max_value>& s) : m_semaphore(s) { }
+    explicit acquire_operation(semaphore<max_value>& s) : m_semaphore(s) {}
 
     [[nodiscard]] auto await_ready() const noexcept -> bool
     {
-        // If the semaphore is shutdown or a resources can be acquired without suspending release the lock and resume execution.
+        // If the semaphore is shutdown or a resources can be acquired without suspending release the lock and resume
+        // execution.
         if (m_semaphore.m_shutdown.load(std::memory_order::acquire) || m_semaphore.try_acquire())
         {
             m_semaphore.m_mutex.unlock();
@@ -59,7 +60,7 @@ public:
             return false;
         }
 
-        m_awaiting_coroutine = awaiting_coroutine;
+        m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
         detail::awaiter_list_push(m_semaphore.m_acquire_waiters, this);
         m_semaphore.m_mutex.unlock();
         return true;
@@ -74,9 +75,9 @@ public:
         return semaphore_acquire_result::acquired;
     }
 
-    acquire_operation<max_value>* m_next{nullptr};
-    semaphore<max_value>&         m_semaphore;
-    std::coroutine_handle<>       m_awaiting_coroutine;
+    acquire_operation<max_value>*        m_next{nullptr};
+    std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
+    semaphore<max_value>&                m_semaphore;
 };
 
 } // namespace detail
@@ -85,9 +86,7 @@ template<std::ptrdiff_t max_value>
 class semaphore
 {
 public:
-    explicit semaphore(const std::ptrdiff_t starting_value)
-        : m_counter(starting_value)
-    { }
+    explicit semaphore(const std::ptrdiff_t starting_value) : m_counter(starting_value) {}
 
     ~semaphore() { coro::sync_wait(shutdown()); }
 
@@ -108,7 +107,8 @@ public:
     }
 
     /**
-     * @brief Releases a resources back to the semaphore, if the semaphore is already at value() == max() this does nothing.
+     * @brief Releases a resources back to the semaphore, if the semaphore is already at value() == max() this does
+     * nothing.
      * @return
      */
     [[nodiscard]] auto release() -> coro::task<void>
@@ -126,7 +126,7 @@ public:
         if (waiter != nullptr)
         {
             m_mutex.unlock();
-            waiter->m_awaiting_coroutine.resume();
+            waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         }
         else
         {
@@ -149,7 +149,8 @@ public:
             {
                 return false;
             }
-        } while (!m_counter.compare_exchange_weak(expected, expected - 1, std::memory_order::acq_rel, std::memory_order::acquire));
+        } while (!m_counter.compare_exchange_weak(
+            expected, expected - 1, std::memory_order::acq_rel, std::memory_order::acquire));
 
         return true;
     }
@@ -184,7 +185,7 @@ public:
             while (waiter != nullptr)
             {
                 auto* next = waiter->m_next;
-                waiter->m_awaiting_coroutine.resume();
+                waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
                 waiter = next;
             }
         }

--- a/include/coro/shared_mutex.hpp
+++ b/include/coro/shared_mutex.hpp
@@ -20,13 +20,14 @@ struct shared_lock_operation
     explicit shared_lock_operation(coro::shared_mutex<executor_type>& shared_mutex, const bool exclusive)
         : m_shared_mutex(shared_mutex),
           m_exclusive(exclusive)
-    {}
+    {
+    }
     ~shared_lock_operation() = default;
 
-    shared_lock_operation(const shared_lock_operation&) = delete;
-    shared_lock_operation(shared_lock_operation&&) = delete;
+    shared_lock_operation(const shared_lock_operation&)                    = delete;
+    shared_lock_operation(shared_lock_operation&&)                         = delete;
     auto operator=(const shared_lock_operation&) -> shared_lock_operation& = delete;
-    auto operator=(shared_lock_operation&&) -> shared_lock_operation& = delete;
+    auto operator=(shared_lock_operation&&) -> shared_lock_operation&      = delete;
 
     auto await_ready() const noexcept -> bool
     {
@@ -63,8 +64,8 @@ struct shared_lock_operation
         }
         else
         {
-            tail_waiter->m_next = this;
-            m_shared_mutex.m_tail_waiter         = this;
+            tail_waiter->m_next          = this;
+            m_shared_mutex.m_tail_waiter = this;
         }
 
         // If this is an exclusive lock acquire then mark it as so so that shared locks after this
@@ -74,20 +75,20 @@ struct shared_lock_operation
             ++m_shared_mutex.m_exclusive_waiters;
         }
 
-        m_awaiting_coroutine = awaiting_coroutine;
+        m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
         m_shared_mutex.m_mutex.unlock();
         return true;
     }
 
-    auto await_resume() noexcept -> void { }
+    auto await_resume() noexcept -> void {}
 
 protected:
     friend class coro::shared_mutex<executor_type>;
 
-    std::coroutine_handle<> m_awaiting_coroutine;
-    shared_lock_operation* m_next{nullptr};
-    coro::shared_mutex<executor_type>& m_shared_mutex;
-    bool m_exclusive{false};
+    shared_lock_operation*               m_next{nullptr};
+    std::atomic<std::coroutine_handle<>> m_awaiting_coroutine;
+    coro::shared_mutex<executor_type>&   m_shared_mutex;
+    bool                                 m_exclusive{false};
 };
 
 } // namespace detail
@@ -210,7 +211,7 @@ public:
      */
     [[nodiscard]] auto unlock_shared() -> coro::task<void>
     {
-        auto lk = co_await m_mutex.scoped_lock();
+        auto lk    = co_await m_mutex.scoped_lock();
         auto users = m_shared_users.fetch_sub(1, std::memory_order::acq_rel);
 
         // If this is the final unlock_shared() see if there is anyone to wakeup.
@@ -238,7 +239,7 @@ public:
      */
     [[nodiscard]] auto unlock() -> coro::task<void>
     {
-        auto lk = co_await m_mutex.scoped_lock();
+        auto  lk          = co_await m_mutex.scoped_lock();
         auto* head_waiter = m_head_waiter.load(std::memory_order::acquire);
         if (head_waiter != nullptr)
         {
@@ -257,10 +258,7 @@ public:
      *
      * @return executor_type&
      */
-    [[nodiscard]] auto executor() -> executor_type&
-    {
-        return *m_executor;
-    }
+    [[nodiscard]] auto executor() -> executor_type& { return *m_executor; }
 
 private:
     friend struct detail::shared_lock_operation<executor_type>;
@@ -349,7 +347,7 @@ private:
 
             // Since this is an exclusive lock waiting we can resume it directly.
             lk.unlock();
-            head_waiter->m_awaiting_coroutine.resume();
+            head_waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         }
         else
         {
@@ -376,7 +374,7 @@ private:
 
                 m_shared_users.fetch_add(1, std::memory_order::release);
 
-                m_executor->resume(to_resume->m_awaiting_coroutine);
+                m_executor->resume(to_resume->m_awaiting_coroutine.load(std::memory_order::acquire));
             }
 
             // Cannot unlock until the entire set of shared waiters has been traversed. I think this

--- a/include/coro/sync_wait.hpp
+++ b/include/coro/sync_wait.hpp
@@ -52,7 +52,7 @@ public:
     auto initial_suspend() noexcept -> std::suspend_always { return {}; }
 
 protected:
-    sync_wait_event*   m_event{nullptr};
+    sync_wait_event* m_event{nullptr};
 
     virtual ~sync_wait_task_promise_base() = default;
 };
@@ -86,8 +86,8 @@ public:
     auto get_return_object() noexcept { return coroutine_type::from_promise(*this); }
 
     template<typename value_type>
-        requires(return_type_is_reference and std::is_constructible_v<return_type, value_type &&>) or
-                (not return_type_is_reference and std::is_constructible_v<stored_type, value_type &&>)
+        requires(return_type_is_reference && std::is_constructible_v<return_type, value_type &&>) ||
+                    (!return_type_is_reference && std::is_constructible_v<stored_type, value_type &&>)
     auto return_value(value_type&& value) -> void
     {
         if constexpr (return_type_is_reference)
@@ -102,7 +102,7 @@ public:
     }
 
     auto return_value(stored_type value) -> void
-        requires(not return_type_is_reference)
+        requires(!return_type_is_reference)
     {
         if constexpr (std::is_move_constructible_v<stored_type>)
         {

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -88,8 +88,8 @@ public:
     auto get_return_object() noexcept -> task_type;
 
     template<typename value_type>
-        requires(return_type_is_reference && std::is_constructible_v<return_type, value_type &&>) or
-                    (not return_type_is_reference && std::is_constructible_v<stored_type, value_type &&>)
+        requires(return_type_is_reference && std::is_constructible_v<return_type, value_type &&>) ||
+                    (!return_type_is_reference && std::is_constructible_v<stored_type, value_type &&>)
     auto return_value(value_type&& value) -> void
     {
         if constexpr (return_type_is_reference)
@@ -104,7 +104,7 @@ public:
     }
 
     auto return_value(stored_type&& value) -> void
-        requires(not return_type_is_reference)
+        requires(!return_type_is_reference)
     {
         if constexpr (std::is_move_constructible_v<stored_type>)
         {

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <coroutine>
 #include <exception>
 #include <stdexcept>
@@ -72,9 +73,9 @@ public:
     using coroutine_handle                         = std::coroutine_handle<promise<return_type>>;
     static constexpr bool return_type_is_reference = std::is_reference_v<return_type>;
     using stored_type                              = std::conditional_t<
-        return_type_is_reference,
-        std::remove_reference_t<return_type>*,
-        std::remove_const_t<return_type>>;
+                                     return_type_is_reference,
+                                     std::remove_reference_t<return_type>*,
+                                     std::remove_const_t<return_type>>;
     using variant_type = std::variant<unset_return_value, stored_type, std::exception_ptr>;
 
     promise() noexcept {}
@@ -87,9 +88,9 @@ public:
     auto get_return_object() noexcept -> task_type;
 
     template<typename value_type>
-    requires(return_type_is_reference and std::is_constructible_v<return_type, value_type&&>) or
-        (not return_type_is_reference and
-         std::is_constructible_v<stored_type, value_type&&>) auto return_value(value_type&& value) -> void
+        requires(return_type_is_reference and std::is_constructible_v<return_type, value_type &&>) or
+                    (not return_type_is_reference and std::is_constructible_v<stored_type, value_type &&>)
+    auto return_value(value_type&& value) -> void
     {
         if constexpr (return_type_is_reference)
         {
@@ -102,7 +103,8 @@ public:
         }
     }
 
-    auto return_value(stored_type&& value) -> void requires(not return_type_is_reference)
+    auto return_value(stored_type&& value) -> void
+        requires(not return_type_is_reference)
     {
         if constexpr (std::is_move_constructible_v<stored_type>)
         {

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -88,8 +88,8 @@ public:
     auto get_return_object() noexcept -> task_type;
 
     template<typename value_type>
-        requires(return_type_is_reference and std::is_constructible_v<return_type, value_type &&>) or
-                    (not return_type_is_reference and std::is_constructible_v<stored_type, value_type &&>)
+        requires(return_type_is_reference && std::is_constructible_v<return_type, value_type &&>) or
+                    (not return_type_is_reference && std::is_constructible_v<stored_type, value_type &&>)
     auto return_value(value_type&& value) -> void
     {
         if constexpr (return_type_is_reference)

--- a/include/coro/task.hpp
+++ b/include/coro/task.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <coroutine>
 #include <exception>
@@ -26,14 +27,13 @@ struct promise_base
         {
             // If there is a continuation call it, otherwise this is the end of the line.
             auto& promise = coroutine.promise();
-            if (promise.m_continuation != nullptr)
+            auto c = promise.m_continuation.load(std::memory_order::acquire);
+            if (c != nullptr)
             {
-                return promise.m_continuation;
+                return c;
             }
-            else
-            {
-                return std::noop_coroutine();
-            }
+
+            return std::noop_coroutine();
         }
 
         auto await_resume() noexcept -> void
@@ -49,10 +49,10 @@ struct promise_base
 
     auto final_suspend() noexcept { return final_awaitable{}; }
 
-    auto continuation(std::coroutine_handle<> continuation) noexcept -> void { m_continuation = continuation; }
+    auto continuation(std::coroutine_handle<> continuation) noexcept -> void { m_continuation.store(continuation, std::memory_order::release); }
 
 protected:
-    std::coroutine_handle<> m_continuation{nullptr};
+    std::atomic<std::coroutine_handle<>> m_continuation{nullptr};
 };
 
 template<typename return_type>

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -35,6 +35,12 @@ public:
 
         std::thread                        m_thread;
         riften::Deque<schedule_operation*> m_queue{};
+
+        auto start() -> void;
+
+    private:
+        thread_pool_ws& m_thread_pool;
+        uint32_t        m_idx;
     };
 
     struct options

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -59,12 +59,13 @@ public:
         auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void;
         auto await_resume() noexcept -> void {}
 
-        schedule_operation*     m_next{nullptr};
-        std::coroutine_handle<> m_awaiting_coroutine{nullptr};
+        schedule_operation*                  m_next{nullptr};
+        std::coroutine_handle<>              m_awaiting_coroutine{nullptr};
+        std::atomic<std::coroutine_handle<>> m_atomic_coroutine{nullptr};
 
     private:
-        thread_pool_ws& m_thread_pool;
-        bool            m_allocated{false};
+        thread_pool_ws&   m_thread_pool;
+        std::atomic<bool> m_allocated{false};
     };
 
     /**

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "coro/detail/awaiter_list.hpp"
+#include "coro/detail/riften_deque.hpp"
 #include "coro/detail/task_self_deleting.hpp"
 #include "coro/task.hpp"
 
 #include <chrono>
 #include <condition_variable>
 #include <functional>
-#include <riften/deque.hpp>
+// #include <riften/deque.hpp>
 #include <thread>
 
 namespace coro

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -60,8 +60,7 @@ public:
         auto await_resume() noexcept -> void {}
 
         schedule_operation*                  m_next{nullptr};
-        std::coroutine_handle<>              m_awaiting_coroutine{nullptr};
-        std::atomic<std::coroutine_handle<>> m_atomic_coroutine{nullptr};
+        std::atomic<std::coroutine_handle<>> m_awaiting_coroutine{nullptr};
 
     private:
         thread_pool_ws&   m_thread_pool;

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -38,6 +38,10 @@ public:
 
         auto start() -> void;
 
+        std::atomic<bool> m_sleeping{false};
+        std::mutex m_wait_mutex{};
+        std::condition_variable m_wait_cv{};
+
     private:
         thread_pool_ws& m_thread_pool;
         uint32_t        m_idx;
@@ -58,7 +62,7 @@ public:
     class schedule_operation
     {
         friend class thread_pool_ws;
-        explicit schedule_operation(thread_pool_ws& tp) noexcept;
+        explicit schedule_operation(thread_pool_ws& tp, bool allocated = false) noexcept;
 
     public:
         auto await_ready() noexcept -> bool { return false; }
@@ -70,7 +74,7 @@ public:
 
     private:
         thread_pool_ws&   m_thread_pool;
-        std::atomic<bool> m_allocated{false};
+        std::atomic<bool> m_allocated;
     };
 
     /**
@@ -123,7 +127,7 @@ private:
     std::atomic<schedule_operation*>            m_global_queue{nullptr};
     std::atomic<uint32_t>                       m_sleeping{0};
     std::mutex                                  m_wait_mutex{};
-    std::condition_variable_any                 m_wait_cv{};
+    // std::condition_variable_any                 m_wait_cv{};
     std::atomic<uint32_t>                       m_workers_started{0};
     std::atomic<uint32_t>                       m_workers_stopped{0};
     std::atomic<uint64_t>                       m_try_wake_workers_size{0};

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "coro/detail/awaiter_list.hpp"
+#include "coro/task.hpp"
+
+#include <chrono>
+#include <riften/deque.hpp>
+#include <thread>
+
+namespace coro
+{
+
+class thread_pool_ws
+{
+public:
+    struct options
+    {
+        uint32_t worker_count = std::thread::hardware_concurrency();
+    };
+
+    class schedule_operation
+    {
+        friend class thread_pool_ws;
+        explicit schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp) {}
+
+    public:
+        auto await_ready() noexcept -> bool { return false; }
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
+        {
+            m_awaiting_coroutine = awaiting_coroutine;
+            // See if we are running on a thread pool worker to enqueue locally.
+            auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
+            if (idx.has_value())
+            {
+                m_thread_pool.m_queues[idx.value()]->emplace(this);
+            }
+            else
+            {
+                detail::awaiter_list_push(m_thread_pool.m_global_queue, this);
+            }
+        }
+        auto await_resume() noexcept -> void {}
+
+        schedule_operation*     m_next{nullptr};
+        std::coroutine_handle<> m_awaiting_coroutine{nullptr};
+
+    private:
+        thread_pool_ws& m_thread_pool;
+    };
+
+    thread_pool_ws(options opts = options{.worker_count = std::thread::hardware_concurrency()})
+    {
+        for (uint32_t i = 0; i < opts.worker_count; ++i)
+        {
+            m_queues.emplace_back(std::make_unique<riften::Deque<schedule_operation*>>());
+        }
+
+        m_workers.reserve(opts.worker_count);
+        for (uint32_t i = 0; i < opts.worker_count; ++i)
+        {
+            m_workers.emplace_back([this, i](std::stop_token st) -> void { this->execute(std::move(st), i); });
+        }
+    }
+
+    ~thread_pool_ws();
+
+    thread_pool_ws(const thread_pool_ws&)                             = delete;
+    thread_pool_ws(thread_pool_ws&&)                                  = delete;
+    auto operator=(const thread_pool_ws&) noexcept -> thread_pool_ws& = delete;
+    auto operator=(thread_pool_ws&&) noexcept -> thread_pool_ws&      = delete;
+
+    auto schedule() -> schedule_operation;
+    template<typename return_type>
+    auto schedule(coro::task<return_type> user_task) -> coro::task<return_type>
+    {
+        co_await schedule();
+        co_return co_await user_task;
+    }
+
+    auto spawn_detached(coro::task<void> user_task) -> bool
+    {
+        (void)user_task;
+        return false;
+    }
+
+    auto spawn_joinable(coro::task<void> user_task) -> coro::task<void> { co_return co_await user_task; }
+
+    auto yield() -> schedule_operation { return schedule_operation{*this}; }
+
+    auto resume(std::coroutine_handle<> handle) -> bool
+    {
+        (void)handle;
+        return true;
+    }
+
+    auto size() -> std::size_t { return 0; }
+
+    auto empty() -> bool { return false; }
+
+    auto shutdown() -> void {}
+
+private:
+    friend schedule_operation;
+
+    std::vector<std::jthread>                                        m_workers{};
+    std::vector<std::unique_ptr<riften::Deque<schedule_operation*>>> m_queues;
+    std::atomic<schedule_operation*>                                 m_global_queue{nullptr};
+    static thread_local std::optional<uint32_t>                      m_thread_pool_queue_idx;
+
+    auto execute(std::stop_token st, uint32_t idx) -> void;
+    auto drain_thread_queue(riften::Deque<schedule_operation*>& queue) -> bool;
+    auto try_steal(uint32_t my_idx) -> bool;
+    auto drain_peer_queue(riften::Deque<schedule_operation*>& queue) -> bool;
+    auto drain_global_queue(riften::Deque<schedule_operation*>& queue) -> bool;
+};
+
+} // namespace coro

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -33,7 +33,7 @@ public:
         auto operator=(const worker_info&) noexcept -> worker_info& = delete;
         auto operator=(worker_info&&) noexcept -> worker_info&      = delete;
 
-        std::jthread                       m_thread;
+        std::thread                        m_thread;
         std::mutex                         m_wait_mutex{};
         std::condition_variable_any        m_wait_cv{};
         riften::Deque<schedule_operation*> m_queue{};
@@ -120,7 +120,7 @@ private:
     std::atomic<uint32_t>                       m_sleeping{0};
     static thread_local std::optional<uint32_t> m_thread_pool_queue_idx;
 
-    auto execute(std::stop_token st, uint32_t idx) -> void;
+    auto execute(uint32_t idx) -> void;
     auto drain_thread_queue(riften::Deque<schedule_operation*>& queue) -> bool;
     auto try_steal(uint32_t my_idx) -> bool;
     auto drain_peer_queue(riften::Deque<schedule_operation*>& queue) -> bool;

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -34,10 +34,7 @@ public:
         auto operator=(worker_info&&) noexcept -> worker_info&      = delete;
 
         std::thread                        m_thread;
-        std::mutex                         m_wait_mutex{};
-        std::condition_variable_any        m_wait_cv{};
         riften::Deque<schedule_operation*> m_queue{};
-        std::atomic<bool>                  m_asleep{false};
     };
 
     struct options
@@ -115,9 +112,12 @@ private:
     options                                     m_opts;
     std::atomic<bool>                           m_shutdown_requested{false};
     std::atomic<uint64_t>                       m_size{0};
+    std::atomic<uint64_t>                       m_queue_size{0};
     std::vector<std::unique_ptr<worker_info>>   m_workers{};
     std::atomic<schedule_operation*>            m_global_queue{nullptr};
     std::atomic<uint32_t>                       m_sleeping{0};
+    std::mutex                                  m_wait_mutex{};
+    std::condition_variable_any                 m_wait_cv{};
     static thread_local std::optional<uint32_t> m_thread_pool_queue_idx;
 
     auto execute(uint32_t idx) -> void;

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -4,6 +4,8 @@
 #include "coro/task.hpp"
 
 #include <chrono>
+#include <condition_variable>
+#include <functional>
 #include <riften/deque.hpp>
 #include <thread>
 
@@ -12,33 +14,51 @@ namespace coro
 
 class thread_pool_ws
 {
+    struct private_constructor
+    {
+        explicit private_constructor() = default;
+    };
+
 public:
+    class schedule_operation;
+
+    struct worker_info
+    {
+        worker_info(thread_pool_ws& tp, uint32_t i);
+        ~worker_info() = default;
+
+        worker_info(const worker_info&)                             = delete;
+        worker_info(worker_info&&)                                  = delete;
+        auto operator=(const worker_info&) noexcept -> worker_info& = delete;
+        auto operator=(worker_info&&) noexcept -> worker_info&      = delete;
+
+        std::jthread                       m_thread;
+        std::mutex                         m_wait_mutex{};
+        std::condition_variable_any        m_wait_cv{};
+        riften::Deque<schedule_operation*> m_queue{};
+        std::atomic<bool>                  m_asleep{false};
+    };
+
     struct options
     {
-        uint32_t worker_count = std::thread::hardware_concurrency();
+        /// @brief The number of executor threads for this thread pool. Uses std::hardware_concurrency() by default.
+        uint32_t thread_count = std::thread::hardware_concurrency();
+        /// @brief Functor to call on each executor thread upon starting execution. The parameter is the thread's ID
+        /// assigned to it by the thread pool.
+        std::function<void(std::size_t)> on_thread_start_functor = nullptr;
+        /// @brief Functor to call on each executor thread upon stopping execution. The parameter is the thread's ID
+        /// assigned to it by the thread pool.
+        std::function<void(std::size_t)> on_thread_stop_functor = nullptr;
     };
 
     class schedule_operation
     {
         friend class thread_pool_ws;
-        explicit schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp) {}
+        explicit schedule_operation(thread_pool_ws& tp) noexcept;
 
     public:
         auto await_ready() noexcept -> bool { return false; }
-        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
-        {
-            m_awaiting_coroutine = awaiting_coroutine;
-            // See if we are running on a thread pool worker to enqueue locally.
-            auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
-            if (idx.has_value())
-            {
-                m_thread_pool.m_queues[idx.value()]->emplace(this);
-            }
-            else
-            {
-                detail::awaiter_list_push(m_thread_pool.m_global_queue, this);
-            }
-        }
+        auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void;
         auto await_resume() noexcept -> void {}
 
         schedule_operation*     m_next{nullptr};
@@ -46,21 +66,20 @@ public:
 
     private:
         thread_pool_ws& m_thread_pool;
+        bool            m_allocated{false};
     };
 
-    thread_pool_ws(options opts = options{.worker_count = std::thread::hardware_concurrency()})
-    {
-        for (uint32_t i = 0; i < opts.worker_count; ++i)
-        {
-            m_queues.emplace_back(std::make_unique<riften::Deque<schedule_operation*>>());
-        }
+    /**
+     * @see thread_pool_ws::make_unique
+     */
+    thread_pool_ws(options opts, private_constructor);
 
-        m_workers.reserve(opts.worker_count);
-        for (uint32_t i = 0; i < opts.worker_count; ++i)
-        {
-            m_workers.emplace_back([this, i](std::stop_token st) -> void { this->execute(std::move(st), i); });
-        }
-    }
+    static auto make_unique(
+        options opts = options{
+            .thread_count            = std::thread::hardware_concurrency(),
+            .on_thread_start_functor = nullptr,
+            .on_thread_stop_functor  = nullptr,
+        }) -> std::unique_ptr<thread_pool_ws>;
 
     ~thread_pool_ws();
 
@@ -69,49 +88,44 @@ public:
     auto operator=(const thread_pool_ws&) noexcept -> thread_pool_ws& = delete;
     auto operator=(thread_pool_ws&&) noexcept -> thread_pool_ws&      = delete;
 
-    auto schedule() -> schedule_operation;
+    [[nodiscard]] auto thread_count() const noexcept -> size_t { return m_workers.size(); }
+
+    [[nodiscard]] auto schedule() -> schedule_operation;
+
     template<typename return_type>
-    auto schedule(coro::task<return_type> user_task) -> coro::task<return_type>
+    [[nodiscard]] auto schedule(coro::task<return_type> user_task) -> coro::task<return_type>
     {
         co_await schedule();
         co_return co_await user_task;
     }
+    auto spawn_detached(coro::task<void> user_task) -> bool;
+    auto spawn_joinable(coro::task<void> user_task) -> coro::task<void>;
 
-    auto spawn_detached(coro::task<void> user_task) -> bool
-    {
-        (void)user_task;
-        return false;
-    }
-
-    auto spawn_joinable(coro::task<void> user_task) -> coro::task<void> { co_return co_await user_task; }
-
-    auto yield() -> schedule_operation { return schedule_operation{*this}; }
-
-    auto resume(std::coroutine_handle<> handle) -> bool
-    {
-        (void)handle;
-        return true;
-    }
-
-    auto size() -> std::size_t { return 0; }
-
-    auto empty() -> bool { return false; }
-
-    auto shutdown() -> void {}
+    [[nodiscard]] auto yield() -> schedule_operation { return schedule_operation{*this}; }
+    auto               resume(std::coroutine_handle<> handle) noexcept -> bool;
+    auto               size() noexcept -> std::size_t { return m_size.load(std::memory_order::acquire); }
+    auto               empty() noexcept -> bool { return size() == 0; }
+    [[nodiscard]] auto is_shutdown() const -> bool { return m_shutdown_requested.load(std::memory_order::acquire); }
+    auto               shutdown() noexcept -> void;
 
 private:
     friend schedule_operation;
 
-    std::vector<std::jthread>                                        m_workers{};
-    std::vector<std::unique_ptr<riften::Deque<schedule_operation*>>> m_queues;
-    std::atomic<schedule_operation*>                                 m_global_queue{nullptr};
-    static thread_local std::optional<uint32_t>                      m_thread_pool_queue_idx;
+    options                                     m_opts;
+    std::atomic<bool>                           m_shutdown_requested{false};
+    std::atomic<uint64_t>                       m_size{0};
+    std::vector<std::unique_ptr<worker_info>>   m_workers{};
+    std::atomic<schedule_operation*>            m_global_queue{nullptr};
+    std::atomic<uint32_t>                       m_sleeping{0};
+    static thread_local std::optional<uint32_t> m_thread_pool_queue_idx;
 
     auto execute(std::stop_token st, uint32_t idx) -> void;
     auto drain_thread_queue(riften::Deque<schedule_operation*>& queue) -> bool;
     auto try_steal(uint32_t my_idx) -> bool;
     auto drain_peer_queue(riften::Deque<schedule_operation*>& queue) -> bool;
     auto drain_global_queue(riften::Deque<schedule_operation*>& queue) -> bool;
+    auto resume_task(std::optional<schedule_operation*> op) -> bool;
+    auto try_wake_worker() noexcept -> void;
 };
 
 } // namespace coro

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "coro/detail/awaiter_list.hpp"
+#include "coro/detail/task_self_deleting.hpp"
 #include "coro/task.hpp"
 
 #include <chrono>

--- a/include/coro/thread_pool_ws.hpp
+++ b/include/coro/thread_pool_ws.hpp
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <functional>
-// #include <riften/deque.hpp>
 #include <thread>
 
 namespace coro
@@ -125,6 +124,9 @@ private:
     std::atomic<uint32_t>                       m_sleeping{0};
     std::mutex                                  m_wait_mutex{};
     std::condition_variable_any                 m_wait_cv{};
+    std::atomic<uint32_t>                       m_workers_started{0};
+    std::atomic<uint32_t>                       m_workers_stopped{0};
+    std::atomic<uint64_t>                       m_try_wake_workers_size{0};
     static thread_local std::optional<uint32_t> m_thread_pool_queue_idx;
 
     auto execute(uint32_t idx) -> void;

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -4,22 +4,14 @@
 namespace coro
 {
 
-condition_variable::awaiter_base::awaiter_base(
-    coro::condition_variable& cv,
-    coro::scoped_lock& l)
+condition_variable::awaiter_base::awaiter_base(coro::condition_variable& cv, coro::scoped_lock& l)
     : m_condition_variable(cv),
-        m_lock(l)
+      m_lock(l)
 {
-
 }
 
-condition_variable::awaiter::awaiter(
-    coro::condition_variable& cv,
-    coro::scoped_lock& l
-) noexcept
-    : awaiter_base(cv, l)
+condition_variable::awaiter::awaiter(coro::condition_variable& cv, coro::scoped_lock& l) noexcept : awaiter_base(cv, l)
 {
-
 }
 
 auto condition_variable::awaiter::await_ready() const noexcept -> bool
@@ -29,7 +21,7 @@ auto condition_variable::awaiter::await_ready() const noexcept -> bool
 
 auto condition_variable::awaiter::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
 {
-    m_awaiting_coroutine = awaiting_coroutine;
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
     coro::detail::awaiter_list_push(m_condition_variable.m_awaiters, static_cast<awaiter_base*>(this));
     m_lock.m_mutex->unlock();
     return true;
@@ -39,27 +31,26 @@ auto condition_variable::awaiter::on_notify() -> coro::task<condition_variable::
 {
     // Re-lock, the waiter is now responsible for unlocking.
     co_await m_lock.m_mutex->lock();
-    m_awaiting_coroutine.resume();
+    m_awaiting_coroutine.load(std::memory_order::acquire).resume();
     co_return notify_status_t::ready;
 }
 
 condition_variable::awaiter_with_predicate::awaiter_with_predicate(
-    coro::condition_variable& cv,
-    coro::scoped_lock& l,
-    condition_variable::predicate_type p
-) noexcept
+    coro::condition_variable& cv, coro::scoped_lock& l, condition_variable::predicate_type p) noexcept
     : awaiter_base(cv, l),
       m_predicate(std::move(p))
-{}
+{
+}
 
 auto condition_variable::awaiter_with_predicate::await_ready() const noexcept -> bool
 {
     return m_predicate();
 }
 
-auto condition_variable::awaiter_with_predicate::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+auto condition_variable::awaiter_with_predicate::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept
+    -> bool
 {
-    m_awaiting_coroutine = awaiting_coroutine;
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
     coro::detail::awaiter_list_push(m_condition_variable.m_awaiters, static_cast<awaiter_base*>(this));
     m_lock.m_mutex->unlock();
     return true;
@@ -70,7 +61,7 @@ auto condition_variable::awaiter_with_predicate::on_notify() -> coro::task<condi
     co_await m_lock.m_mutex->lock();
     if (m_predicate())
     {
-        m_awaiting_coroutine.resume();
+        m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         co_return notify_status_t::ready;
     }
 
@@ -81,16 +72,14 @@ auto condition_variable::awaiter_with_predicate::on_notify() -> coro::task<condi
 #ifndef EMSCRIPTEN
 
 condition_variable::awaiter_with_predicate_stop_token::awaiter_with_predicate_stop_token(
-    coro::condition_variable& cv,
-    coro::scoped_lock& l,
+    coro::condition_variable&          cv,
+    coro::scoped_lock&                 l,
     condition_variable::predicate_type p,
-    std::stop_token stop_token
-) noexcept
+    std::stop_token                    stop_token) noexcept
     : awaiter_base(cv, l),
       m_predicate(std::move(p)),
       m_stop_token(std::move(stop_token))
 {
-
 }
 
 auto condition_variable::awaiter_with_predicate_stop_token::await_ready() noexcept -> bool
@@ -99,15 +88,17 @@ auto condition_variable::awaiter_with_predicate_stop_token::await_ready() noexce
     return m_predicate_result;
 }
 
-auto condition_variable::awaiter_with_predicate_stop_token::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
+auto condition_variable::awaiter_with_predicate_stop_token::await_suspend(
+    std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
 {
-    m_awaiting_coroutine = awaiting_coroutine;
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
     coro::detail::awaiter_list_push(m_condition_variable.m_awaiters, static_cast<awaiter_base*>(this));
     m_lock.m_mutex->unlock();
     return true;
 }
 
-auto condition_variable::awaiter_with_predicate_stop_token::on_notify() -> coro::task<condition_variable::notify_status_t>
+auto condition_variable::awaiter_with_predicate_stop_token::on_notify()
+    -> coro::task<condition_variable::notify_status_t>
 {
     co_await m_lock.m_mutex->lock();
     m_predicate_result = m_predicate();
@@ -115,7 +106,7 @@ auto condition_variable::awaiter_with_predicate_stop_token::on_notify() -> coro:
     // If the predicate is ready or a stop has been requested resume.
     if (m_predicate_result || m_stop_token.stop_requested())
     {
-        m_awaiting_coroutine.resume();
+        m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         co_return notify_status_t::ready;
     }
 
@@ -128,28 +119,22 @@ auto condition_variable::awaiter_with_predicate_stop_token::on_notify() -> coro:
 #ifdef LIBCORO_FEATURE_NETWORKING
 
 condition_variable::controller_data::controller_data(
-    std::optional<std::cv_status>& status,
-    bool& predicate_result,
+    std::optional<std::cv_status>&                    status,
+    bool&                                             predicate_result,
     std::optional<condition_variable::predicate_type> predicate,
-    std::optional<const std::stop_token> stop_token
-) noexcept
+    std::optional<const std::stop_token>              stop_token) noexcept
     : m_status(status),
       m_predicate_result(predicate_result),
       m_predicate(std::move(predicate)),
       m_stop_token({std::move(stop_token)})
 {
-
 }
 
 condition_variable::awaiter_with_wait_hook::awaiter_with_wait_hook(
-    coro::condition_variable& cv,
-    coro::scoped_lock& l,
-    condition_variable::controller_data& data
-) noexcept
+    coro::condition_variable& cv, coro::scoped_lock& l, condition_variable::controller_data& data) noexcept
     : awaiter_base(cv, l),
       m_data(data)
 {
-
 }
 
 auto condition_variable::awaiter_with_wait_hook::on_notify() -> coro::task<condition_variable::notify_status_t>
@@ -255,10 +240,8 @@ auto condition_variable::wait(coro::scoped_lock& lock) -> awaiter
     return awaiter{*this, lock};
 }
 
-auto condition_variable::wait(
-    coro::scoped_lock& lock,
-    condition_variable::predicate_type predicate
-) -> awaiter_with_predicate
+auto condition_variable::wait(coro::scoped_lock& lock, condition_variable::predicate_type predicate)
+    -> awaiter_with_predicate
 {
     return awaiter_with_predicate{*this, lock, std::move(predicate)};
 }
@@ -266,10 +249,9 @@ auto condition_variable::wait(
 #ifndef EMSCRIPTEN
 
 auto condition_variable::wait(
-    coro::scoped_lock& lock,
-    std::stop_token stop_token,
-    condition_variable::predicate_type predicate
-) -> awaiter_with_predicate_stop_token
+    coro::scoped_lock&                 lock,
+    std::stop_token                    stop_token,
+    condition_variable::predicate_type predicate) -> awaiter_with_predicate_stop_token
 {
     return awaiter_with_predicate_stop_token{*this, lock, std::move(predicate), std::move(stop_token)};
 }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -26,7 +26,7 @@ auto event::set(resume_order_policy policy) noexcept -> void
         while (waiters != nullptr)
         {
             auto* next = waiters->m_next;
-            waiters->m_awaiting_coroutine.resume();
+            waiters->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             waiters = next;
         }
     }
@@ -41,7 +41,7 @@ auto event::awaiter::await_suspend(std::coroutine_handle<> awaiting_coroutine) n
 {
     const void* const set_state = &m_event;
 
-    m_awaiting_coroutine = awaiting_coroutine;
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
 
     // This value will update if other threads write to it via acquire.
     void* old_value = m_event.m_state.load(std::memory_order::acquire);

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -1,5 +1,5 @@
-#include "coro/detail/awaiter_list.hpp"
 #include "coro/mutex.hpp"
+#include "coro/detail/awaiter_list.hpp"
 
 namespace coro
 {
@@ -12,9 +12,9 @@ auto lock_operation_base::await_ready() const noexcept -> bool
 
 auto lock_operation_base::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> bool
 {
-    m_awaiting_coroutine = awaiting_coroutine;
-    auto& state = m_mutex.m_state;
-    void* current = state.load(std::memory_order::acquire);
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
+    auto&       state          = m_mutex.m_state;
+    void*       current        = state.load(std::memory_order::acquire);
     const void* unlocked_value = m_mutex.unlocked_value();
     do
     {
@@ -27,7 +27,7 @@ auto lock_operation_base::await_suspend(std::coroutine_handle<> awaiting_corouti
             if (state.compare_exchange_weak(current, nullptr, std::memory_order::acq_rel, std::memory_order::acquire))
             {
                 // We've acquired the lock, don't suspend.
-                m_awaiting_coroutine = nullptr;
+                m_awaiting_coroutine.store(nullptr, std::memory_order::release);
                 return false;
             }
         }
@@ -35,7 +35,8 @@ auto lock_operation_base::await_suspend(std::coroutine_handle<> awaiting_corouti
         {
             // The lock is still owned, attempt to add ourself as a waiter.
             m_next = static_cast<lock_operation_base*>(current);
-            if (state.compare_exchange_weak(current, static_cast<void*>(this), std::memory_order::acq_rel, std::memory_order::acquire))
+            if (state.compare_exchange_weak(
+                    current, static_cast<void*>(this), std::memory_order::acq_rel, std::memory_order::acquire))
             {
                 // We've successfully added ourself to the waiter queue.
                 return true;
@@ -82,10 +83,10 @@ auto mutex::unlock() -> void
         if (current == nullptr)
         {
             if (m_state.compare_exchange_weak(
-                current,
-                const_cast<void*>(unlocked_value()),
-                std::memory_order::acq_rel,
-                std::memory_order::acquire))
+                    current,
+                    const_cast<void*>(unlocked_value()),
+                    std::memory_order::acq_rel,
+                    std::memory_order::acquire))
             {
                 // We've successfully unlocked the mutex, return since there are no current waiters.
                 std::atomic_thread_fence(std::memory_order::acq_rel);
@@ -93,20 +94,22 @@ auto mutex::unlock() -> void
             }
             else
             {
-                // This means someone has added themselves as a waiter, we need to try again with our updated current state.
-                // assert(m_state now holds a lock_operation_base*)
+                // This means someone has added themselves as a waiter, we need to try again with our updated current
+                // state. assert(m_state now holds a lock_operation_base*)
                 continue;
             }
         }
         else
         {
-            // There are waiters, lets wake the first one up. This will set the state to the next waiter, or nullptr (no waiters but locked).
-            std::atomic<detail::lock_operation_base*>* casted = reinterpret_cast<std::atomic<detail::lock_operation_base*>*>(&m_state);
+            // There are waiters, lets wake the first one up. This will set the state to the next waiter, or nullptr (no
+            // waiters but locked).
+            std::atomic<detail::lock_operation_base*>* casted =
+                reinterpret_cast<std::atomic<detail::lock_operation_base*>*>(&m_state);
             auto* waiter = detail::awaiter_list_pop<detail::lock_operation_base>(*casted);
             // assert waiter != nullptr, nobody else should be unlocking this mutex.
             // Directly transfer control to the waiter, they are now responsible for unlocking the mutex.
             std::atomic_thread_fence(std::memory_order::acq_rel);
-            waiter->m_awaiting_coroutine.resume();
+            waiter->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
             return;
         }
     } while (true);

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -370,7 +370,7 @@ auto scheduler::process_scheduled_execute_inline() -> void
         while (ops != nullptr)
         {
             auto* next = ops->m_next;
-            m_handles_to_resume.emplace_back(ops->m_awaiting_coroutine);
+            m_handles_to_resume.emplace_back(ops->m_awaiting_coroutine.load(std::memory_order::acquire));
 
             if (ops->m_allocated)
             {
@@ -410,7 +410,7 @@ auto scheduler::process_event_execute(detail::poll_info* pi, poll_status status)
             std::atomic_thread_fence(std::memory_order::acquire);
         }
 
-        m_handles_to_resume.emplace_back(pi->m_awaiting_coroutine);
+        m_handles_to_resume.emplace_back(pi->m_awaiting_coroutine.load(std::memory_order::acquire));
     }
 }
 
@@ -457,7 +457,7 @@ auto scheduler::process_timeout_execute() -> void
                 std::atomic_thread_fence(std::memory_order::acquire);
             }
 
-            m_handles_to_resume.emplace_back(pi->m_awaiting_coroutine);
+            m_handles_to_resume.emplace_back(pi->m_awaiting_coroutine.load(std::memory_order::acquire));
             pi->m_poll_status = coro::poll_status::timeout;
         }
     }

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -286,6 +286,12 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
 
 auto thread_pool_ws::try_wake_worker() noexcept -> void
 {
+    // We're shutting down, no need to even attempt to wake any workers.
+    if (m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        return;
+    }
+
     // Attempt to wake a sleeper if there are any.
     if (m_sleeping.load(std::memory_order::acquire) > 0)
     {

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -182,7 +182,7 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
         had_tasks |= drain_global_queue(thread_queue);
 
         // If there were no tasks left to work on, this thread can exit.
-        if (had_tasks)
+        if (!had_tasks)
         {
             break;
         }

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -48,6 +48,7 @@ thread_pool_ws::~thread_pool_ws()
 
 thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp)
 {
+    m_thread_pool.m_queue_size.fetch_add(1, std::memory_order::release);
     m_thread_pool.m_size.fetch_add(1, std::memory_order::release);
 }
 
@@ -122,14 +123,17 @@ auto thread_pool_ws::shutdown() noexcept -> void
 {
     if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
     {
-        for (auto& worker : m_workers)
         {
-            std::unique_lock<std::mutex> lk{worker->m_wait_mutex};
-            worker->m_wait_cv.notify_one();
+            std::unique_lock<std::mutex> lk{m_wait_mutex};
+            m_wait_cv.notify_all();
         }
+
         for (auto& worker : m_workers)
         {
-            worker->m_thread.join();
+            if (worker->m_thread.joinable())
+            {
+                worker->m_thread.join();
+            }
         }
     }
 }
@@ -144,8 +148,6 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
     }
 
     auto&  info         = m_workers[idx];
-    auto&  wait_mutex   = info->m_wait_mutex;
-    auto&  wait_cv      = info->m_wait_cv;
     auto&  thread_queue = info->m_queue;
     size_t spin_counter{0};
     while (!m_shutdown_requested.load(std::memory_order::acquire))
@@ -165,14 +167,15 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
             continue;
         }
 
-        // Set our internal state to sleeping.
-        info->m_asleep.store(true, std::memory_order::release);
-        // Notify any schedule operations we are going to sleep.
-        m_sleeping.fetch_add(1, std::memory_order::release);
-
         // Go to sleep until a task is scheduled.
-        std::unique_lock<std::mutex> lk{wait_mutex};
-        wait_cv.wait(lk);
+        std::unique_lock<std::mutex> lk{m_wait_mutex};
+        m_sleeping.fetch_add(1, std::memory_order::release);
+        m_wait_cv.wait(
+            lk,
+            [&]() {
+                return m_queue_size.load(std::memory_order::acquire) > 0 ||
+                       m_shutdown_requested.load(std::memory_order::acquire);
+            });
     }
 
     while (m_size.load(std::memory_order::acquire) > 0)
@@ -258,6 +261,7 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
 {
     if (op.has_value())
     {
+        m_queue_size.fetch_sub(1, std::memory_order::release);
         auto v = op.value();
         v->m_awaiting_coroutine.resume();
         m_size.fetch_sub(1, std::memory_order::release);
@@ -272,31 +276,19 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
 
 auto thread_pool_ws::try_wake_worker() noexcept -> void
 {
-    // If there are any workers currently sleeping
-    auto expected_sleeping = m_sleeping.load(std::memory_order::acquire);
-    while (expected_sleeping > 0)
+    // Attempt to wake a sleeper if there are any.
+    auto sleeping = m_sleeping.load(std::memory_order::acquire);
+    if (sleeping > 0)
     {
-        // Attempt to "acquire" one to wake-up.
-        if (m_sleeping.compare_exchange_strong(
-                expected_sleeping, expected_sleeping - 1, std::memory_order::acq_rel, std::memory_order::acquire))
+        std::unique_lock<std::mutex> lk{m_wait_mutex};
+        sleeping = m_sleeping.load(std::memory_order::acquire);
+        if (sleeping == 0)
         {
-            for (auto& worker : m_workers)
-            {
-                bool expected_asleep{true};
-                if (worker->m_asleep.compare_exchange_strong(
-                        expected_asleep, false, std::memory_order::acq_rel, std::memory_order::relaxed))
-                {
-                    std::unique_lock<std::mutex> lk{worker->m_wait_mutex};
-                    worker->m_wait_cv.notify_one();
-                    return;
-                }
-            }
-
-            // If we get here without waking up.. not good!
-            std::cerr
-                << "thread_pool_ws::try_wake_worker() acquired thread to wake but failed to find a sleeping thread.\n";
             return;
         }
+
+        m_sleeping.fetch_sub(1, std::memory_order::release);
+        m_wait_cv.notify_one();
     }
 }
 

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -54,8 +54,7 @@ thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexc
 
 auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
 {
-    m_awaiting_coroutine = awaiting_coroutine;
-    m_atomic_coroutine.store(awaiting_coroutine, std::memory_order::release);
+    m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
     // See if we are running on a thread pool worker to enqueue locally.
     auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
     if (idx.has_value())
@@ -264,8 +263,7 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
     {
         m_queue_size.fetch_sub(1, std::memory_order::release);
         auto v = op.value();
-        // v->m_awaiting_coroutine.resume();
-        v->m_atomic_coroutine.load(std::memory_order::acquire).resume();
+        v->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         m_size.fetch_sub(1, std::memory_order::release);
         if (v->m_allocated.load(std::memory_order::acquire))
         {
@@ -279,12 +277,11 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
 auto thread_pool_ws::try_wake_worker() noexcept -> void
 {
     // Attempt to wake a sleeper if there are any.
-    auto sleeping = m_sleeping.load(std::memory_order::acquire);
-    if (sleeping > 0)
+    if (m_sleeping.load(std::memory_order::acquire) > 0)
     {
         std::unique_lock<std::mutex> lk{m_wait_mutex};
-        sleeping = m_sleeping.load(std::memory_order::acquire);
-        if (sleeping == 0)
+        // Check again after acquiring the lock to see if there are any sleeping workers.
+        if (m_sleeping.load(std::memory_order::acquire) == 0)
         {
             return;
         }

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -1,5 +1,4 @@
 #include "coro/thread_pool_ws.hpp"
-#include "coro/detail/task_self_deleting.hpp"
 #include "coro/task_group.hpp"
 
 #include <iostream>

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -1,29 +1,154 @@
 #include "coro/thread_pool_ws.hpp"
+#include "coro/detail/task_self_deleting.hpp"
+#include "coro/task_group.hpp"
 
 #include <iostream>
 
 namespace coro
 {
+namespace detail
+{
+static auto make_spawned_joinable_wait_task(std::unique_ptr<coro::task_group<coro::thread_pool_ws>> group_ptr)
+    -> coro::task<void>
+{
+    co_await *group_ptr;
+    co_return;
+}
+
+} // namespace detail
+
 thread_local std::optional<uint32_t> thread_pool_ws::m_thread_pool_queue_idx{std::nullopt};
+
+thread_pool_ws::worker_info::worker_info(thread_pool_ws& tp, uint32_t i)
+{
+    // Start the thread after all of the worker_info fields have been initialized.
+    m_thread = std::jthread([&tp, i](std::stop_token st) -> void { tp.execute(std::move(st), i); });
+}
+
+thread_pool_ws::thread_pool_ws(options opts, private_constructor) : m_opts(std::move(opts))
+{
+    m_workers.reserve(m_opts.thread_count);
+}
+
+auto thread_pool_ws::make_unique(options opts) -> std::unique_ptr<thread_pool_ws>
+{
+    auto tp = std::make_unique<thread_pool_ws>(std::move(opts), private_constructor{});
+
+    for (uint32_t i = 0; i < tp->m_opts.thread_count; ++i)
+    {
+        tp->m_workers.emplace_back(std::make_unique<worker_info>(*tp, i));
+    }
+
+    return tp;
+}
 
 thread_pool_ws::~thread_pool_ws()
 {
-    for (auto& worker : m_workers)
+    shutdown();
+}
+
+thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp)
+{
+    m_thread_pool.m_size.fetch_add(1, std::memory_order::release);
+}
+
+auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
+{
+    m_awaiting_coroutine = awaiting_coroutine;
+    // See if we are running on a thread pool worker to enqueue locally.
+    auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
+    if (idx.has_value())
     {
-        worker.request_stop();
-        worker.join();
+        m_thread_pool.m_workers[idx.value()]->m_queue.emplace(this);
     }
+    else
+    {
+        detail::awaiter_list_push(m_thread_pool.m_global_queue, this);
+    }
+
+    m_thread_pool.try_wake_worker();
 }
 
 auto thread_pool_ws::schedule() -> schedule_operation
 {
+    if (m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        throw std::runtime_error("coro::thread_pool_ws is shutting down, unable to schedule new tasks.");
+    }
+
     return schedule_operation(*this);
+}
+
+auto thread_pool_ws::spawn_detached(coro::task<void> user_task) -> bool
+{
+    if (m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        return false;
+    }
+
+    auto wrapper_task = detail::make_task_self_deleting(std::move(user_task));
+    return resume(wrapper_task.handle());
+}
+
+auto thread_pool_ws::spawn_joinable(coro::task<void> user_task) -> coro::task<void>
+{
+    if (m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        throw std::runtime_error("coro::thread_pool_ws is shutting down, unable to spawn new tasks.");
+    }
+
+    auto group_ptr = std::make_unique<coro::task_group<coro::thread_pool_ws>>(this, std::move(user_task));
+    return detail::make_spawned_joinable_wait_task(std::move(group_ptr));
+}
+
+auto thread_pool_ws::resume(std::coroutine_handle<> handle) noexcept -> bool
+{
+    if (handle == nullptr || handle.done())
+    {
+        return false;
+    }
+
+    if (m_shutdown_requested.load(std::memory_order::acquire))
+    {
+        return false;
+    }
+
+    auto* op        = new schedule_operation{*this};
+    op->m_allocated = true;
+    op->await_suspend(handle);
+    return true;
+}
+
+auto thread_pool_ws::shutdown() noexcept -> void
+{
+    if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
+    {
+        for (auto& worker : m_workers)
+        {
+            worker->m_thread.request_stop();
+            std::unique_lock<std::mutex> lk{worker->m_wait_mutex};
+            worker->m_wait_cv.notify_one();
+        }
+        for (auto& worker : m_workers)
+        {
+            worker->m_thread.join();
+        }
+    }
 }
 
 auto thread_pool_ws::execute(std::stop_token st, uint32_t idx) -> void
 {
     m_thread_pool_queue_idx = {idx};
-    auto&  thread_queue     = *m_queues[idx];
+
+    if (m_opts.on_thread_start_functor != nullptr)
+    {
+        m_opts.on_thread_start_functor(idx);
+    }
+
+    auto&  info         = m_workers[idx];
+    auto&  wait_mutex   = info->m_wait_mutex;
+    auto&  wait_cv      = info->m_wait_cv;
+    auto&  thread_queue = info->m_queue;
     size_t spin_counter{0};
     while (!st.stop_requested())
     {
@@ -42,7 +167,32 @@ auto thread_pool_ws::execute(std::stop_token st, uint32_t idx) -> void
             continue;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        // Set our internal state to sleeping.
+        info->m_asleep.store(true, std::memory_order::release);
+        // Notify any schedule operations we are going to sleep.
+        m_sleeping.fetch_add(1, std::memory_order::release);
+
+        // Go to sleep until a task is scheduled.
+        std::unique_lock<std::mutex> lk{wait_mutex};
+        wait_cv.wait(lk);
+    }
+
+    while (m_size.load(std::memory_order::acquire) > 0)
+    {
+        bool had_tasks = drain_thread_queue(thread_queue);
+        had_tasks |= try_steal(idx);
+        had_tasks |= drain_global_queue(thread_queue);
+
+        // If there were no tasks left to work on, this thread can exit.
+        if (had_tasks)
+        {
+            break;
+        }
+    }
+
+    if (m_opts.on_thread_stop_functor != nullptr)
+    {
+        m_opts.on_thread_stop_functor(idx);
     }
 }
 
@@ -51,12 +201,7 @@ auto thread_pool_ws::drain_thread_queue(riften::Deque<schedule_operation*>& queu
     bool had_task{false};
     while (!queue.empty())
     {
-        auto op = queue.pop();
-        if (op.has_value())
-        {
-            op.value()->m_awaiting_coroutine.resume();
-            had_task = true;
-        }
+        had_task |= resume_task(queue.pop());
     }
     return had_task;
 }
@@ -64,7 +209,7 @@ auto thread_pool_ws::drain_thread_queue(riften::Deque<schedule_operation*>& queu
 auto thread_pool_ws::try_steal(uint32_t my_idx) -> bool
 {
     bool had_tasks{false};
-    auto queue_size = m_queues.size();
+    auto queue_size = m_workers.size();
     for (size_t i = 0; i < queue_size; ++i)
     {
         if (i == my_idx)
@@ -72,7 +217,7 @@ auto thread_pool_ws::try_steal(uint32_t my_idx) -> bool
             continue;
         }
 
-        had_tasks |= drain_peer_queue(*m_queues[i]);
+        had_tasks |= drain_peer_queue(m_workers[i]->m_queue);
     }
     return had_tasks;
 }
@@ -82,12 +227,7 @@ auto thread_pool_ws::drain_peer_queue(riften::Deque<schedule_operation*>& queue)
     bool had_task{false};
     while (!queue.empty())
     {
-        auto op = queue.steal();
-        if (op.has_value())
-        {
-            op.value()->m_awaiting_coroutine.resume();
-            had_task = true;
-        }
+        had_task |= resume_task(queue.steal());
     }
     return had_task;
 }
@@ -107,11 +247,59 @@ auto thread_pool_ws::drain_global_queue(riften::Deque<schedule_operation*>& queu
             }
         }
 
-        // If another worker beat us to it notify there are tasks to try and steal.
+        // 1. If we got the global list we have tasks.
+        // 2. If we didn't get the global list we know we can possibly steal.
+        // Either way there should be tasks to process.
         return true;
     }
 
     return false;
+}
+
+auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
+{
+    if (op.has_value())
+    {
+        auto v = op.value();
+        v->m_awaiting_coroutine.resume();
+        m_size.fetch_sub(1, std::memory_order::release);
+        if (v->m_allocated)
+        {
+            delete v;
+        }
+        return true;
+    }
+    return false;
+}
+
+auto thread_pool_ws::try_wake_worker() noexcept -> void
+{
+    // If there are any workers currently sleeping
+    auto expected_sleeping = m_sleeping.load(std::memory_order::acquire);
+    while (expected_sleeping > 0)
+    {
+        // Attempt to "acquire" one to wake-up.
+        if (m_sleeping.compare_exchange_strong(
+                expected_sleeping, expected_sleeping - 1, std::memory_order::acq_rel, std::memory_order::acquire))
+        {
+            for (auto& worker : m_workers)
+            {
+                bool expected_asleep{true};
+                if (worker->m_asleep.compare_exchange_strong(
+                        expected_asleep, false, std::memory_order::acq_rel, std::memory_order::relaxed))
+                {
+                    std::unique_lock<std::mutex> lk{worker->m_wait_mutex};
+                    worker->m_wait_cv.notify_one();
+                    return;
+                }
+            }
+
+            // If we get here without waking up.. not good!
+            std::cerr
+                << "thread_pool_ws::try_wake_worker() acquired thread to wake but failed to find a sleeping thread.\n";
+            return;
+        }
+    }
 }
 
 } // namespace coro

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -1,0 +1,117 @@
+#include "coro/thread_pool_ws.hpp"
+
+#include <iostream>
+
+namespace coro
+{
+thread_local std::optional<uint32_t> thread_pool_ws::m_thread_pool_queue_idx{std::nullopt};
+
+thread_pool_ws::~thread_pool_ws()
+{
+    for (auto& worker : m_workers)
+    {
+        worker.request_stop();
+        worker.join();
+    }
+}
+
+auto thread_pool_ws::schedule() -> schedule_operation
+{
+    return schedule_operation(*this);
+}
+
+auto thread_pool_ws::execute(std::stop_token st, uint32_t idx) -> void
+{
+    m_thread_pool_queue_idx = {idx};
+    auto&  thread_queue     = *m_queues[idx];
+    size_t spin_counter{0};
+    while (!st.stop_requested())
+    {
+        bool had_tasks = drain_thread_queue(thread_queue);
+        had_tasks |= try_steal(idx);
+        had_tasks |= drain_global_queue(thread_queue);
+
+        if (had_tasks)
+        {
+            spin_counter = 0;
+            continue;
+        }
+
+        if (++spin_counter <= 100)
+        {
+            continue;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+}
+
+auto thread_pool_ws::drain_thread_queue(riften::Deque<schedule_operation*>& queue) -> bool
+{
+    bool had_task{false};
+    while (!queue.empty())
+    {
+        auto op = queue.pop();
+        if (op.has_value())
+        {
+            op.value()->m_awaiting_coroutine.resume();
+            had_task = true;
+        }
+    }
+    return had_task;
+}
+
+auto thread_pool_ws::try_steal(uint32_t my_idx) -> bool
+{
+    bool had_tasks{false};
+    auto queue_size = m_queues.size();
+    for (size_t i = 0; i < queue_size; ++i)
+    {
+        if (i == my_idx)
+        {
+            continue;
+        }
+
+        had_tasks |= drain_peer_queue(*m_queues[i]);
+    }
+    return had_tasks;
+}
+
+auto thread_pool_ws::drain_peer_queue(riften::Deque<schedule_operation*>& queue) -> bool
+{
+    bool had_task{false};
+    while (!queue.empty())
+    {
+        auto op = queue.steal();
+        if (op.has_value())
+        {
+            op.value()->m_awaiting_coroutine.resume();
+            had_task = true;
+        }
+    }
+    return had_task;
+}
+
+auto thread_pool_ws::drain_global_queue(riften::Deque<schedule_operation*>& queue) -> bool
+{
+    if (m_global_queue.load(std::memory_order::acquire) != nullptr)
+    {
+        auto* head_op = detail::awaiter_list_pop_all(m_global_queue);
+        if (head_op != nullptr)
+        {
+            while (head_op != nullptr)
+            {
+                auto* next_op = head_op->m_next;
+                queue.emplace(head_op);
+                head_op = next_op;
+            }
+        }
+
+        // If another worker beat us to it notify there are tasks to try and steal.
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace coro

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -21,7 +21,7 @@ thread_local std::optional<uint32_t> thread_pool_ws::m_thread_pool_queue_idx{std
 thread_pool_ws::worker_info::worker_info(thread_pool_ws& tp, uint32_t i)
 {
     // Start the thread after all of the worker_info fields have been initialized.
-    m_thread = std::jthread([&tp, i](std::stop_token st) -> void { tp.execute(std::move(st), i); });
+    m_thread = std::thread([&tp, i]() -> void { tp.execute(i); });
 }
 
 thread_pool_ws::thread_pool_ws(options opts, private_constructor) : m_opts(std::move(opts))
@@ -124,7 +124,6 @@ auto thread_pool_ws::shutdown() noexcept -> void
     {
         for (auto& worker : m_workers)
         {
-            worker->m_thread.request_stop();
             std::unique_lock<std::mutex> lk{worker->m_wait_mutex};
             worker->m_wait_cv.notify_one();
         }
@@ -135,7 +134,7 @@ auto thread_pool_ws::shutdown() noexcept -> void
     }
 }
 
-auto thread_pool_ws::execute(std::stop_token st, uint32_t idx) -> void
+auto thread_pool_ws::execute(uint32_t idx) -> void
 {
     m_thread_pool_queue_idx = {idx};
 
@@ -149,7 +148,7 @@ auto thread_pool_ws::execute(std::stop_token st, uint32_t idx) -> void
     auto&  wait_cv      = info->m_wait_cv;
     auto&  thread_queue = info->m_queue;
     size_t spin_counter{0};
-    while (!st.stop_requested())
+    while (!m_shutdown_requested.load(std::memory_order::acquire))
     {
         bool had_tasks = drain_thread_queue(thread_queue);
         had_tasks |= try_steal(idx);

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -18,15 +18,20 @@ static auto make_spawned_joinable_wait_task(std::unique_ptr<coro::task_group<cor
 
 thread_local std::optional<uint32_t> thread_pool_ws::m_thread_pool_queue_idx{std::nullopt};
 
-thread_pool_ws::worker_info::worker_info(thread_pool_ws& tp, uint32_t i)
+thread_pool_ws::worker_info::worker_info(thread_pool_ws& tp, uint32_t i) : m_thread_pool(tp), m_idx(i)
 {
-    // Start the thread after all of the worker_info fields have been initialized.
-    m_thread = std::thread([&tp, i]() -> void { tp.execute(i); });
 }
 
 thread_pool_ws::thread_pool_ws(options opts, private_constructor) : m_opts(std::move(opts))
 {
     m_workers.reserve(m_opts.thread_count);
+}
+
+auto thread_pool_ws::worker_info::start() -> void
+{
+    // Each worker's thread is only started after *all* worker_info structures are initialized
+    // since they all reference each other's queues for stealing.
+    m_thread = std::thread([this]() -> void { m_thread_pool.execute(m_idx); });
 }
 
 auto thread_pool_ws::make_unique(options opts) -> std::unique_ptr<thread_pool_ws>
@@ -36,6 +41,11 @@ auto thread_pool_ws::make_unique(options opts) -> std::unique_ptr<thread_pool_ws
     for (uint32_t i = 0; i < tp->m_opts.thread_count; ++i)
     {
         tp->m_workers.emplace_back(std::make_unique<worker_info>(*tp, i));
+    }
+
+    for (auto& worker : tp->m_workers)
+    {
+        worker->start();
     }
 
     return tp;

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -55,6 +55,7 @@ thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexc
 auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
 {
     m_awaiting_coroutine = awaiting_coroutine;
+    m_atomic_coroutine.store(awaiting_coroutine, std::memory_order::release);
     // See if we are running on a thread pool worker to enqueue locally.
     auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
     if (idx.has_value())
@@ -113,8 +114,8 @@ auto thread_pool_ws::resume(std::coroutine_handle<> handle) noexcept -> bool
         return false;
     }
 
-    auto* op        = new schedule_operation{*this};
-    op->m_allocated = true;
+    auto* op = new schedule_operation{*this};
+    op->m_allocated.store(true, std::memory_order::release);
     op->await_suspend(handle);
     return true;
 }
@@ -263,9 +264,10 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
     {
         m_queue_size.fetch_sub(1, std::memory_order::release);
         auto v = op.value();
-        v->m_awaiting_coroutine.resume();
+        // v->m_awaiting_coroutine.resume();
+        v->m_atomic_coroutine.load(std::memory_order::acquire).resume();
         m_size.fetch_sub(1, std::memory_order::release);
-        if (v->m_allocated)
+        if (v->m_allocated.load(std::memory_order::acquire))
         {
             delete v;
         }

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -158,18 +158,6 @@ auto thread_pool_ws::shutdown() noexcept -> void
             std::this_thread::yield();
         }
 
-        if (m_size.load(std::memory_order::acquire) > 0)
-        {
-            std::string msg = "shutdown() m_size = " + m_size.load() + '\n';
-            throw std::runtime_error{msg};
-        }
-
-        if (m_queue_size.load(std::memory_order::acquire) > 0)
-        {
-            std::string msg = "shutdown() m_queue_size = " + m_queue_size.load() + '\n';
-            throw std::runtime_error{msg};
-        }
-
         for (auto& worker : m_workers)
         {
             if (worker->m_thread.joinable())

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -48,6 +48,11 @@ auto thread_pool_ws::make_unique(options opts) -> std::unique_ptr<thread_pool_ws
         worker->start();
     }
 
+    while (tp->m_workers_started.load(std::memory_order::acquire) != tp->m_opts.thread_count)
+    {
+        std::this_thread::yield();
+    }
+
     return tp;
 }
 
@@ -58,8 +63,6 @@ thread_pool_ws::~thread_pool_ws()
 
 thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp)
 {
-    m_thread_pool.m_queue_size.fetch_add(1, std::memory_order::release);
-    m_thread_pool.m_size.fetch_add(1, std::memory_order::release);
 }
 
 auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
@@ -81,8 +84,14 @@ auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> a
 
 auto thread_pool_ws::schedule() -> schedule_operation
 {
+    m_try_wake_workers_size.fetch_add(1, std::memory_order::release);
+    m_queue_size.fetch_add(1, std::memory_order::release);
+    m_size.fetch_add(1, std::memory_order::release);
     if (m_shutdown_requested.load(std::memory_order::acquire))
     {
+        m_try_wake_workers_size.fetch_sub(1, std::memory_order::release);
+        m_queue_size.fetch_sub(1, std::memory_order::release);
+        m_size.fetch_sub(1, std::memory_order::release);
         throw std::runtime_error("coro::thread_pool_ws is shutting down, unable to schedule new tasks.");
     }
 
@@ -118,8 +127,14 @@ auto thread_pool_ws::resume(std::coroutine_handle<> handle) noexcept -> bool
         return false;
     }
 
+    m_try_wake_workers_size.fetch_add(1, std::memory_order::release);
+    m_queue_size.fetch_add(1, std::memory_order::release);
+    m_size.fetch_add(1, std::memory_order::release);
     if (m_shutdown_requested.load(std::memory_order::acquire))
     {
+        m_try_wake_workers_size.fetch_sub(1, std::memory_order::release);
+        m_queue_size.fetch_sub(1, std::memory_order::release);
+        m_size.fetch_sub(1, std::memory_order::release);
         return false;
     }
 
@@ -138,6 +153,23 @@ auto thread_pool_ws::shutdown() noexcept -> void
             m_wait_cv.notify_all();
         }
 
+        while (m_workers_stopped.load(std::memory_order::acquire) < m_opts.thread_count)
+        {
+            std::this_thread::yield();
+        }
+
+        if (m_size.load(std::memory_order::acquire) > 0)
+        {
+            std::string msg = "shutdown() m_size = " + m_size.load() + '\n';
+            throw std::runtime_error{msg};
+        }
+
+        if (m_queue_size.load(std::memory_order::acquire) > 0)
+        {
+            std::string msg = "shutdown() m_queue_size = " + m_queue_size.load() + '\n';
+            throw std::runtime_error{msg};
+        }
+
         for (auto& worker : m_workers)
         {
             if (worker->m_thread.joinable())
@@ -145,12 +177,20 @@ auto thread_pool_ws::shutdown() noexcept -> void
                 worker->m_thread.join();
             }
         }
+
+        // Make sure all try wake tasks are completed prior to destructing this thread pool.
+        while (m_try_wake_workers_size.load(std::memory_order::acquire) > 0)
+        {
+            std::this_thread::yield();
+        }
     }
 }
 
 auto thread_pool_ws::execute(uint32_t idx) -> void
 {
     m_thread_pool_queue_idx = {idx};
+
+    m_workers_started.fetch_add(1, std::memory_order::release);
 
     if (m_opts.on_thread_start_functor != nullptr)
     {
@@ -177,7 +217,7 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
             continue;
         }
 
-        // Go to sleep until a task is scheduled.
+        // Go to sleep until a task is scheduled or a shutdown has been requested.
         std::unique_lock<std::mutex> lk{m_wait_mutex};
         m_sleeping.fetch_add(1, std::memory_order::release);
         m_wait_cv.wait(
@@ -188,23 +228,20 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
             });
     }
 
-    while (m_size.load(std::memory_order::acquire) > 0)
+    // Run until the queue is fully drained.
+    while (m_queue_size.load(std::memory_order::acquire) > 0)
     {
-        bool had_tasks = drain_thread_queue(thread_queue);
-        had_tasks |= try_steal(idx);
-        had_tasks |= drain_global_queue(thread_queue);
-
-        // If there were no tasks left to work on, this thread can exit.
-        if (!had_tasks)
-        {
-            break;
-        }
+        (void)drain_thread_queue(thread_queue);
+        (void)try_steal(idx);
+        (void)drain_global_queue(thread_queue);
     }
 
     if (m_opts.on_thread_stop_functor != nullptr)
     {
         m_opts.on_thread_stop_functor(idx);
     }
+
+    m_workers_stopped.fetch_add(1, std::memory_order::release);
 }
 
 auto thread_pool_ws::drain_thread_queue(riften::Deque<schedule_operation*>& queue) -> bool
@@ -289,22 +326,36 @@ auto thread_pool_ws::try_wake_worker() noexcept -> void
     // We're shutting down, no need to even attempt to wake any workers.
     if (m_shutdown_requested.load(std::memory_order::acquire))
     {
+        m_try_wake_workers_size.fetch_sub(1, std::memory_order::release);
         return;
     }
 
-    // Attempt to wake a sleeper if there are any.
-    if (m_sleeping.load(std::memory_order::acquire) > 0)
+    auto asleep = m_sleeping.load(std::memory_order::acquire);
+    while (asleep > 0 && !m_shutdown_requested.load(std::memory_order::acquire))
     {
-        std::unique_lock<std::mutex> lk{m_wait_mutex};
-        // Check again after acquiring the lock to see if there are any sleeping workers.
-        if (m_sleeping.load(std::memory_order::acquire) == 0)
+        if (m_sleeping.compare_exchange_weak(
+                asleep, asleep - 1, std::memory_order::acq_rel, std::memory_order::acquire))
         {
-            return;
+            m_wait_cv.notify_one();
+            break;
         }
-
-        m_sleeping.fetch_sub(1, std::memory_order::release);
-        m_wait_cv.notify_one();
     }
+
+    m_try_wake_workers_size.fetch_sub(1, std::memory_order::release);
+
+    // // Attempt to wake a sleeper if there are any.
+    // if (m_sleeping.load(std::memory_order::acquire) > 0)
+    // {
+    //     std::unique_lock<std::mutex> lk{m_wait_mutex};
+    //     // Check again after acquiring the lock to see if there are any sleeping workers.
+    //     if (m_sleeping.load(std::memory_order::acquire) == 0)
+    //     {
+    //         return;
+    //     }
+
+    //     m_sleeping.fetch_sub(1, std::memory_order::release);
+    //     m_wait_cv.notify_one();
+    // }
 }
 
 } // namespace coro

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -2,6 +2,11 @@
 #include "coro/task_group.hpp"
 
 #include <iostream>
+#include <mutex>
+
+#ifdef LIBCORO_TSAN
+#include <sanitizer/tsan_interface.h>
+#endif
 
 namespace coro
 {
@@ -61,13 +66,21 @@ thread_pool_ws::~thread_pool_ws()
     shutdown();
 }
 
-thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp) noexcept : m_thread_pool(tp)
+thread_pool_ws::schedule_operation::schedule_operation(thread_pool_ws& tp, bool allocated) noexcept
+    : m_thread_pool(tp),
+      m_allocated(allocated)
 {
+#ifdef LIBCORO_TSAN
+    // TSAN thinks the non-atomic constructor is a data race with the loads of this atomic on other threads.
+    __tsan_release(&m_allocated);
+#endif
 }
 
 auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void
 {
     m_awaiting_coroutine.store(awaiting_coroutine, std::memory_order::release);
+    auto& tp = m_thread_pool; // take a copy since allocated schedule_operations can be deleted before this function completes.
+
     // See if we are running on a thread pool worker to enqueue locally.
     auto& idx = thread_pool_ws::m_thread_pool_queue_idx;
     if (idx.has_value())
@@ -79,7 +92,8 @@ auto thread_pool_ws::schedule_operation::await_suspend(std::coroutine_handle<> a
         detail::awaiter_list_push(m_thread_pool.m_global_queue, this);
     }
 
-    m_thread_pool.try_wake_worker();
+    // At this point `this` is no longer safe to use since a worker thread could have completed this coroutine.
+    tp.try_wake_worker();
 }
 
 auto thread_pool_ws::schedule() -> schedule_operation
@@ -95,7 +109,7 @@ auto thread_pool_ws::schedule() -> schedule_operation
         throw std::runtime_error("coro::thread_pool_ws is shutting down, unable to schedule new tasks.");
     }
 
-    return schedule_operation(*this);
+    return schedule_operation{*this};
 }
 
 auto thread_pool_ws::spawn_detached(coro::task<void> user_task) -> bool
@@ -138,8 +152,7 @@ auto thread_pool_ws::resume(std::coroutine_handle<> handle) noexcept -> bool
         return false;
     }
 
-    auto* op = new schedule_operation{*this};
-    op->m_allocated.store(true, std::memory_order::release);
+    auto* op = new schedule_operation{*this, true};
     op->await_suspend(handle);
     return true;
 }
@@ -149,8 +162,14 @@ auto thread_pool_ws::shutdown() noexcept -> void
     if (m_shutdown_requested.exchange(true, std::memory_order::acq_rel) == false)
     {
         {
-            std::unique_lock<std::mutex> lk{m_wait_mutex};
-            m_wait_cv.notify_all();
+            for (auto& info : m_workers)
+            {
+                std::unique_lock<std::mutex> lk{info->m_wait_mutex};
+                info->m_sleeping.store(false, std::memory_order::release);
+                info->m_wait_cv.notify_one();
+            }
+            // std::unique_lock<std::mutex> lk{m_wait_mutex};
+            // m_wait_cv.notify_all();
         }
 
         while (m_workers_stopped.load(std::memory_order::acquire) < m_opts.thread_count)
@@ -205,16 +224,28 @@ auto thread_pool_ws::execute(uint32_t idx) -> void
             continue;
         }
 
-        // Go to sleep until a task is scheduled or a shutdown has been requested.
-        std::unique_lock<std::mutex> lk{m_wait_mutex};
-        m_sleeping.fetch_add(1, std::memory_order::release);
-        m_wait_cv.wait(
-            lk,
-            [&]() {
-                return m_queue_size.load(std::memory_order::acquire) > 0 ||
-                       m_shutdown_requested.load(std::memory_order::acquire);
-            });
+        // Notify to all scheduled tasks that this worker is going to sleep and upon
+        // scheduling a task this worker will need to be woken up.
+        {
+            std::scoped_lock lk{m_wait_mutex, info->m_wait_mutex};
+            info->m_sleeping.exchange(true);
+            m_sleeping.fetch_add(1, std::memory_order::release);
+        }
+
+        // Go to sleep.
+        {
+            std::unique_lock lk{info->m_wait_mutex};
+            info->m_wait_cv.wait(
+                lk,
+                [&]() {
+                    return !info->m_sleeping.load(std::memory_order::acquire) ||
+                           m_queue_size.load(std::memory_order::acquire) > 0 ||
+                           m_shutdown_requested.load(std::memory_order::acquire);
+                });
+        }
     }
+
+    // while true; do gdb -ex run -ex quit --args taskset -c 0-1 ./test/libcoro_test "[thread_pool_ws]"; done
 
     // Run until the queue is fully drained.
     while (m_queue_size.load(std::memory_order::acquire) > 0)
@@ -246,14 +277,10 @@ auto thread_pool_ws::try_steal(uint32_t my_idx) -> bool
 {
     bool had_tasks{false};
     auto queue_size = m_workers.size();
-    for (size_t i = 0; i < queue_size; ++i)
+    for (size_t i = 1; i < queue_size; ++i)
     {
-        if (i == my_idx)
-        {
-            continue;
-        }
-
-        had_tasks |= drain_peer_queue(m_workers[i]->m_queue);
+        auto steal_idx = (my_idx + i) % queue_size;
+        had_tasks |= drain_peer_queue(m_workers[steal_idx]->m_queue);
     }
     return had_tasks;
 }
@@ -325,8 +352,17 @@ auto thread_pool_ws::try_wake_worker() noexcept -> void
         if (m_sleeping.compare_exchange_weak(
                 asleep, asleep - 1, std::memory_order::acq_rel, std::memory_order::acquire))
         {
-            m_wait_cv.notify_one();
-            break;
+            for (auto & info : m_workers)
+            {
+                std::unique_lock lk {info->m_wait_mutex};
+                if (info->m_sleeping.load(std::memory_order::acquire))
+                {
+                    info->m_sleeping.store(false, std::memory_order::release);
+                    info->m_wait_cv.notify_one();
+                    break; // for
+                }
+            }
+            break; // while
         }
     }
 

--- a/src/thread_pool_ws.cpp
+++ b/src/thread_pool_ws.cpp
@@ -298,9 +298,10 @@ auto thread_pool_ws::resume_task(std::optional<schedule_operation*> op) -> bool
     {
         m_queue_size.fetch_sub(1, std::memory_order::release);
         auto v = op.value();
+        auto allocated = v->m_allocated.load(std::memory_order::acquire);
         v->m_awaiting_coroutine.load(std::memory_order::acquire).resume();
         m_size.fetch_sub(1, std::memory_order::release);
-        if (v->m_allocated.load(std::memory_order::acquire))
+        if (allocated)
         {
             delete v;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBCORO_TEST_SOURCE_FILES
         test_sync_wait.cpp
         test_task.cpp
         test_task_group.cpp
+        test_thread_pool_ws.cpp
         test_thread_pool.cpp
         test_when_all.cpp
 

--- a/test/bench.cpp
+++ b/test/bench.cpp
@@ -23,6 +23,8 @@ using sc = std::chrono::steady_clock;
 constexpr std::size_t default_iterations = 5'000'000;
 // constexpr std::size_t default_iterations = 10;
 
+std::atomic<uint16_t> g_next_port{8080};
+
 static auto
     print_stats(const std::string& bench_name, uint64_t operations, sc::time_point start, sc::time_point stop) -> void
 {
@@ -390,12 +392,15 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark][tcp]")
     std::atomic<uint64_t> accepted{0};
     std::atomic<uint64_t> clients_completed{0};
 
+    auto port = g_next_port.fetch_add(1);
+
     auto server_scheduler = coro::scheduler::make_unique(coro::scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::scheduler::execution_strategy_t::process_tasks_on_thread_pool});
     auto make_server_task = [](std::unique_ptr<coro::scheduler>& server_scheduler,
                                std::atomic<uint64_t>&            listening,
-                               std::atomic<uint64_t>&            accepted) -> coro::task<void>
+                               std::atomic<uint64_t>&            accepted,
+                               uint16_t port) -> coro::task<void>
     {
         auto make_on_connection_task = [](coro::net::tcp::client client,
                                           coro::latch&           wait_for_clients) -> coro::task<void>
@@ -436,7 +441,7 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark][tcp]")
         co_await server_scheduler->schedule();
 
         coro::latch            wait_for_clients{connections};
-        coro::net::tcp::server server{server_scheduler, {"127.0.0.1", 8080}};
+        coro::net::tcp::server server{server_scheduler, {"127.0.0.1", port}};
 
         listening++;
 
@@ -466,11 +471,12 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark][tcp]")
                                const std::string&                             msg,
                                std::atomic<uint64_t>&                         clients_completed,
                                std::map<std::chrono::milliseconds, uint64_t>& g_histogram,
-                               std::mutex&                                    g_histogram_mutex) -> coro::task<void>
+                               std::mutex&                                    g_histogram_mutex,
+                               uint16_t port) -> coro::task<void>
     {
         co_await client_scheduler->schedule();
         std::map<std::chrono::milliseconds, uint64_t> histogram;
-        coro::net::tcp::client                        client{client_scheduler, {"127.0.0.1", 8080}};
+        coro::net::tcp::client                        client{client_scheduler, {"127.0.0.1", port}};
 
         auto cstatus = co_await client.connect(); // std::chrono::seconds{1});
         REQUIRE_THREAD_SAFE(cstatus == coro::net::connect_status::connected);
@@ -517,7 +523,7 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark][tcp]")
 
     // Create the server to accept incoming tcp connections.
     auto server_thread =
-        std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted)); }};
+        std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted, port)); }};
 
     // The server can take a small bit of time to start up, if we don't wait for it to notify then
     // the first few connections can easily fail to connect causing this test to fail.
@@ -533,7 +539,7 @@ TEST_CASE("benchmark tcp::server echo server thread pool", "[benchmark][tcp]")
                         for (size_t i = 0; i < connections; ++i)
                         {
                             tasks.emplace_back(make_client_task(
-                                client_scheduler, msg, clients_completed, g_histogram, g_histogram_mutex));
+                                client_scheduler, msg, clients_completed, g_histogram, g_histogram_mutex, port));
                         }
                         coro::sync_wait(coro::when_all(std::move(tasks)));
                     }};
@@ -635,7 +641,7 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark][tcp]")
 
         co_await s.scheduler->schedule();
 
-        coro::net::tcp::server server{s.scheduler, {"127.0.0.1", static_cast<uint16_t>(8080 + s.id)}};
+        coro::net::tcp::server server{s.scheduler, {"127.0.0.1", static_cast<uint16_t>(10'000 + s.id)}};
 
         listening++;
 
@@ -671,7 +677,7 @@ TEST_CASE("benchmark tcp::server echo server inline", "[benchmark][tcp]")
         coro::net::tcp::client                        client{
             c.scheduler,
             coro::net::socket_address{
-                coro::net::ip_address::from_string("127.0.0.1"), static_cast<uint16_t>(8080 + c.id)}};
+                coro::net::ip_address::from_string("127.0.0.1"), static_cast<uint16_t>(10'000 + c.id)}};
 
         // Connect to server with some retry logic to ensure a connection is established
         coro::net::connect_status cstatus = coro::net::connect_status::error;
@@ -808,12 +814,15 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
     std::atomic<uint64_t> accepted{0};
     std::atomic<uint64_t> clients_completed{0};
 
+    auto port = g_next_port.fetch_add(1);
+
     auto server_scheduler = coro::scheduler::make_unique(coro::scheduler::options{
         .pool               = coro::thread_pool::options{},
         .execution_strategy = coro::scheduler::execution_strategy_t::process_tasks_on_thread_pool});
     auto make_server_task = [](std::unique_ptr<coro::scheduler>& server_scheduler,
                                std::atomic<uint64_t>&            listening,
-                               std::atomic<uint64_t>&            accepted) -> coro::task<void>
+                               std::atomic<uint64_t>&            accepted,
+                               uint16_t port) -> coro::task<void>
     {
         auto make_on_connection_task = [](coro::net::tls::client client,
                                           coro::latch&           wait_for_clients) -> coro::task<void>
@@ -880,7 +889,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
             server_scheduler,
             std::make_shared<coro::net::tls::context>(
                 "cert.pem", coro::net::tls::tls_file_type::pem, "key.pem", coro::net::tls::tls_file_type::pem),
-            {"127.0.0.1", 8080}};
+            {"127.0.0.1", port}};
 
         listening++;
 
@@ -914,7 +923,8 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
                                const std::string&                             msg,
                                std::atomic<uint64_t>&                         clients_completed,
                                std::map<std::chrono::milliseconds, uint64_t>& g_histogram,
-                               coro::mutex&                                   histogram_mutex) -> coro::task<void>
+                               coro::mutex&                                   histogram_mutex,
+                               uint16_t port) -> coro::task<void>
     {
         co_await client_scheduler->schedule();
         {
@@ -922,7 +932,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
             coro::net::tls::client                        client{
                 client_scheduler,
                 std::make_shared<coro::net::tls::context>(coro::net::tls::verify_peer_t::no),
-                                       {"127.0.0.1", 8080}};
+                                       {"127.0.0.1", port}};
 
             auto cstatus = co_await client.connect();
             REQUIRE_THREAD_SAFE(cstatus == coro::net::tls::connection_status::connected);
@@ -1007,7 +1017,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
 
     // Create the server to accept incoming tcp connections.
     auto server_thread =
-        std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted)); }};
+        std::thread{[&]() { coro::sync_wait(make_server_task(server_scheduler, listening, accepted, port)); }};
 
     // The server can take a small bit of time to start up, if we don't wait for it to notify then
     // the first few connections can easily fail to connect causing this test to fail.
@@ -1023,7 +1033,7 @@ TEST_CASE("benchmark tls::server echo server thread pool", "[benchmark]")
                         for (size_t i = 0; i < connections; ++i)
                         {
                             tasks.emplace_back(make_client_task(
-                                client_scheduler, msg, clients_completed, g_histogram, histogram_mutex));
+                                client_scheduler, msg, clients_completed, g_histogram, histogram_mutex, port));
                         }
                         coro::sync_wait(coro::when_all(std::move(tasks)));
                     }};

--- a/test/test_queue.cpp
+++ b/test/test_queue.cpp
@@ -85,9 +85,10 @@ TEST_CASE("queue produce consume direct", "[queue]")
 {
     const uint64_t        ITERATIONS = 10;
     coro::queue<uint64_t> q{};
-    auto tp = coro::thread_pool::make_unique();
+    auto                  tp = coro::thread_pool::make_unique();
 
-    auto make_producer_task = [](std::unique_ptr<coro::thread_pool>& tp, coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    auto make_producer_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                 coro::queue<uint64_t>&              q) -> coro::task<uint64_t>
     {
         co_await tp->schedule();
         for (uint64_t i = 0; i < ITERATIONS; ++i)
@@ -101,7 +102,8 @@ TEST_CASE("queue produce consume direct", "[queue]")
         co_return 0;
     };
 
-    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp, coro::queue<uint64_t>& q) -> coro::task<uint64_t>
+    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                 coro::queue<uint64_t>&              q) -> coro::task<uint64_t>
     {
         co_await tp->schedule();
 
@@ -130,7 +132,7 @@ TEST_CASE("queue multithreaded produce consume", "[queue]")
     const uint64_t        WORKERS    = 3;
     const uint64_t        ITERATIONS = 100;
     coro::queue<uint64_t> q{};
-    auto tp = coro::thread_pool::make_unique();
+    auto                  tp = coro::thread_pool::make_unique();
     std::atomic<uint64_t> counter{0};
     coro::latch           wait{WORKERS};
 
@@ -148,7 +150,8 @@ TEST_CASE("queue multithreaded produce consume", "[queue]")
         co_return;
     };
 
-    auto make_shutdown_task = [](std::unique_ptr<coro::thread_pool>& tp, coro::queue<uint64_t>& q, coro::latch& w) -> coro::task<void>
+    auto make_shutdown_task =
+        [](std::unique_ptr<coro::thread_pool>& tp, coro::queue<uint64_t>& q, coro::latch& w) -> coro::task<void>
     {
         co_await tp->schedule();
         // Wait for all producers to complete.
@@ -161,7 +164,9 @@ TEST_CASE("queue multithreaded produce consume", "[queue]")
         co_return;
     };
 
-    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp, coro::queue<uint64_t>& q, std::atomic<uint64_t>& counter) -> coro::task<void>
+    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                 coro::queue<uint64_t>&              q,
+                                 std::atomic<uint64_t>&              counter) -> coro::task<void>
     {
         std::cerr << "make_consumer_task()\n";
         co_await tp->schedule();
@@ -190,7 +195,7 @@ TEST_CASE("queue multithreaded produce consume", "[queue]")
     tasks.emplace_back(make_shutdown_task(tp, q, wait));
 
     coro::sync_wait(coro::when_all(std::move(tasks)));
-    REQUIRE(counter == 14850);
+    REQUIRE(counter.load() == 14850);
 }
 
 TEST_CASE("queue stopped", "[queue]")

--- a/test/test_ring_buffer.cpp
+++ b/test/test_ring_buffer.cpp
@@ -53,9 +53,9 @@ TEST_CASE("ring_buffer single element", "[ring_buffer]")
 
 TEST_CASE("ring_buffer max_size", "[ring_buffer]")
 {
-    coro::ring_buffer<uint64_t, 2> rb2{};
-    coro::ring_buffer<uint64_t, 16> rb16{};
-    coro::ring_buffer<uint64_t, 256> rb256{};
+    coro::ring_buffer<uint64_t, 2>     rb2{};
+    coro::ring_buffer<uint64_t, 16>    rb16{};
+    coro::ring_buffer<uint64_t, 256>   rb256{};
     coro::ring_buffer<uint64_t, 12345> rb12345{};
 
     REQUIRE(rb2.max_size() == 2);
@@ -91,105 +91,112 @@ TEST_CASE("ring_buffer is full", "[ring_buffer]")
 TEST_CASE("ring_buffer many elements many producers many consumers", "[ring_buffer]")
 {
     {
-    std::cerr << "BEGIN ring_buffer many elements many producers many consumers\n";
-    const size_t iterations = 1'000'000;
-    const size_t consumers  = 100;
-    const size_t producers  = 100;
+        std::cerr << "BEGIN ring_buffer many elements many producers many consumers\n";
+        const size_t iterations = 1'000'000;
+        const size_t consumers  = 100;
+        const size_t producers  = 100;
 
-    coro::ring_buffer<uint64_t, 64> rb{};
-    auto tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 4});
-    coro::latch                     wait{producers};
-    std::atomic<uint64_t> counter{0};
-    std::atomic<uint64_t> initated_consumes{0};
-    std::atomic<uint64_t> successful_consumes{0};
-    std::atomic<uint64_t> producer_counter{0};
+        coro::ring_buffer<uint64_t, 64> rb{};
+        auto                  tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 4});
+        coro::latch           wait{producers};
+        std::atomic<uint64_t> counter{0};
+        std::atomic<uint64_t> initated_consumes{0};
+        std::atomic<uint64_t> successful_consumes{0};
+        std::atomic<uint64_t> producer_counter{0};
 
-    auto make_producer_task =
-        [](std::unique_ptr<coro::thread_pool>& tp, coro::ring_buffer<uint64_t, 64>& rb, coro::latch& w, std::atomic<uint64_t>& producer_counter) -> coro::task<void>
-    {
-        co_await tp->schedule();
-        auto to_produce = iterations / producers;
-
-        for (size_t i = 1; i <= to_produce; ++i)
+        auto make_producer_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                     coro::ring_buffer<uint64_t, 64>&    rb,
+                                     coro::latch&                        w,
+                                     std::atomic<uint64_t>&              producer_counter) -> coro::task<void>
         {
-            if (co_await rb.produce(i) != coro::ring_buffer_result::produce::produced)
+            co_await tp->schedule();
+            auto to_produce = iterations / producers;
+
+            for (size_t i = 1; i <= to_produce; ++i)
             {
-                std::cerr << "rb.produce(" << i << ") == coro::ring_buffer_result::produce::stopped\n";
-            }
-            else
-            {
-                producer_counter.fetch_add(i, std::memory_order::seq_cst);
-            }
-        }
-
-        w.count_down();
-        co_return;
-    };
-
-    auto make_shutdown_task =
-        [](std::unique_ptr<coro::thread_pool>& tp, coro::ring_buffer<uint64_t, 64>& rb, coro::latch& w) -> coro::task<void>
-    {
-        // Wait for all producers to complete before signally shutdown with drain.
-        co_await tp->schedule();
-        co_await w;
-
-        while (!rb.empty())
-        {
-            co_await tp->yield();
-        }
-
-        co_await rb.shutdown_drain(tp);
-        co_return;
-    };
-
-    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp, coro::ring_buffer<uint64_t, 64>& rb, std::atomic<uint64_t>& counter, std::atomic<uint64_t>& successful_consumes, std::atomic<uint64_t>& initated_consumes) -> coro::task<void>
-    {
-        co_await tp->schedule();
-
-        // For the sanity of this test to complete consistently we'll consume the exact number of times
-        // the reuslting REQUIREs at the end don't always line up perfectly with this many threads and the shutdown.
-        auto consumes = iterations / producers;
-        for(uint64_t i = 0; i < consumes; ++i)
-        // while (true)
-        {
-            initated_consumes++;
-            auto expected = co_await rb.consume();
-            if (!expected)
-            {
-                break;
+                if (co_await rb.produce(i) != coro::ring_buffer_result::produce::produced)
+                {
+                    std::cerr << "rb.produce(" << i << ") == coro::ring_buffer_result::produce::stopped\n";
+                }
+                else
+                {
+                    producer_counter.fetch_add(i, std::memory_order::seq_cst);
+                }
             }
 
-            successful_consumes++;
-            auto item = std::move(*expected);
-            counter.fetch_add(item, std::memory_order::seq_cst);
+            w.count_down();
+            co_return;
+        };
 
-            co_await tp->yield(); // mimic some work
+        auto make_shutdown_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                     coro::ring_buffer<uint64_t, 64>&    rb,
+                                     coro::latch&                        w) -> coro::task<void>
+        {
+            // Wait for all producers to complete before signally shutdown with drain.
+            co_await tp->schedule();
+            co_await w;
+
+            while (!rb.empty())
+            {
+                co_await tp->yield();
+            }
+
+            co_await rb.shutdown_drain(tp);
+            co_return;
+        };
+
+        auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& tp,
+                                     coro::ring_buffer<uint64_t, 64>&    rb,
+                                     std::atomic<uint64_t>&              counter,
+                                     std::atomic<uint64_t>&              successful_consumes,
+                                     std::atomic<uint64_t>&              initated_consumes) -> coro::task<void>
+        {
+            co_await tp->schedule();
+
+            // For the sanity of this test to complete consistently we'll consume the exact number of times
+            // the reuslting REQUIREs at the end don't always line up perfectly with this many threads and the shutdown.
+            auto consumes = iterations / producers;
+            for (uint64_t i = 0; i < consumes; ++i)
+            // while (true)
+            {
+                initated_consumes++;
+                auto expected = co_await rb.consume();
+                if (!expected)
+                {
+                    break;
+                }
+
+                successful_consumes++;
+                auto item = std::move(*expected);
+                counter.fetch_add(item, std::memory_order::seq_cst);
+
+                co_await tp->yield(); // mimic some work
+            }
+
+            co_return;
+        };
+
+        std::vector<coro::task<void>> tasks{};
+        tasks.reserve(consumers * producers + 1);
+
+        for (size_t i = 0; i < consumers; ++i)
+        {
+            tasks.emplace_back(make_consumer_task(tp, rb, counter, successful_consumes, initated_consumes));
         }
+        for (size_t i = 0; i < producers; ++i)
+        {
+            tasks.emplace_back(make_producer_task(tp, rb, wait, producer_counter));
+        }
+        tasks.emplace_back(make_shutdown_task(tp, rb, wait));
 
-        co_return;
-    };
+        coro::sync_wait(coro::when_all(std::move(tasks)));
+        std::cerr << "initated_consumes=[" << initated_consumes << "]\n";
+        std::cerr << "successful_consumes=[" << successful_consumes << "]\n";
 
-    std::vector<coro::task<void>> tasks{};
-    tasks.reserve(consumers * producers + 1);
-
-    for (size_t i = 0; i < consumers; ++i)
-    {
-        tasks.emplace_back(make_consumer_task(tp, rb, counter, successful_consumes, initated_consumes));
-    }
-    for (size_t i = 0; i < producers; ++i)
-    {
-        tasks.emplace_back(make_producer_task(tp, rb, wait, producer_counter));
-    }
-    tasks.emplace_back(make_shutdown_task(tp, rb, wait));
-
-    coro::sync_wait(coro::when_all(std::move(tasks)));
-    std::cerr << "initated_consumes=[" << initated_consumes << "]\n";
-    std::cerr << "successful_consumes=[" << successful_consumes << "]\n";
-
-    REQUIRE(rb.empty());
-    REQUIRE(successful_consumes == iterations);
-    REQUIRE(producer_counter == 5000500000);
-    REQUIRE(counter == 5000500000);
+        REQUIRE(rb.empty());
+        REQUIRE(successful_consumes.load() == iterations);
+        REQUIRE(producer_counter.load() == 5000500000);
+        REQUIRE(counter.load() == 5000500000);
     }
     std::cerr << "END ring_buffer many elements many producers many consumers\n";
 }
@@ -206,7 +213,8 @@ TEST_CASE("ring_buffer producer consumer separate threads", "[ring_buffer]")
     auto producer_tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
     auto consumer_tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
 
-    auto make_producer_task = [](std::unique_ptr<coro::thread_pool>& producer_tp, coro::ring_buffer<uint64_t, 2>& rb) -> coro::task<void>
+    auto make_producer_task = [](std::unique_ptr<coro::thread_pool>& producer_tp,
+                                 coro::ring_buffer<uint64_t, 2>&     rb) -> coro::task<void>
     {
         for (size_t i = 0; i < iterations; ++i)
         {
@@ -220,7 +228,8 @@ TEST_CASE("ring_buffer producer consumer separate threads", "[ring_buffer]")
         co_return;
     };
 
-    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& consumer_tp, coro::ring_buffer<uint64_t, 2>& rb) -> coro::task<void>
+    auto make_consumer_task = [](std::unique_ptr<coro::thread_pool>& consumer_tp,
+                                 coro::ring_buffer<uint64_t, 2>&     rb) -> coro::task<void>
     {
         while (true)
         {
@@ -477,15 +486,14 @@ TEST_CASE("ring_buffer shutdown_drain non-empty consumer shutdown", "[ring_buffe
 
 TEST_CASE("ring_buffer notify producers", "[ring_buffer]")
 {
-    auto tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
+    auto tp             = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
     auto make_test_task = [](std::unique_ptr<coro::thread_pool>& tp) -> coro::task<void>
     {
         coro::ring_buffer<int, 1> rb{};
 
-        auto make_produce_task = [](coro::ring_buffer<int, 1>& rb, int i) -> coro::task<coro::ring_buffer_result::produce>
-        {
-            co_return co_await rb.produce(i);
-        };
+        auto make_produce_task = [](coro::ring_buffer<int, 1>& rb,
+                                    int                        i) -> coro::task<coro::ring_buffer_result::produce>
+        { co_return co_await rb.produce(i); };
 
         auto make_notify_task = [](coro::ring_buffer<int, 1>& rb) -> coro::task<void>
         {
@@ -503,8 +511,7 @@ TEST_CASE("ring_buffer notify producers", "[ring_buffer]")
             tp->schedule(make_produce_task(rb, 4)),
             tp->schedule(make_produce_task(rb, 5)),
             tp->schedule(make_produce_task(rb, 6)),
-            tp->schedule(make_notify_task(rb))
-        );
+            tp->schedule(make_notify_task(rb)));
 
         REQUIRE(std::get<0>(results).return_value() == coro::ring_buffer_result::produce::notified);
         REQUIRE(std::get<1>(results).return_value() == coro::ring_buffer_result::produce::notified);
@@ -518,15 +525,14 @@ TEST_CASE("ring_buffer notify producers", "[ring_buffer]")
 
 TEST_CASE("ring_buffer notify consumers", "[ring_buffer]")
 {
-    auto tp = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
+    auto tp             = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
     auto make_test_task = [](std::unique_ptr<coro::thread_pool>& tp) -> coro::task<void>
     {
         coro::ring_buffer<int, 1> rb{};
 
-        auto make_consume_task = [](coro::ring_buffer<int, 1>& rb) -> coro::task<coro::expected<int, coro::ring_buffer_result::consume>>
-        {
-            co_return co_await rb.consume();
-        };
+        auto make_consume_task =
+            [](coro::ring_buffer<int, 1>& rb) -> coro::task<coro::expected<int, coro::ring_buffer_result::consume>>
+        { co_return co_await rb.consume(); };
 
         auto make_notify_task = [](coro::ring_buffer<int, 1>& rb) -> coro::task<void>
         {
@@ -540,8 +546,7 @@ TEST_CASE("ring_buffer notify consumers", "[ring_buffer]")
             tp->schedule(make_consume_task(rb)),
             tp->schedule(make_consume_task(rb)),
             tp->schedule(make_consume_task(rb)),
-            tp->schedule(make_notify_task(rb))
-        );
+            tp->schedule(make_notify_task(rb)));
 
         REQUIRE(std::get<0>(results).return_value().error() == coro::ring_buffer_result::consume::notified);
         REQUIRE(std::get<1>(results).return_value().error() == coro::ring_buffer_result::consume::notified);

--- a/test/test_shared_mutex.cpp
+++ b/test/test_shared_mutex.cpp
@@ -201,11 +201,11 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
         coro::scheduler::options{.pool = coro::thread_pool::options{.thread_count = 8}});
     coro::shared_mutex<coro::scheduler> m{s};
 
-    std::atomic<bool> read_value{false};
+    std::atomic<bool> trigger{false};
 
     auto make_exclusive_task = [](std::unique_ptr<coro::scheduler> &    s,
                                   coro::shared_mutex<coro::scheduler>& m,
-                                  std::atomic<bool>&                      read_value) -> coro::task<void>
+                                  std::atomic<bool>&                      trigger) -> coro::task<void>
     {
         // Let some readers get through.
         co_await s->yield_for(std::chrono::milliseconds{50});
@@ -216,7 +216,7 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
             std::cerr << "make_shared_task exclusive lock acquired\n";
             // Stack readers on the mutex
             co_await s->yield_for(std::chrono::milliseconds{50});
-            read_value.exchange(true, std::memory_order::release);
+            trigger.exchange(true, std::memory_order::release);
             std::cerr << "make_shared_task exclusive lock releasing\n";
             co_await m.unlock();
         }
@@ -226,65 +226,37 @@ TEST_CASE("mutex many shared and exclusive waiters interleaved", "[shared_mutex]
 
     auto make_shared_tasks_task = [](std::unique_ptr<coro::scheduler> &    s,
                                      coro::shared_mutex<coro::scheduler>& m,
-                                     std::atomic<bool>&                      read_value) -> coro::task<void>
+                                     std::atomic<bool>&                      trigger) -> coro::task<void>
     {
         auto make_shared_task = [](std::unique_ptr<coro::scheduler> &    s,
                                    coro::shared_mutex<coro::scheduler>& m,
-                                   std::atomic<bool>&                      read_value) -> coro::task<bool>
+                                   std::atomic<bool>&                      trigger) -> coro::task<void>
         {
             co_await s->schedule();
             std::cerr << "make_shared_task shared lock acquiring\n";
             co_await m.lock_shared();
             std::cerr << "make_shared_task shared lock acquired\n";
-            bool value = read_value.load(std::memory_order::acquire);
+            auto value = trigger.load(std::memory_order::acquire);
             co_await m.unlock_shared();
-            std::cerr << "make_shared_task shared lock releasing on thread_id = " << std::this_thread::get_id() << "\n";
-            co_return value;
+            std::cerr << "make_shared_task shared lock releasing on thread_id = " << std::this_thread::get_id() << " value=" << value << "\n";
+            co_return;
         };
 
         co_await s->schedule();
 
-        std::list<coro::task<bool>> shared_tasks{};
+        coro::task_group<coro::scheduler> shared_tasks{s};
 
-        bool stop{false};
-        while (!stop)
+        while (!trigger.load(std::memory_order::acquire))
         {
-            shared_tasks.emplace_back(make_shared_task(s, m, read_value));
-            shared_tasks.back().resume();
-
+            (void)shared_tasks.start(make_shared_task(s, m, trigger));
             co_await s->yield_for(std::chrono::milliseconds{1});
-
-            for (const auto& st : shared_tasks)
-            {
-                if (st.is_ready())
-                {
-                    stop = st.promise().result();
-                }
-            }
         }
 
-        while (true)
-        {
-            bool tasks_remaining{false};
-            for (const auto& st : shared_tasks)
-            {
-                if (!st.is_ready())
-                {
-                    tasks_remaining = true;
-                    break;
-                }
-            }
-
-            if (!tasks_remaining)
-            {
-                break;
-            }
-        }
-
+        co_await shared_tasks;
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_shared_tasks_task(s, m, read_value), make_exclusive_task(s, m, read_value)));
+    coro::sync_wait(coro::when_all(make_shared_tasks_task(s, m, trigger), make_exclusive_task(s, m, trigger)));
 }
 #endif // #ifdef LIBCORO_FEATURE_NETWORKING
 

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -274,7 +274,7 @@ TEST_CASE("issue-287", "[thread_pool_ws]")
     REQUIRE(g_count.load() == ITERATIONS);
 }
 
-TEST_CASE("thread_pool_ws::spawn", "[thread_pool_ws]")
+TEST_CASE("thread_pool_ws::spawn_detached", "[thread_pool_ws]")
 {
     auto                  tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 2});
     std::atomic<uint64_t> counter{0};

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -11,14 +11,14 @@ TEST_CASE("thread_pool_ws", "[thread_pool_ws]")
 
 TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
 {
-    coro::thread_pool_ws tp{coro::thread_pool_ws::options{.worker_count = 8}};
-    coro::mutex          m{};
+    auto        tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 8});
+    coro::mutex m{};
 
     auto make_task = [&tp, &m](int task_id) -> coro::task<void>
     {
-        for (size_t i = 0; i < 5'000'000; ++i)
+        for (size_t i = 0; i < 5'000; ++i)
         {
-            co_await tp.schedule();
+            co_await tp->schedule();
             std::stringstream ss;
             ss << task_id << " iteration " << i << " thread id =[" << std::this_thread::get_id() << "]\n";
             // std::cout << ss.str();
@@ -31,7 +31,7 @@ TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
     tasks.reserve(iterations);
     for (size_t i = 0; i < iterations; ++i)
     {
-        tasks.emplace_back(tp.schedule(make_task(i)));
+        tasks.emplace_back(tp->schedule(make_task(i)));
     }
 
     coro::sync_wait(coro::when_all(std::move(tasks)));

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -202,7 +202,9 @@ TEST_CASE("thread_pool_ws event jump threads", "[thread_pool_ws]")
         co_return;
     };
 
-    coro::sync_wait(coro::when_all(make_tp1_task(tp1, e), make_tp2_task(tp2, e)));
+    auto task1 = tp1->spawn_joinable(make_tp1_task(tp1, e));
+
+    coro::sync_wait(coro::when_all(std::move(task1), make_tp2_task(tp2, e)));
 }
 
 TEST_CASE("thread_pool_ws high cpu usage when threadcount is greater than the number of tasks", "[thread_pool_ws]")

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -252,7 +252,7 @@ TEST_CASE("thread_pool_ws high cpu usage when threadcount is greater than the nu
 
 TEST_CASE("issue-287", "[thread_pool_ws]")
 {
-    const int ITERATIONS = 200000;
+    const int ITERATIONS = 200'000;
 
     std::atomic<uint32_t> g_count = 0;
     auto                  tp      = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -11,7 +11,11 @@ TEST_CASE("thread_pool_ws", "[thread_pool_ws]")
 
 TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
 {
-    auto        tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 8});
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{
+        .thread_count = 8,
+    });
+    //    .on_thread_start_functor = [](std::size_t i) -> void { std::cerr << "thread " << i << " starting\n"; },
+    //    .on_thread_stop_functor  = [](std::size_t i) -> void { std::cerr << "thread " << i << " starting\n"; }});
     coro::mutex m{};
 
     auto make_task = [&tp, &m](int task_id) -> coro::task<void>

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -1,0 +1,43 @@
+#include "catch_amalgamated.hpp"
+
+#include <coro/coro.hpp>
+
+#include <iostream>
+
+TEST_CASE("thread_pool_ws", "[thread_pool_ws]")
+{
+    std::cerr << "[thread_pool_ws]\n\n";
+}
+
+TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
+{
+    coro::thread_pool_ws tp{coro::thread_pool_ws::options{.worker_count = 8}};
+    coro::mutex          m{};
+
+    auto make_task = [&tp, &m](int task_id) -> coro::task<void>
+    {
+        for (size_t i = 0; i < 5'000'000; ++i)
+        {
+            co_await tp.schedule();
+            std::stringstream ss;
+            ss << task_id << " iteration " << i << " thread id =[" << std::this_thread::get_id() << "]\n";
+            // std::cout << ss.str();
+        }
+        co_return;
+    };
+
+    size_t                        iterations{1024};
+    std::vector<coro::task<void>> tasks{};
+    tasks.reserve(iterations);
+    for (size_t i = 0; i < iterations; ++i)
+    {
+        tasks.emplace_back(tp.schedule(make_task(i)));
+    }
+
+    coro::sync_wait(coro::when_all(std::move(tasks)));
+}
+
+TEST_CASE("~thread_pool_ws", "[thread_pool_ws]")
+{
+    std::cerr << "[~thread_pool_ws]\n\n";
+}

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -16,9 +16,8 @@ TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
     });
     //    .on_thread_start_functor = [](std::size_t i) -> void { std::cerr << "thread " << i << " starting\n"; },
     //    .on_thread_stop_functor  = [](std::size_t i) -> void { std::cerr << "thread " << i << " starting\n"; }});
-    coro::mutex m{};
 
-    auto make_task = [&tp, &m](int task_id) -> coro::task<void>
+    auto make_task = [&tp](int task_id) -> coro::task<void>
     {
         for (size_t i = 0; i < 5'000; ++i)
         {
@@ -230,7 +229,7 @@ TEST_CASE("thread_pool_ws high cpu usage when threadcount is greater than the nu
             std::this_thread::sleep_for(delay);
             auto amount = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - now);
             auto lk     = co_await m.scoped_lock();
-            std::cout << "delay=" << std::chrono::duration_cast<std::chrono::milliseconds>(delay).count()
+            std::cerr << "delay=" << std::chrono::duration_cast<std::chrono::milliseconds>(delay).count()
                       << " actual=" << amount.count() << "\n";
             co_return;
         };
@@ -247,6 +246,8 @@ TEST_CASE("thread_pool_ws high cpu usage when threadcount is greater than the nu
         {
             co_await tasks[i];
         }
+
+        std::cerr << "wait_for_task() return\n";
 
         co_return;
     };
@@ -323,21 +324,27 @@ TEST_CASE("thread_pool_ws::schedule(task)", "[thread_pool_ws]")
 TEST_CASE("thread_pool_ws::schedule(task) manually resume returned task", "[thread_pool_ws]")
 {
     auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+    std::mutex block{};
 
-    auto long_task = []() -> coro::task<bool>
+    auto long_task = [](std::mutex& b) -> coro::task<bool>
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds{200});
+        std::unique_lock<std::mutex> blk{b};
         co_return true;
     };
 
-    auto task = long_task();
-    tp->resume(task.handle());
-
+    block.lock();
+    auto task = long_task(block);
     REQUIRE(!task.is_ready());
+    tp->resume(task.handle());
+    block.unlock();
 
-    std::this_thread::sleep_for(std::chrono::milliseconds{500});
+    while (!task.is_ready())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+
+    auto result = task.promise().result();
     REQUIRE(task.is_ready());
-    auto result = coro::sync_wait(task);
     REQUIRE(result == true);
 }
 

--- a/test/test_thread_pool_ws.cpp
+++ b/test/test_thread_pool_ws.cpp
@@ -37,6 +37,326 @@ TEST_CASE("thread_pool_ws simple testing", "[thread_pool_ws]")
     coro::sync_wait(coro::when_all(std::move(tasks)));
 }
 
+TEST_CASE("thread_pool_ws one worker one task", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{1});
+
+    auto func = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+    {
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
+        co_return 42;
+    };
+
+    auto result = coro::sync_wait(func(tp));
+    REQUIRE(result == 42);
+}
+
+TEST_CASE("thread_pool_ws one worker many tasks tuple", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{1});
+
+    auto f = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+    {
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
+        co_return 50;
+    };
+
+    auto tasks = coro::sync_wait(coro::when_all(f(tp), f(tp), f(tp), f(tp), f(tp)));
+    REQUIRE(std::tuple_size<decltype(tasks)>() == 5);
+
+    uint64_t counter{0};
+    std::apply([&counter](auto&&... t) -> void { ((counter += t.return_value()), ...); }, tasks);
+
+    REQUIRE(counter == 250);
+}
+
+TEST_CASE("thread_pool_ws one worker many tasks vector", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{1});
+
+    auto f = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+    {
+        co_await tp->schedule(); // Schedule this coroutine on the scheduler.
+        co_return 50;
+    };
+
+    std::vector<coro::task<uint64_t>> input_tasks;
+    input_tasks.emplace_back(f(tp));
+    input_tasks.emplace_back(f(tp));
+    input_tasks.emplace_back(f(tp));
+
+    auto output_tasks = coro::sync_wait(coro::when_all(std::move(input_tasks)));
+
+    REQUIRE(output_tasks.size() == 3);
+
+    uint64_t counter{0};
+    for (const auto& task : output_tasks)
+    {
+        counter += task.return_value();
+    }
+
+    REQUIRE(counter == 150);
+}
+
+TEST_CASE("thread_pool_ws N workers 100k tasks", "[thread_pool_ws]")
+{
+    constexpr const std::size_t iterations = 100'000;
+    auto                        tp         = coro::thread_pool_ws::make_unique();
+
+    auto make_task = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+    {
+        co_await tp->schedule();
+        co_return 1;
+    };
+
+    std::vector<coro::task<uint64_t>> input_tasks{};
+    input_tasks.reserve(iterations);
+    for (std::size_t i = 0; i < iterations; ++i)
+    {
+        input_tasks.emplace_back(make_task(tp));
+    }
+
+    auto output_tasks = coro::sync_wait(coro::when_all(std::move(input_tasks)));
+    REQUIRE(output_tasks.size() == iterations);
+
+    uint64_t counter{0};
+    for (const auto& task : output_tasks)
+    {
+        counter += task.return_value();
+    }
+
+    REQUIRE(counter == iterations);
+}
+
+TEST_CASE("thread_pool_ws 1 worker task spawns another task", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{1});
+
+    auto f1 = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+    {
+        co_await tp->schedule();
+
+        auto f2 = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<uint64_t>
+        {
+            co_await tp->schedule();
+            co_return 5;
+        };
+
+        co_return 1 + co_await f2(tp);
+    };
+
+    REQUIRE(coro::sync_wait(f1(tp)) == 6);
+}
+
+TEST_CASE("thread_pool_ws shutdown", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{1});
+
+    auto f = [](std::unique_ptr<coro::thread_pool_ws>& tp) -> coro::task<bool>
+    {
+        try
+        {
+            co_await tp->schedule();
+        }
+        catch (...)
+        {
+            co_return true;
+        }
+        co_return false;
+    };
+
+    tp->shutdown();
+
+    REQUIRE(coro::sync_wait(f(tp)) == true);
+}
+
+TEST_CASE("thread_pool_ws event jump threads", "[thread_pool_ws]")
+{
+    // This test verifies that the thread that sets the event ends up executing every waiter on the event
+
+    auto tp1 = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+    auto tp2 = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+
+    coro::event e{};
+
+    auto make_tp1_task = [](std::unique_ptr<coro::thread_pool_ws>& tp1, coro::event& e) -> coro::task<void>
+    {
+        co_await tp1->schedule();
+        auto before_thread_id = std::this_thread::get_id();
+        std::cerr << "before event thread_id = " << before_thread_id << "\n";
+        co_await e;
+        auto after_thread_id = std::this_thread::get_id();
+        std::cerr << "after event thread_id = " << after_thread_id << "\n";
+
+        REQUIRE(before_thread_id != after_thread_id);
+
+        co_return;
+    };
+
+    auto make_tp2_task = [](std::unique_ptr<coro::thread_pool_ws>& tp2, coro::event& e) -> coro::task<void>
+    {
+        co_await tp2->schedule();
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        std::cerr << "setting event\n";
+        e.set();
+        co_return;
+    };
+
+    coro::sync_wait(coro::when_all(make_tp1_task(tp1, e), make_tp2_task(tp2, e)));
+}
+
+TEST_CASE("thread_pool_ws high cpu usage when threadcount is greater than the number of tasks", "[thread_pool_ws]")
+{
+    // https://github.com/jbaldwin/libcoro/issues/262
+    // This test doesn't really trigger any error conditions but was reported via
+    // an issue that the thread_pool_ws threads not doing work would spin on the CPU
+    // if there were less tasks running than threads in the pool.
+    // This was due to using m_size instead of m_queue.size() causing the threads
+    // that had no work to go into a spin trying to acquire work.
+
+    auto wait_for_task = [](std::unique_ptr<coro::thread_pool_ws>& tp, std::chrono::seconds delay) -> coro::task<>
+    {
+        coro::mutex m{};
+
+        auto sleep_for_task = [](std::chrono::seconds delay, coro::mutex& m) -> coro::task<void>
+        {
+            auto now = std::chrono::steady_clock::now();
+            std::this_thread::sleep_for(delay);
+            auto amount = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - now);
+            auto lk     = co_await m.scoped_lock();
+            std::cout << "delay=" << std::chrono::duration_cast<std::chrono::milliseconds>(delay).count()
+                      << " actual=" << amount.count() << "\n";
+            co_return;
+        };
+
+        std::vector<coro::task<void>> tasks{};
+        tasks.reserve(3);
+        co_await tp->schedule();
+        for (int i = 0; i < 3; ++i)
+        {
+            tasks.emplace_back(tp->spawn_joinable(sleep_for_task(delay, m)));
+        }
+
+        for (int i = 0; i < 3; ++i)
+        {
+            co_await tasks[i];
+        }
+
+        co_return;
+    };
+
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 3});
+    coro::sync_wait(coro::when_all(wait_for_task(tp, std::chrono::seconds{1})));
+    coro::sync_wait(coro::when_all(wait_for_task(tp, std::chrono::seconds{3})));
+}
+
+TEST_CASE("issue-287", "[thread_pool_ws]")
+{
+    const int ITERATIONS = 200000;
+
+    std::atomic<uint32_t> g_count = 0;
+    auto                  tp      = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+
+    auto task = [](std::atomic<uint32_t>& count) -> coro::task<void>
+    {
+        count++;
+        co_return;
+    };
+
+    for (int i = 0; i < ITERATIONS; ++i)
+    {
+        REQUIRE(tp->spawn_detached(task(g_count)));
+    }
+
+    tp->shutdown();
+
+    std::cerr << "g_count = \t" << g_count.load() << std::endl;
+    REQUIRE(g_count.load() == ITERATIONS);
+}
+
+TEST_CASE("thread_pool_ws::spawn", "[thread_pool_ws]")
+{
+    auto                  tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 2});
+    std::atomic<uint64_t> counter{0};
+
+    auto make_task = [](std::atomic<uint64_t>& counter, uint64_t amount) -> coro::task<void>
+    {
+        counter += amount;
+        co_return;
+    };
+
+    REQUIRE(tp->spawn_detached(make_task(counter, 1)));
+    REQUIRE(tp->spawn_detached(make_task(counter, 2)));
+    REQUIRE(tp->spawn_detached(make_task(counter, 3)));
+
+    tp->shutdown();
+
+    REQUIRE(counter == 6);
+}
+
+TEST_CASE("thread_pool_ws::schedule(task)", "[thread_pool_ws]")
+{
+    auto            tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+    uint64_t        counter{0};
+    std::thread::id coroutine_tid;
+
+    auto make_task = [](uint64_t value, std::thread::id& coroutine_id) -> coro::task<uint64_t>
+    {
+        coroutine_id = std::this_thread::get_id();
+        co_return value;
+    };
+
+    auto main_tid = std::this_thread::get_id();
+
+    counter += coro::sync_wait(tp->schedule(make_task(53, coroutine_tid)));
+
+    REQUIRE(counter == 53);
+    REQUIRE(main_tid != coroutine_tid);
+}
+
+TEST_CASE("thread_pool_ws::schedule(task) manually resume returned task", "[thread_pool_ws]")
+{
+    auto tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+
+    auto long_task = []() -> coro::task<bool>
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds{200});
+        co_return true;
+    };
+
+    auto task = long_task();
+    tp->resume(task.handle());
+
+    REQUIRE(!task.is_ready());
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{500});
+    REQUIRE(task.is_ready());
+    auto result = coro::sync_wait(task);
+    REQUIRE(result == true);
+}
+
+TEST_CASE("thread_pool_ws::spawn_joinable", "[thread_pool_ws]")
+{
+    auto                  tp = coro::thread_pool_ws::make_unique(coro::thread_pool_ws::options{.thread_count = 1});
+    std::atomic<uint64_t> counter{0};
+    coro::event           e1{};
+
+    auto long_task = [](std::atomic<uint64_t>& c, coro::event& e1) -> coro::task<void>
+    {
+        ++c;
+        e1.set();
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        ++c;
+        co_return;
+    };
+
+    auto join_task = tp->spawn_joinable(long_task(counter, e1));
+    coro::sync_wait(e1);
+    REQUIRE(counter.load() == 1);
+    coro::sync_wait(join_task);
+    REQUIRE(counter.load() == 2);
+}
+
 TEST_CASE("~thread_pool_ws", "[thread_pool_ws]")
 {
     std::cerr << "[~thread_pool_ws]\n\n";


### PR DESCRIPTION
This is a proof of concept that would replace the normal coro::thread_pool if it works out, this uses a chase lev work stealing queue with an atomic list for the global queue when schedules happen outside a thread pool worker. It leverages thread_local uint32_t to lookup the current threads index for its owned internally local thread queue, if that isn't set then we know we're off a worker thread and need to enqueue on the global queue.