### PR TITLE
prevent task_group from blocking if no tasks are run

### DIFF
--- a/include/coro/task_group.hpp
+++ b/include/coro/task_group.hpp
@@ -134,7 +134,7 @@ private:
     /// The number of alive tasks.
     std::atomic<uint64_t> m_size{};
     /// Event to trigger if m_size goes to zero.
-    coro::event m_on_empty_event{};
+    coro::event m_on_empty_event{true};
 
     auto count_down() -> void
     {

--- a/test/test_task_group.cpp
+++ b/test/test_task_group.cpp
@@ -12,6 +12,14 @@ TEST_CASE("task_group", "[task_group]")
 
 using namespace std::chrono_literals;
 
+TEST_CASE("task_group schedule no tasks", "[task_group]")
+{
+    auto s = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});
+    coro::task_group<coro::thread_pool> tc{s};
+    REQUIRE(tc.empty());
+    coro::sync_wait(tc);
+}
+
 TEST_CASE("task_group schedule single task", "[task_group]")
 {
     auto        s = coro::thread_pool::make_unique(coro::thread_pool::options{.thread_count = 1});


### PR DESCRIPTION
If task_group is created and no tasks are started on it, co_awaiting it will cause the awaiter to await forever. This fixes the issue by setting the m_on_empty_event on construction.

---

Unrelated, but is there a reason `coro::task_group::start` is `[[nodiscard]]`?