### PR TITLE
make -Wall, -Wextra and /W4 private to the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ if(DEFINED EMSCRIPTEN)
     add_link_options(-sEXIT_RUNTIME)
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(
         $<$<COMPILE_LANGUAGE:CXX>:-Wall>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
@@ -259,7 +259,7 @@ if(LIBCORO_FEATURE_NETWORKING)
     endif()
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.2.0")
         message(FATAL_ERROR "g++ version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 10.2.0")
     endif()
@@ -267,7 +267,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     target_compile_options(${PROJECT_NAME} PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
     )
-elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
         message(FATAL_ERROR "Clang version ${CMAKE_CXX_COMPILER_VERSION} is unsupported, please upgrade to at least 16.0.0")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,17 @@ if(DEFINED EMSCRIPTEN)
     add_link_options(-sEXIT_RUNTIME)
 endif()
 
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
+    add_compile_options(
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
+    )
+elseif(MSVC)
+    add_compile_options(
+        /W4
+    )
+endif()
+
 add_library(${PROJECT_NAME} ${LIBCORO_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX PREFIX "" VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
@@ -255,8 +266,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 
     target_compile_options(${PROJECT_NAME} PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
     )
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
@@ -265,12 +274,6 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
 
     target_compile_options(${PROJECT_NAME} PUBLIC
         $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wall>
-        $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-    )
-elseif(MSVC)
-    target_compile_options(${PROJECT_NAME} PUBLIC
-        /W4
     )
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 project(libcoro_examples)
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     set(LIBCORO_EXAMPLE_OPTIONS -fcoroutines -Wall -Wextra)
-elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(LIBCORO_EXAMPLE_OPTIONS -Wall -Wextra)
 elseif(MSVC)
     set(LIBCORO_EXAMPLE_OPTIONS /W4)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,7 +67,7 @@ else ()
     target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(${PROJECT_NAME} PRIVATE libcoro)
 
-    if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang|MSVC")
+    if (NOT (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang" OR MSVC))
         message(FATAL_ERROR "Unsupported compiler.")
     endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,7 +67,7 @@ else ()
     target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(${PROJECT_NAME} PRIVATE libcoro)
 
-    if (NOT (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang" OR MSVC))
+    if (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|MSVC")
         message(FATAL_ERROR "Unsupported compiler.")
     endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,25 +67,7 @@ else ()
     target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(${PROJECT_NAME} PRIVATE libcoro)
 
-    if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-        target_compile_options(${PROJECT_NAME} PRIVATE
-                $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
-                $<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>
-                $<$<COMPILE_LANGUAGE:CXX>:-fconcepts>
-                $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
-                $<$<COMPILE_LANGUAGE:CXX>:-Wall>
-                $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-        )
-    elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-        target_compile_options(${PROJECT_NAME} PRIVATE
-                $<$<COMPILE_LANGUAGE:CXX>:-std=c++20>
-                $<$<COMPILE_LANGUAGE:CXX>:-fexceptions>
-                $<$<COMPILE_LANGUAGE:CXX>:-Wall>
-                $<$<COMPILE_LANGUAGE:CXX>:-Wextra>
-        )
-    elseif (MSVC)
-        target_compile_options(${PROJECT_NAME} PRIVATE /W4)
-    else ()
+    if (NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang|MSVC")
         message(FATAL_ERROR "Unsupported compiler.")
     endif ()
 


### PR DESCRIPTION
This PR sets the -Wall, -Wextra and /W4 flags scoped to just the libcoro project.
It also removes the duplicate flags in libcoro_test and removed flags -fcoroutines and -fconcepts (these are set by default when the language version is set to C++20)
- ref: https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fcoroutines
- ref: https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fconcepts

`-std=c++20` could be removed from libcoro_test because its always set through CMAKE_CXX_STANDARD
`-fexceptions` is removed because its set publicly in libcoro

Fixes #453